### PR TITLE
Bugfix: Uncaught JSON parse execption

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -299,7 +299,11 @@ function loadAsDirectory(dirname, options, type, sync, callback) {
 						callback(err);
 						return;
 					}
-					content = JSON.parse(content);
+					try {
+						content = JSON.parse(content);
+					} catch (jsonError) {
+						return callback(jsonError);
+					}
 					var packageMains = type === "loader" ? options.loaderPackageMains : options.packageMains;
 					for(var i = 0; i < packageMains.length; i++) {
 						var field = packageMains[i];


### PR DESCRIPTION
Invalid package json that can not be parsed as JSON will throw exceptions. These exceptions are not caught but 'escape'. This will typically cause termination of the node process using enhanced-resolve library. The 'client code' has no chance to handle the exception.

I believe that the expectation is really that these errors should be caught and passed to the callback function instead, thus allowing client code to recover from errors caused by bad json.
