### PR TITLE
FIX: TypeError: Cannot read property 'startsWith' of undefined in cas…

### DIFF
--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -149,7 +149,7 @@ Storage.prototype.purge = function(what) {
 		});
 	} else if(typeof what === "string") {
 		for(var key of this.data.keys()) {
-			if(key.startsWith(what))
+			if(key && key.startsWith(what))
 				this.data.delete(key);
 		}
 	} else {


### PR DESCRIPTION
…e key is undefined


I'm on the latest webpack, webpack-dev-server and using the HRM. Everytime something changes, it crashes in:

> E:\project\node_modules\enhanced-resolve\lib\CachedInputFileSystem.js:148
>                         if(key.startsWith(what))
>                               ^
> 
> TypeError: Cannot read property 'startsWith' of undefined
>     at Storage.purge (E:\project\node_modules\enhanced-resolve\lib\CachedInputFileSystem.js:148:10)
>     at Storage.purge (E:\project\node_modules\enhanced-resolve\lib\CachedInputFileSystem.js:153:9)
>     at CachedInputFileSystem.purge (E:\project\node_modules\enhanced-resolve\lib\CachedInputFileSystem.js:262:20)
>     at Watchpack.watcher.once (E:\project\node_modules\webpack\lib\node\NodeWatchFileSystem.js:42:26)
>     at Object.onceWrapper (events.js:293:19)
>     at emitTwo (events.js:106:13)
>     at Watchpack.emit (events.js:194:7)
>     at Watchpack._onTimeout (E:\project\node_modules\watchpack\lib\watchpack.js:142:7)
>     at ontimeout (timers.js:386:14)
>     at tryOnTimeout (timers.js:250:5)

I can't figure out from where is coming, if I console all the keys, I'm getting:

> Key: E:\node_modules
> Key: E:\project\node_modules
> Key: E:\project\app\main.jsx
> Key: E:\project\node_modules\webpack-dev-server\client\index.js
> Key: E:\project\node_modules\babel-loader
> Key: E:\project\node_modules\webpack\hot\dev-server
> Key: E:\project\node_modules\babel-loader.js
> Key: E:\project\node_modules\webpack\hot\dev-server.js
> Key: E:\project\node_modules\webpack-dev-server\client\node_modules
> Key: E:\project\node_modules\node_modules
> Key: E:\project\node_modules\webpack-dev-server\node_modules
> Key: E:\project\node_modules\webpack\hot
> Key: E:\project\node_modules\babel-loader.json
> Key: E:\project\node_modules\webpack-dev-server\client\socket
> Key: E:\project\node_modules\webpack-dev-server\client\overlay
> Key: E:\project\node_modules\webpack\hot\emitter
> Key: E:\project\node_modules\webpack-dev-server\node_modules\strip-ansi
> Key: E:\project\node_modules\webpack-dev-server\node_modules\loglevel
> Key: E:\project\node_modules\webpack-dev-server\node_modules\webpack\hot
> Key: E:\project\node_modules\webpack-dev-server\client\socket.js
> Key: E:\project\node_modules\webpack-dev-server\client\overlay.js
> Key: E:\project\node_modules\webpack\hot\emitter.js
> Key: E:\project\node_modules\babel-loader\lib\index.js
> Key: E:\project\node_modules\webpack-dev-server\node_modules\webpack\hot\emitter
> Key: E:\project\node_modules\strip-ansi
> Key: E:\project\node_modules\loglevel
> Key: E:\project\node_modules\webpack-dev-server\node_modules\strip-ansi.js
> Key: E:\project\node_modules\webpack-dev-server\node_modules\loglevel.js
> Key: E:\project\node_modules\webpack\hot\log.js
> Key: E:\project\node_modules\webpack\hot\log-apply-result.js
> Key: E:\project\node_modules\webpack\hot\poll.js
> Key: E:\project\node_modules\webpack\hot\signal.js
> Key: E:\project\node_modules\webpack\hot\only-dev-server.js
> Key: E:\project\node_modules\url\url.js
> Key: E:\project\node_modules\webpack\hot\log
> Key: E:\project\node_modules\webpack\hot\log-apply-result
> Key: E:\project\node_modules\webpack-dev-server\node_modules\webpack\hot\emitter.js
> Key: E:\project\node_modules\strip-ansi.js
> Key: E:\project\node_modules\loglevel.js
> Key: E:\project\node_modules\webpack-dev-server\node_modules\strip-ansi.jsx
> Key: E:\project\node_modules\webpack-dev-server\node_modules\loglevel.jsx
> Key: undefined

and also getting an undefined in the this.data array