### PR TITLE
Drop node engine down to 6.9.0 to support AWS lambda environments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "should": "^8.0.2"
   },
   "engines": {
-    "node": ">=6.11.5"
+    "node": ">=6.9.0"
   },
   "main": "lib/node.js",
   "homepage": "http://github.com/webpack/enhanced-resolve",


### PR DESCRIPTION
Drops node engine version down, and confirms build/test against node 6.9.0.

This resolves issue #141, which in-turn will enable https://github.com/webpack/webpack/issues/6579 to be resolved.