### PR TITLE
Restore `resolve.root` Resolver

### DIFF
--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -90,6 +90,14 @@ exports.createResolver = function(options) {
 	// A prepared Resolver to which the plugins are attached
 	var resolver = options.resolver || new Resolver(fileSystem);
 
+	// One or more directories to use as the base directory when resolving
+	// module imports
+	var roots = (function() {
+		if(Array.isArray(options.root)) return options.root;
+		if(options.root) return [options.root];
+		return [];
+	}());
+
 	//// options processing ////
 
 	extensions = [].concat(extensions);
@@ -167,6 +175,10 @@ exports.createResolver = function(options) {
 	})
 	if(!enforceModuleExtension)
 		plugins.push(new TryNextPlugin("raw-module", null, "module"));
+
+	roots.forEach(function(root) {
+		plugins.push(new ModulesInRootPlugin("module", root, "resolve"));
+	});
 
 	// module
 	modules.forEach(function(item) {


### PR DESCRIPTION
Use the provided `options.root` path(s) to add `ModuleInRootPlugin`
instance(s) to the `plugins` collection. This allows for the webpack
configuration to include an absolute path or collection of paths for
the `resolve.root` property.

https://webpack.github.io/docs/configuration.html#resolve-root