### PR TITLE
Fix alias resolution when symlink is used

### DIFF
--- a/lib/DirectoryDescriptionFileFieldAliasPlugin.js
+++ b/lib/DirectoryDescriptionFileFieldAliasPlugin.js
@@ -95,10 +95,11 @@ DirectoryDescriptionFileFieldAliasPlugin.prototype.apply = function(resolver) {
 	});
 	resolver.plugin("result", function(request, callback) {
 		var directory = cdUp(request.path);
+		var requestPath = request.path;
 		findDescriptionFileField(this, directory, filename, field, function(err, fieldData, directory) {
 			if(err) return callback(err);
 			if(!fieldData) return callback();
-			var relative = request.path.substr(directory.length+1).replace(/\\/g, "/");
+			var relative = requestPath.substr(directory.length+1).replace(/\\/g, "/");
 			if(typeof fieldData[relative] !== "undefined")
 				var data = fieldData[relative];
 			else if(typeof fieldData["./" + relative] !== "undefined")


### PR DESCRIPTION
Hi,

Alias resolution doesn't work on a symlink module.
I discovered this when i tried to use ```superagent```. This module uses the browser support in  ```package.json```:
```javascript
 "browser": {
    "./lib/node/index.js": "./lib/client.js",
    "emitter": "component-emitter",
    "reduce": "reduce-component"
  },
"main": "./lib/node/index.js",
```
When I install it with ```npm install``` it's Ok but when I want to use it as global dependency (```npm install -g superagent``` and ```npm link``` in my module folder), I see that the main file used is no longer aliased to ```./lib/client.js```

After some research I found that ```DirectoryDescriptionFileFieldAliasPlugin.js``` has an issue when ```request.path``` is modified by ```ResultSymlinkPlugin.js```

I tried to resolve this with this pull request but I was not able to write a unit test because ```MemoryFileSystem``` doesn't support symLink.
