### PR TITLE
Add LICENSE file to npm releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "author": "Tobias Koppers @sokra",
   "description": "Offers a async require.resolve function. It's highly configurable.",
   "files": [
-    "lib"
+    "lib",
+    "LICENSE"
   ],
   "dependencies": {
     "graceful-fs": "^4.1.2",


### PR DESCRIPTION
Fix for #130

Adds the LICENSE file during `npm pack` and `npm publish`.