### PR TITLE
Add wrong case path check when resolve failed in case-sensitive FS. (resolves webpack/webpack#5543)

### DIFF
--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -145,7 +145,7 @@ class Resolver extends Tapable {
 			request: request
 		};
 
-		const message = "resolve '" + request + "' in '" + path + "'";
+		const message = "resolve '" + request + "' in '" + path + "'. ";
 
 		// Try to resolve assuming there is no error
 		// We don't log stuff in this case

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -31,6 +31,7 @@ const AppendPlugin = require("./AppendPlugin");
 const ResultPlugin = require("./ResultPlugin");
 const ModuleAppendPlugin = require("./ModuleAppendPlugin");
 const UnsafeCachePlugin = require("./UnsafeCachePlugin");
+const WrongCaseErrorPlugin = require("./WrongCaseErrorPlugin");
 
 exports.createResolver = function(options) {
 
@@ -269,6 +270,9 @@ exports.createResolver = function(options) {
 
 	// resolved
 	plugins.push(new ResultPlugin(resolver.hooks.resolved));
+
+	// no resolve
+	plugins.push(new WrongCaseErrorPlugin(resolver.hooks.noResolve));
 
 	//// RESOLVER ////
 

--- a/lib/SyncAsyncFileSystemDecorator.js
+++ b/lib/SyncAsyncFileSystemDecorator.js
@@ -7,6 +7,7 @@
 function SyncAsyncFileSystemDecorator(fs) {
 	this.fs = fs;
 	if(fs.statSync) {
+		this.statSync = fs.statSync.bind(fs);
 		this.stat = function(arg, callback) {
 			let result;
 			try {
@@ -18,6 +19,7 @@ function SyncAsyncFileSystemDecorator(fs) {
 		};
 	}
 	if(fs.readdirSync) {
+		this.readdirSync = fs.readdirSync.bind(fs);
 		this.readdir = function(arg, callback) {
 			let result;
 			try {
@@ -29,6 +31,7 @@ function SyncAsyncFileSystemDecorator(fs) {
 		};
 	}
 	if(fs.readFileSync) {
+		this.readFileSync = fs.readFileSync.bind(fs);
 		this.readFile = function(arg, callback) {
 			let result;
 			try {
@@ -40,6 +43,7 @@ function SyncAsyncFileSystemDecorator(fs) {
 		};
 	}
 	if(fs.readlinkSync) {
+		this.readlinkSync = fs.readlinkSync.bind(fs);
 		this.readlink = function(arg, callback) {
 			let result;
 			try {
@@ -51,6 +55,7 @@ function SyncAsyncFileSystemDecorator(fs) {
 		};
 	}
 	if(fs.readJsonSync) {
+		this.readJsonSync = fs.readJsonSync.bind(fs);
 		this.readJson = function(arg, callback) {
 			let result;
 			try {

--- a/lib/WrongCaseErrorPlugin.js
+++ b/lib/WrongCaseErrorPlugin.js
@@ -1,0 +1,80 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+const path = require("path");
+
+module.exports = class WrongCaseErrorPlugin {
+	constructor(source) {
+		this.source = source;
+		this._fsInfo = {
+			checked: false,
+			caseInsensitive: false,
+		};
+	}
+
+	checkFS(fs) {
+		if(!this._fsInfo.checked) {
+			try {
+				const upperStat = fs.statSync(process.execPath.toUpperCase());
+				const lowerStat = fs.statSync(process.execPath.toLowerCase());
+				if(upperStat.dev === lowerStat.dev && upperStat.ino === lowerStat.ino) {
+					this._fsInfo.caseInsensitive = true;
+				}
+			} catch(e) {}
+			this._fsInfo.checked = true;
+		}
+		return this._fsInfo;
+	}
+	matchFileWithCaseInsensitive(fs, filepath, dirname, filename) {
+		if(dirname === filepath) return;
+		try {
+			const list = fs.readdirSync(dirname);
+			const lowerFilename = filename.toLowerCase();
+			const matchedName = list.find(name => name !== filename && name.toLowerCase() === lowerFilename);
+			if(matchedName) {
+				return {
+					usedName: filename,
+					matchedName: matchedName,
+					matchedNameDir: dirname,
+				};
+			}
+		} catch(e) {}
+		return this.matchFileWithCaseInsensitive(fs, dirname, path.dirname(dirname), path.basename(dirname));
+	}
+	apply(resolver) {
+		const fs = resolver.fileSystem;
+		this.source.tap("NoResolvePlugin", (request, error) => {
+			const fsInfo = this.checkFS(fs);
+			// Check if used wrong case path
+			if(!fsInfo.caseInsensitive) {
+				const missing = error.missing;
+				const checkedDir = new Set();
+				let i = 0;
+				let matchedFile;
+				while(i < missing.length && !matchedFile) {
+					const checkFile = missing[i];
+					const checkDir = path.dirname(checkFile);
+					const checkName = path.basename(checkFile);
+					if(checkedDir.has(checkDir)) {
+						i++;
+						continue;
+					}
+					checkedDir.add(checkDir);
+					matchedFile = this.matchFileWithCaseInsensitive(fs, checkFile, checkDir, checkName);
+					if(matchedFile) {
+						error.message += ("You may be using a wrong case path which the '" +
+							matchedFile.usedName +
+							"' is not found but the '" +
+							matchedFile.matchedName +
+							"' is. (in: " + checkFile + ")");
+						break;
+					}
+					i++;
+				}
+			}
+		});
+	}
+};

--- a/test/fixtures/wrongCase/index.js
+++ b/test/fixtures/wrongCase/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+	console.log("WrongCase");
+};

--- a/test/no-resolve.js
+++ b/test/no-resolve.js
@@ -1,0 +1,27 @@
+var resolve = require("../");
+var path = require("path");
+
+describe("no resolve", function() {
+	it("should check and tell wrong case usage in case-sensitive system", function(done) {
+		resolve(path.join(__dirname, "fixtures"), "./WRONGcASE", function(err) {
+			if(err) { // will not found only in case-sensitive system.
+				err.message.should.containEql("wrong case path");
+				err.message.should.containEql("'WRONGcASE'");
+				err.message.should.containEql("'wrongCase'");
+
+				//right case but non-existent file
+				resolve(path.join(__dirname, "fixtures"), "./wrongCase/missing-file", function(_err) {
+					_err.message.should.not.containEql("wrong case path");
+					done();
+				});
+			} else { //case-insensitive, shouldn't check case when not found.
+				resolve(path.join(__dirname, "fixtures"), "./WRONGcASE/missing-file", function(_err) {
+					_err.message.should.not.containEql("wrong case path");
+					_err.message.should.not.containEql("'WRONGcASE'");
+					_err.message.should.not.containEql("'wrongCase'");
+					done();
+				});
+			}
+		});
+	});
+});


### PR DESCRIPTION
This PR resolves webpack/webpack#5543, works by following steps:

1. Fired when a request not found.
2. Check if in case-sensitive file system.
3. Check if has the same but different case file/dir name from the inside out by `readdir`.
4. Append warning message to not found Error's message if found above.


workspace:
```
-- enhanced-resolve
   |-- ...
   |-- demo.js
-- testDir
   |-- file.js
```

demo.js:
```javascript
const resolve = require("./");
resolve({}, __dirname, '../TESTdiR/file', (err, filepath) => {
	console.log(err.message);
});
```

output:
![image](https://user-images.githubusercontent.com/4403937/36164603-cf61758c-1127-11e8-93c1-3b4d9aa1073f.png)

Not sure if this message is appropriate. Looking forward to the review. :p