### PR TITLE
Fix undefined parsed.module or parsed.directory issue

### DIFF
--- a/lib/ParsePlugin.js
+++ b/lib/ParsePlugin.js
@@ -18,7 +18,7 @@ ParsePlugin.prototype.apply = function(resolver) {
 		if(request.query && !parsed.query) {
 			obj.query = request.query;
 		}
-		if(callback.log) {
+		if(parsed && callback.log) {
 			if(parsed.module)
 				callback.log("Parsed request is a module");
 			if(parsed.directory)


### PR DESCRIPTION
When upgrading to latest Webpack, I got some errors related to parsed being undefined, so this fix is a tentative one.