### PR TITLE
[Proposal] Performance: Make file resolving asyncSeriesBail instead of parallel

### DIFF
--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -117,7 +117,7 @@ Resolver.prototype.doResolve = function doResolve(type, request, message, callba
 			if(result) return callback(null, result);
 			return callback();
 		}
-		return resolver.applyPluginsParallelBailResult1(type, request, createInnerCallback(innerCallback, {
+		return resolver.applyPluginsAsyncSeriesBailResult1(type, request, createInnerCallback(innerCallback, {
 			log: callback.log,
 			missing: callback.missing,
 			stack: newStack


### PR DESCRIPTION
tl;dr - this change shaves ~2.5 min off our longest webpack build at Redfin.

We've been putting off upgrading off webpack v1 for awhile, because when we tried to upgrade from webpack1 to v2/v3, our build perf took a big hit. We found/fixed a couple issues, but we were still looking at an increase from ~1:45 webpack build with v1 to ~4.5+ min with webpack v3 (v2 was even worse -- 5+ minutes)

I couldn't sleep, so I dug in with a profiler+console.log again, and noticed that `CachedInputFileSystem.readlink` was getting called with _all_ values of `module.extensions`, even when the file extension was specified on the require, or was the first extension in the list. For us, that's a _lot_ of calls! I originally tried removing removing some unnecessary module.extensions (we were using webpack 1 defaults + .css/.less). That helped quite a bit, but we were still making a bunch of calls unnecessarily, and OSX's filesystem hasn't been the fastest for us, so I followed up with this change from parallel -> asyncSeries, which improve performance tremendously.

Example timings:

```
bare v3
[06:01:19] Finished 'webpack' after 4.57 min
[06:06:27] Finished 'webpack' after 4.82 min

v3, _just_ parallel->async
[06:18:13] Finished 'webpack' after 2.3 min

v3, _both_ fewer module.extensions and parallel->async
[06:13:16] Finished 'webpack' after 2.18 min
```

Both changes have the affect of significantly reducing the number of calls to, e.g. `readlink` through the CachedInputFileSystem.

I'm not 100% sure this is the correct solution, because I'm not super familiar with this code, and I'm pretty sleep-deprived, but this gets us a very significant performance improvement in webpack 3, and would make it possible to upgrade from webpack 1 (finally!). If not the right approach, LMK and I can revisit (or if it's easy for someone else to handle, feel free)

Thanks!


