### PR TITLE
Use optimized string searching for faster alias resolving

### DIFF
--- a/lib/AliasPlugin.js
+++ b/lib/AliasPlugin.js
@@ -6,6 +6,23 @@ var assign = require("object-assign");
 var createInnerCallback = require("./createInnerCallback");
 var getInnerRequest = require("./getInnerRequest");
 
+function startsWith(string, searchString) {
+	var stringLength = string.length;
+	var searchLength = searchString.length;
+
+	// early out if the search length is greater than the search string
+	if(searchLength > stringLength) {
+		return false;
+	}
+	var index = -1;
+	while(++index < searchLength) {
+		if(string.charCodeAt(index) != searchString.charCodeAt(index)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 function AliasPlugin(source, options, target) {
 	this.source = source;
 	this.name = options.name;
@@ -23,8 +40,8 @@ AliasPlugin.prototype.apply = function(resolver) {
 	resolver.plugin(this.source, function(request, callback) {
 		var innerRequest = getInnerRequest(resolver, request);
 		if(!innerRequest) return callback();
-		if((!onlyModule && innerRequest.indexOf(name + "/") === 0) || innerRequest === name) {
-			if(innerRequest.indexOf(alias + "/") !== 0 && innerRequest != alias) {
+		if(innerRequest === name || (!onlyModule && startsWith(innerRequest, name + "/"))) {
+			if(innerRequest != alias && !startsWith(innerRequest, alias + "/")) {
 				var newRequestStr = alias + innerRequest.substr(name.length);
 				var obj = assign({}, request, {
 					request: newRequestStr

--- a/lib/AliasPlugin.js
+++ b/lib/AliasPlugin.js
@@ -16,7 +16,7 @@ function startsWith(string, searchString) {
 	}
 	var index = -1;
 	while(++index < searchLength) {
-		if(string.charCodeAt(index) != searchString.charCodeAt(index)) {
+		if(string.charCodeAt(index) !== searchString.charCodeAt(index)) {
 			return false;
 		}
 	}
@@ -41,7 +41,7 @@ AliasPlugin.prototype.apply = function(resolver) {
 		var innerRequest = getInnerRequest(resolver, request);
 		if(!innerRequest) return callback();
 		if(innerRequest === name || (!onlyModule && startsWith(innerRequest, name + "/"))) {
-			if(innerRequest != alias && !startsWith(innerRequest, alias + "/")) {
+			if(innerRequest !== alias && !startsWith(innerRequest, alias + "/")) {
 				var newRequestStr = alias + innerRequest.substr(name.length);
 				var obj = assign({}, request, {
 					request: newRequestStr

--- a/lib/getPaths.js
+++ b/lib/getPaths.js
@@ -20,7 +20,7 @@ module.exports = function getPaths(path) {
 	path = path.substr(0, path.length - part.length - 1);
 	paths.push(path)
 	for(var i = parts.length - 2; i > 2; i -= 2) {
-		var part = parts[i];
+		part = parts[i];
 		path = path.substr(0, path.length - part.length) || "/";
 		paths.push(path);
 		seqments.push(part.substr(0, part.length - 1));


### PR DESCRIPTION
`getPaths.js`: updated to fix lint rule so tests pass

`AliasPlugin.js`: changed the call to `indexOf` to use a [modified polyfill](https://github.com/mathiasbynens/String.prototype.startsWith/blob/master/startswith.js) for `String.prototype.startsWith`. In our Webpack build these calls to `indexOf` account for about 12% of total execution time. Turns out v8's implementation isn't written in JavaScript (see [string.js](https://github.com/v8/v8/blob/master/src/js/string.js) which instead calls out to `%StringIndexOf` - v8's way of linking to its C++ code). This jump from JS land to C++ is such a large performance hit that much of v8's JavaScript built-ins are written in JS instead of the faster, compiled C++. I also flipped the execution order of the test cases on both lines from `search() || foo == bar` to `foo == bar || search()` as the equality check will be faster and provides an early out.

The modifications to the polyfill make it less versatile (removed the type errors, for example) and are based on the assumption that `innerRequest`is always a string.

Results agree with the performance profiling showing 11-12% of time going to `indexOf`
current webpack build:
```303108ms
real	5m5.751s
user	5m4.721s
sys	0m4.788s
```

with changes to AliasPlugin.js
```269654ms
real	4m32.438s
user	4m32.318s
sys	0m3.911s
```