### PR TITLE
Fix `_readJsonSync` in CachedInputFileSystem

### DIFF
--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -197,6 +197,7 @@ function CachedInputFileSystem(fileSystem, duration) {
 		this._readJsonSync = function(path) {
 			var buffer = this.readFileSync(path);
 			var data = JSON.parse(buffer.toString("utf-8"));
+			return data;
 		}.bind(this);
 	} else {
 		this.readJsonSync = null;


### PR DESCRIPTION
It was just missing actually return the parsed JSON content.

It was affecting the reading of description files (`package.json`), leaving the content as `undefined`. Like this:
```
descriptionFilePath: '[...]/node_modules/react-router/package.json',
descriptionFileData: undefined,
descriptionFileRoot: '[...]/node_modules/react-router',
```

This PR also fixes https://github.com/benmosher/eslint-plugin-import/issues/688#issuecomment-267343188