### PR TITLE
Include query when caching webpack-bug #1940

### DIFF
--- a/lib/UnsafeCachePlugin.js
+++ b/lib/UnsafeCachePlugin.js
@@ -17,6 +17,7 @@ function getCacheId(request) {
 	return JSON.stringify({
 		context: request.context,
 		path: request.path,
+		query: request.query,
 		request: request.request
 	});
 }

--- a/test/unsafe-cache.js
+++ b/test/unsafe-cache.js
@@ -24,5 +24,26 @@ describe("unsafe-cache", function() {
 				done();
 			});
 		});
-	})
+	});
+	it("should not return from cache if query does not match", function(done) {
+		var cache = {};
+		var cachedResolve = resolve.create({
+			unsafeCache: cache
+		});
+
+		cachedResolve(path.join(__dirname, "fixtures"), "m2/b?query", function(err, result) {
+			if(err) return done(err);
+			Object.keys(cache).should.have.length(2);
+			Object.keys(cache).forEach(function(key) {
+				cache[key] = {
+					path: "yep"
+				};
+			});
+			cachedResolve(path.join(__dirname, "fixtures"), "m2/b?query2", function(err, result) {
+				if(err) return done(err);
+				result.should.not.be.eql("yep")
+				done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
Including the query in the cacheId means it will not return if the queries are different, I believe fixing the issue here: https://github.com/webpack/webpack/issues/1940