### PR TITLE
Fix resolving of DescriptionFiles

### DIFF
--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -148,9 +148,7 @@ exports.createResolver = function(options) {
 	}
 
 	// parsed-resolve
-	descriptionFiles.forEach(function(item) {
-		plugins.push(new DescriptionFilePlugin("parsed-resolve", item, "described-resolve"));
-	});
+	plugins.push(new DescriptionFilePlugin("parsed-resolve", descriptionFiles, "described-resolve"));
 	plugins.push(new NextPlugin("after-parsed-resolve", "described-resolve"));
 
 	// described-resolve
@@ -180,9 +178,7 @@ exports.createResolver = function(options) {
 	})
 
 	// relative
-	descriptionFiles.forEach(function(item) {
-		plugins.push(new DescriptionFilePlugin("relative", item, "described-relative"));
-	});
+	plugins.push(new DescriptionFilePlugin("relative", descriptionFiles, "described-relative"));
 	plugins.push(new NextPlugin("after-relative", "described-relative"));
 
 	// described-relative
@@ -209,9 +205,7 @@ exports.createResolver = function(options) {
 		});
 
 		// undescribed-raw-file
-		descriptionFiles.forEach(function(item) {
-			plugins.push(new DescriptionFilePlugin("undescribed-raw-file", item, "raw-file"));
-		});
+		plugins.push(new DescriptionFilePlugin("undescribed-raw-file", descriptionFiles, "raw-file"));
 		plugins.push(new NextPlugin("after-undescribed-raw-file", "raw-file"));
 
 		// raw-file


### PR DESCRIPTION
This PR will fix the resolving of multiple defined `descriptionFiles`.

Given a Webpack config of:

``` js
resolve: {
  descriptionFiles: ['package.json', 'bower.json']
}
```

Only `package.json` will be searched for (unknown reason). This PR will search for all defined `descriptionFiles`.
