### PR TITLE
Create a shallow copy of options.plugins, instead of referring to the original array

### DIFF
--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -46,7 +46,9 @@ exports.createResolver = function(options) {
 	var descriptionFiles = options.descriptionFiles || ["package.json"];
 
 	// A list of additional resolve plugins which should be applied
-	var plugins = options.plugins || [];
+	// The slice is there to create a copy, because otherwise pushing into plugins
+	// changes the original options.plugins array, causing duplicate plugins
+	var plugins = (options.plugins && options.plugins.slice()) || [];
 
 	// A list of main fields in description files
 	var mainFields = options.mainFields || ["main"];


### PR DESCRIPTION
If you set `options.resolve.plugins` to anything, even an empty array, `enhanced-resolve` will start behaving weirdly. By weirdly I mean that it will duplicate some plugins in the list of plugins. If we, for example, use a mock `HelloHello` plugin in our webpack config, e.g. 
```
resolve: { 
  plugins: [new HelloHello()] 
}
```
, when `WebpackOptionsApply` is producing the `Resolvers` using the `ResolverFactory`, it will think all of the plugins from the `normal` resolver are external plugins for the `context` resolver (https://github.com/webpack/webpack/blob/e896d14829d0afc75c8510862afbe3c8e06d67d8/lib/WebpackOptionsApply.js#L277-L283). 

Example:

# Before fix
```
Number of plugins: 32 (normal resolvers)    49 (context resolvers)

HelloHello                                  HelloHello
UnsafeCachePlugin                           UnsafeCachePlugin
ParsePlugin                                 ParsePlugin
DescriptionFilePlugin                       DescriptionFilePlugin
NextPlugin                                  NextPlugin
ConcordModulesPlugin                        ConcordModulesPlugin
AliasFieldPlugin                            AliasFieldPlugin
ModuleKindPlugin                            ModuleKindPlugin
JoinRequestPlugin                           JoinRequestPlugin
TryNextPlugin                               TryNextPlugin
ModulesInHierachicDirectoriesPlugin         ModulesInHierachicDirectoriesPlugin
DescriptionFilePlugin                       DescriptionFilePlugin
NextPlugin                                  NextPlugin
FileKindPlugin                              FileKindPlugin
TryNextPlugin                               TryNextPlugin
DirectoryExistsPlugin                       DirectoryExistsPlugin
ConcordMainPlugin                           ConcordMainPlugin
MainFieldPlugin                             MainFieldPlugin
MainFieldPlugin                             MainFieldPlugin
MainFieldPlugin                             MainFieldPlugin
UseFilePlugin                               UseFilePlugin
DescriptionFilePlugin                       DescriptionFilePlugin
NextPlugin                                  NextPlugin
TryNextPlugin                               TryNextPlugin
ConcordExtensionsPlugin                     ConcordExtensionsPlugin
AppendPlugin                                AppendPlugin
AppendPlugin                                AppendPlugin
ConcordModulesPlugin                        ConcordModulesPlugin
AliasFieldPlugin                            AliasFieldPlugin
FileExistsPlugin                            FileExistsPlugin
NextPlugin                                  NextPlugin
ResultPlugin                                ResultPlugin
                                            UnsafeCachePlugin
                                            ParsePlugin
                                            DescriptionFilePlugin
                                            NextPlugin
                                            ConcordModulesPlugin
                                            AliasFieldPlugin
                                            ModuleKindPlugin
                                            JoinRequestPlugin
                                            TryNextPlugin
                                            ModulesInHierachicDirectoriesPlugin
                                            DescriptionFilePlugin
                                            NextPlugin
                                            FileKindPlugin
                                            TryNextPlugin
                                            DirectoryExistsPlugin
                                            NextPlugin
                                            ResultPlugin
 
```

This is because the `ResolverFactory` sets `plugins` to be the `options.plugins` array, and because that's a reference and not a copy, `ResolverFactory` pushes into the original `options.plugins` array (from https://github.com/webpack/webpack/blob/e896d14829d0afc75c8510862afbe3c8e06d67d8/lib/WebpackOptionsApply.js#L277-L283), which is meant for external plugins only: https://github.com/webpack/enhanced-resolve/blob/c2f517ec9164ea8b62a03f3cede69bcebaecf889/lib/ResolverFactory.js#L49. This causes issues in larger builds which run out of heap space, especially if loader resolvers are included as well, since both the `normal` and `context`'s plugins are prepended to the `loader` resolver plugins list. Additionally, there might also be complications because some plugins run twice.

# After fix (which is to create a shallow copy):
   
```
Number of plugins: 32 (normal resolvers)    18 (context resolvers)

HelloHello                                  HelloHello
UnsafeCachePlugin                           UnsafeCachePlugin
ParsePlugin                                 ParsePlugin
DescriptionFilePlugin                       DescriptionFilePlugin
NextPlugin                                  NextPlugin
ConcordModulesPlugin                        ConcordModulesPlugin
AliasFieldPlugin                            AliasFieldPlugin
ModuleKindPlugin                            ModuleKindPlugin
JoinRequestPlugin                           JoinRequestPlugin
TryNextPlugin                               TryNextPlugin
ModulesInHierachicDirectoriesPlugin         ModulesInHierachicDirectoriesPlugin
DescriptionFilePlugin                       DescriptionFilePlugin
NextPlugin                                  NextPlugin
FileKindPlugin                              FileKindPlugin
TryNextPlugin                               TryNextPlugin
DirectoryExistsPlugin                       DirectoryExistsPlugin
ConcordMainPlugin                           NextPlugin
MainFieldPlugin                             ResultPlugin
MainFieldPlugin 
MainFieldPlugin 
UseFilePlugin   
DescriptionFilePlugin   
NextPlugin  
TryNextPlugin   
ConcordExtensionsPlugin 
AppendPlugin    
AppendPlugin    
ConcordModulesPlugin    
AliasFieldPlugin    
FileExistsPlugin    
NextPlugin  
ResultPlugin    
```

The fact that setting plugins to be an empty array, i.e. `resolve: { plugins: [] }`, produces the same issue, confirms that the issue is caused by having a single array to which all resolvers now refer to, and push into.




