### PR TITLE
Display invalid package.json errors

### DIFF
--- a/lib/DirectoryDescriptionFileFieldAliasPlugin.js
+++ b/lib/DirectoryDescriptionFileFieldAliasPlugin.js
@@ -25,6 +25,10 @@ function findDescriptionFileField(resolver, directory, filename, field, callback
 			try {
 				content = JSON.parse(content);
 			} catch(e) {
+				if(callback.log)
+					callback.log(descriptionFilePath + " (directory description file): " + e);
+				else
+					e.message = descriptionFilePath + " (directory description file): " + e;
 				return callback(e);
 			}
 			var fieldData;

--- a/lib/DirectoryDescriptionFilePlugin.js
+++ b/lib/DirectoryDescriptionFilePlugin.js
@@ -29,6 +29,8 @@ DirectoryDescriptionFilePlugin.prototype.apply = function(resolver) {
 			} catch(e) {
 				if(callback.log)
 					callback.log(descriptionFilePath + " (directory description file): " + e);
+				else
+					e.message = descriptionFilePath + " (directory description file): " + e;
 				return callback(e);
 			}
 			var mainModules = [];

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -85,10 +85,11 @@ Resolver.prototype.doResolve = function doResolve(types, request, callback, noEr
 			stack: newStack
 		}, "resolve " + types[0] + " " + currentRequestString));
 	}
-	// For multiple type we have to ignore the error
+	// For multiple type we list the errors in the details although some of them are not important
 	this.forEachBail(types, function(type, callback) {
 		this.applyPluginsParallelBailResult(type, request, createInnerCallback(function(err, result) {
 			if(!err && result) return callback(result);
+			if (err) log.push("  " + err.message);
 			callback();
 		}, {
 			log: writeLog,


### PR DESCRIPTION
I had an invalid package.json and webpack would report:

```
➜  stoic.mdcache git:(vitamin-a-squashed) ✗ webpack --display-error-details --display-reasons
Hash: 78fce45e15981a9aa20c
Version: webpack 1.3.3-beta1
Time: 28ms
                Asset  Size  Chunks             Chunk Names
dist/stoic.mdcache.js  1647       0  [emitted]  stoic.mdcache
   [0] multi stoic.mdcache 28 {0} [built] [1 error]

ERROR in multi stoic.mdcache
Module not found: Error: Cannot resolve 'file' or 'directory' ./index-browser in /Users/hugues/proj/stoic-umbrella/stoic.mdcache
resolve directory
  /Users/hugues/proj/stoic-umbrella/stoic.mdcache/index-browser doesn't exist (directory default file)
  /Users/hugues/proj/stoic-umbrella/stoic.mdcache/index-browser/package.json doesn't exist (directory description file)
resolve file
  /Users/hugues/proj/stoic-umbrella/stoic.mdcache/index-browser doesn't exist
  /Users/hugues/proj/stoic-umbrella/stoic.mdcache/index-browser.webpack.js doesn't exist
  /Users/hugues/proj/stoic-umbrella/stoic.mdcache/index-browser.web.js doesn't exist
  /Users/hugues/proj/stoic-umbrella/stoic.mdcache/index-browser.json doesn't exist
  resolve result /Users/hugues/proj/stoic-umbrella/stoic.mdcache/index-browser.js
```

It turns out that my package.json was wrong.
With this PR it will display one extra line:

```
/Users/hugues/proj/stoic-umbrella/stoic.mdcache/package.json (directory description file): SyntaxError: Unexpected string
```

Not sure if this is right way to improve this.
And thanks for a fantastic tool.
