### PR TITLE
Enable alias entry to be set as an array of directory paths vs. single string path

### DIFF
--- a/lib/AliasPlugin.js
+++ b/lib/AliasPlugin.js
@@ -4,6 +4,9 @@
 */
 "use strict";
 
+const fs = require("fs");
+const path = require("path");
+
 function startsWith(string, searchString) {
 	const stringLength = string.length;
 	const searchLength = searchString.length;
@@ -35,18 +38,58 @@ module.exports = class AliasPlugin {
 			if(!innerRequest) return callback();
 			for(const item of this.options) {
 				if(innerRequest === item.name || (!item.onlyModule && startsWith(innerRequest, item.name + "/"))) {
-					if(innerRequest !== item.alias && !startsWith(innerRequest, item.alias + "/")) {
-						const newRequestStr = item.alias + innerRequest.substr(item.name.length);
-						const obj = Object.assign({}, request, {
-							request: newRequestStr
-						});
-						return resolver.doResolve(target, obj, "aliased with mapping '" + item.name + "': '" + item.alias + "' to '" + newRequestStr + "'", resolveContext, (err, result) => {
-							if(err) return callback(err);
+					if(Array.isArray(item.alias)) {
+						for(let i = 0, length = item.alias.length; i < length; i++) {
+							let nItem = Object.assign({}, item);
+							nItem.alias = item.alias[i]; // alias is the folder
 
-							// Don't allow other aliasing or raw request
-							if(result === undefined) return callback(null, null);
-							callback(null, result);
-						});
+							if(innerRequest !== nItem.alias && !startsWith(innerRequest, nItem.alias + "/")) {
+								const newRequestStr = nItem.alias + innerRequest.substr(nItem.name.length);
+								const obj = Object.assign({}, request, {
+									request: newRequestStr
+								});
+
+								var files = fs.readdirSync(nItem.alias, {
+									encoding: "utf-8"
+								});
+
+								let filePathFound = null;
+								const matchingFileFound = files.find((fn, idx, obj) => {
+									let ext = path.extname(fn);
+									let f = newRequestStr + ext;
+									let exists = fs.existsSync(f);
+
+									if(exists) {
+										filePathFound = f;
+									}
+									return exists;
+								});
+
+								if(matchingFileFound) {
+									return resolver.doResolve(target, obj, "aliased with mapping '" + nItem.name + "': '" + nItem.alias + "' to '" + filePathFound + "'", resolveContext, (err, result) => {
+										if(err) return callback(err);
+
+										// Don't allow other aliasing or raw request
+										if(result === undefined) return callback(null, null);
+										callback(null, result);
+									});
+								}
+							}
+						}
+					} else {
+						if(innerRequest !== item.alias && !startsWith(innerRequest, item.alias + "/")) {
+							const newRequestStr = item.alias + innerRequest.substr(item.name.length);
+							const obj = Object.assign({}, request, {
+								request: newRequestStr
+							});
+							return resolver.doResolve(target, obj, "aliased with mapping '" + item.name + "': '" + item.alias + "' to '" + newRequestStr + "'", resolveContext, (err, result) => {
+								if(err) return callback(err);
+
+								// Don't allow other aliasing or raw request
+								if(result === undefined) return callback(null, null);
+								callback(null, result);
+							});
+						}
 					}
 				}
 			}

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -132,7 +132,7 @@ exports.createResolver = function(options) {
 				onlyModule = true;
 				key = key.substr(0, key.length - 1);
 			}
-			if(typeof obj === "string") {
+			if(typeof obj === "string" || Array.isArray(obj)) {
 				obj = {
 					alias: obj
 				};


### PR DESCRIPTION
This PR should enable this feature [feature-request/open issue](https://github.com/webpack/webpack/issues/6817).

Create an alias which points to several directories.
Currently it takes a string, this PR enables it to take a string-array of directories.

I am sure that the current implementation is **NOT** the right way to go.

But if it is a starting point, perhaps I can finish it with your advise, otherwise toss it!

Code/Schema adaptations in other repos which have to be done:

- `webpack-repo`: webpack/schemas/WebpackOptions.json
- `@types/webpack-repo`:  index.d.ts