### PR TITLE
chore: ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .idea
 .vscode
 .DS_Store
+package-lock.json


### PR DESCRIPTION
Ignoring `package-lock.json` as the project is using `yarn.lock`.