### PR TITLE
removing tests from npm installations

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/node_modules
+/coverage
+/test


### PR DESCRIPTION
This fixes #16 by removing the tests folder from npm with an npmignore. I didn't include a version bump for package.json.