### PR TITLE
Check for multiple parts before accessing

### DIFF
--- a/lib/getPaths.js
+++ b/lib/getPaths.js
@@ -9,16 +9,18 @@ module.exports = function getPaths(path) {
 	const paths = [path];
 	const seqments = [parts[parts.length - 1]];
 	let part = parts[parts.length - 1];
-	path = path.substr(0, path.length - part.length - 1);
-	paths.push(path);
-	for(let i = parts.length - 2; i > 2; i -= 2) {
-		part = parts[i];
-		path = path.substr(0, path.length - part.length) || "/";
+	if(parts.length > 1) {
+		path = path.substr(0, path.length - part.length - 1);
 		paths.push(path);
-		seqments.push(part.substr(0, part.length - 1));
+		for(let i = parts.length - 2; i > 2; i -= 2) {
+			part = parts[i];
+			path = path.substr(0, path.length - part.length) || "/";
+			paths.push(path);
+			seqments.push(part.substr(0, part.length - 1));
+		}
+		part = parts[1];
+		seqments.push(part.length > 1 ? part.substr(0, part.length - 1) : part);
 	}
-	part = parts[1];
-	seqments.push(part.length > 1 ? part.substr(0, part.length - 1) : part);
 	return {
 		paths: paths,
 		seqments: seqments

--- a/test/getPaths.js
+++ b/test/getPaths.js
@@ -1,0 +1,14 @@
+var getPaths = require("../lib/getPaths");
+
+describe("getPaths", function() {
+	it("should handle a path with no separators", function() {
+		var paths = getPaths(".");
+		paths.should.have.property("paths", ["."]);
+		paths.should.have.property("seqments", ["."]);
+	});
+	it("should handle a path with multiple separators", function() {
+		var paths = getPaths("./node_modules/react");
+		paths.should.have.property("paths", ["./node_modules/react", "./node_modules", "."]);
+		paths.should.have.property("seqments", ["react", "node_modules", "."]);
+	});
+});


### PR DESCRIPTION
This fixes an issue where the code throws an exception when it tries to access a `part` that does not exist. This occurs when `path` is `"."`.

I have used this in our application code and I have run `npm test` against these changes.