### PR TITLE
Restore support for sub-arrays in mainFields

### DIFF
--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -115,7 +115,7 @@ exports.createResolver = function(options) {
 	});
 
 	mainFields = mainFields.map(item => {
-		if(typeof item === "string") {
+		if(typeof item === "string" || Array.isArray(item)) {
 			item = {
 				name: item,
 				forceRelative: true


### PR DESCRIPTION
Support for sub-arrays in mainFields (i.e. using an object in package.json to determine the main file to use for a module) seems to have been accidentally not included in enhanced-resolve.  This commit re-adds it.  Huge thanks to @sokra for the fix.

Tested by using this version of enhanced-resolve in https://github.com/sjbarag/webpack-mwe .  The test case in that MWE now passes.

fixes #116