### PR TITLE
Add support for request object to UnsafeCachePlugin

### DIFF
--- a/lib/UnsafeCachePlugin.js
+++ b/lib/UnsafeCachePlugin.js
@@ -15,7 +15,11 @@ UnsafeCachePlugin.prototype.apply = function(resolver) {
 	var regExps = this.regExps;
 	var cache = this.cache;
 	resolver.resolve = function resolve(context, request, callback) {
-		var id = context + "->" + request;
+		var requestHash = request;
+		if(typeof requestHash === 'object') {
+			requestHash = JSON.stringify(requestHash);
+		}
+		var id = context + "->" + requestHash;
 		if(cache[id]) {
 			// From cache
 			return callback(null, cache[id]);


### PR DESCRIPTION
While working on a custom loader I noticed that the `resolve()` function of the loader API also accepts an object for the `request` parameter. The method just skips the parsing step and uses the provided object right away.

    Resolver.prototype.resolve = function resolve(context, request, callback) {
	    if(typeof request === "string") request = this.parse(request);
	    this.applyPlugins("resolve", context, request);

However I later noticed that the `UnsafeCachePlugin` has some problems with that. It expects the parameter to be a string and when trying to use it as caching key, will produce something like this:

    "/foo/bar/context->[object Object]"

I fixed this by using the `path` property instead. I'm not sure if the `UnsafeCachePlugin` is even supposed to be able to handle request objects... If not just close this PR and I'm probably going to simply disable the unsafe caching.