### PR TITLE
feat: Accept multiple aliases

### DIFF
--- a/lib/AliasPlugin.js
+++ b/lib/AliasPlugin.js
@@ -1,7 +1,7 @@
 /*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Tobias Koppers @sokra
-*/
+ MIT License http://www.opensource.org/licenses/mit-license.php
+ Author Tobias Koppers @sokra
+ */
 "use strict";
 
 function startsWith(string, searchString) {
@@ -21,7 +21,41 @@ function startsWith(string, searchString) {
 	return true;
 }
 
-module.exports = class AliasPlugin {
+function normalizeOptions(alias) {
+	if (Array.isArray(alias)) return alias;
+
+	return Object.keys(alias).reduce((options, key) => {
+		let onlyModule = false;
+		let obj = alias[key];
+		if (/\$$/.test(key)) {
+			onlyModule = true;
+			key = key.substr(0, key.length - 1);
+		}
+		const base = { name: key, onlyModule: onlyModule };
+
+		let fragments;
+		if (typeof obj === "string") {
+			fragments = [{ alias: obj }];
+		} else if (Array.isArray(obj)) {
+			fragments = obj.reduce(
+				(fragments, aliasString) =>
+					fragments.concat(
+						Object.assign({}, base, {
+							alias: aliasString
+						})
+					),
+				[]
+			);
+		} else {
+			fragments = [obj];
+		}
+		return options.concat(
+			fragments.map(fragment => Object.assign({}, base, fragment))
+		);
+	}, []);
+}
+
+class AliasPlugin {
 	constructor(source, options, target) {
 		this.source = source;
 		this.options = Array.isArray(options) ? options : [options];
@@ -35,43 +69,54 @@ module.exports = class AliasPlugin {
 			.tapAsync("AliasPlugin", (request, resolveContext, callback) => {
 				const innerRequest = request.request || request.path;
 				if (!innerRequest) return callback();
-				for (const item of this.options) {
-					if (
-						innerRequest === item.name ||
-						(!item.onlyModule && startsWith(innerRequest, item.name + "/"))
-					) {
-						if (
-							innerRequest !== item.alias &&
-							!startsWith(innerRequest, item.alias + "/")
-						) {
-							const newRequestStr =
-								item.alias + innerRequest.substr(item.name.length);
-							const obj = Object.assign({}, request, {
-								request: newRequestStr
-							});
-							return resolver.doResolve(
-								target,
-								obj,
-								"aliased with mapping '" +
-									item.name +
-									"': '" +
-									item.alias +
-									"' to '" +
-									newRequestStr +
-									"'",
-								resolveContext,
-								(err, result) => {
-									if (err) return callback(err);
 
-									// Don't allow other aliasing or raw request
-									if (result === undefined) return callback(null, null);
-									callback(null, result);
-								}
-							);
+				optionsRecur(this.options);
+
+				function optionsRecur(options) {
+					const [item, ...restOptions] = options;
+					// Any of options were not matched
+					if (!item) return callback();
+
+					const isEligibleRequest =
+						innerRequest === item.name ||
+						(!item.onlyModule && startsWith(innerRequest, item.name + "/"));
+
+					if (!isEligibleRequest) return optionsRecur(restOptions);
+
+					const needsAliasing =
+						innerRequest !== item.alias &&
+						!startsWith(innerRequest, item.alias + "/");
+
+					if (!needsAliasing) return optionsRecur(restOptions);
+
+					const newRequestStr =
+						item.alias + innerRequest.substr(item.name.length);
+					const obj = Object.assign({}, request, { request: newRequestStr });
+					return resolver.doResolve(
+						target,
+						obj,
+						"aliased with mapping '" +
+							item.name +
+							"': '" +
+							item.alias +
+							"' to '" +
+							newRequestStr +
+							"'",
+						resolveContext,
+						(err, result) => {
+							if (err) return callback(err);
+
+							// Try next alias
+							if (result === undefined) return optionsRecur(restOptions);
+
+							// Found one!
+							callback(null, result);
 						}
-					}
+					);
 				}
-				return callback();
 			});
 	}
-};
+}
+
+module.exports = AliasPlugin;
+module.exports.normalizeOptions = normalizeOptions;

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -127,29 +127,7 @@ exports.createResolver = function(options) {
 		return item;
 	});
 
-	if (typeof alias === "object" && !Array.isArray(alias)) {
-		alias = Object.keys(alias).map(key => {
-			let onlyModule = false;
-			let obj = alias[key];
-			if (/\$$/.test(key)) {
-				onlyModule = true;
-				key = key.substr(0, key.length - 1);
-			}
-			if (typeof obj === "string") {
-				obj = {
-					alias: obj
-				};
-			}
-			obj = Object.assign(
-				{
-					name: key,
-					onlyModule: onlyModule
-				},
-				obj
-			);
-			return obj;
-		});
-	}
+	alias = AliasPlugin.normalizeOptions(alias);
 
 	if (unsafeCache && typeof unsafeCache !== "object") {
 		unsafeCache = {};


### PR DESCRIPTION
ref. https://github.com/webpack/webpack/issues/6817

Expect alias options to be:
```js
  // "Shorthanded" option type
  alias: {
    '@single@': './only',
    '@multi@': ['./first', './second'] // <- What this PR supports
  }
```

, which is equivalent to:

```js
  // "Raw" option type
  alias: [
    { name: '@single@', alias: './only' },
    { name: '@multi@', alias: './first' },
    { name: '@multi@', alias: './second' },
  ]
```

Later on I'll send another PR to [webpack/webpack](https://github.com/webpack/webpack) to support new alias option and to deal with https://github.com/webpack/webpack/issues/6817 .