### PR TITLE
refactor CachedFileSystem

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,1 @@
+declare type URL = typeof import("url").URL;

--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -5,7 +5,8 @@
 
 "use strict";
 
-const { clearInterval, setInterval } = require("timers");
+/** @typedef {import("./Resolver").FileSystem} FileSystem */
+/** @typedef {import("./Resolver").SyncFileSystem} SyncFileSystem */
 
 const dirname = path => {
 	let idx = path.length - 1;
@@ -19,337 +20,430 @@ const dirname = path => {
 	return path.slice(0, idx);
 };
 
-class Storage {
-	constructor(duration) {
-		this.duration = duration;
-		this.running = new Map();
-		this.data = new Map();
-		this.levels = [];
-		if (duration > 0) {
-			this.levels.push(
-				new Set(),
-				new Set(),
-				new Set(),
-				new Set(),
-				new Set(),
-				new Set(),
-				new Set(),
-				new Set(),
-				new Set()
-			);
-			for (let i = 8000; i < duration; i += 500) this.levels.push(new Set());
-		}
-		this.count = 0;
-		/** @type {NodeJS.Timeout | null} */
-		this.interval = null;
-		this.needTickCheck = false;
-		this.nextTick = null;
-		this.passive = true;
-		this.tick = this.tick.bind(this);
-	}
-
-	ensureTick() {
-		if (!this.interval && this.duration > 0 && !this.nextTick)
-			this.interval = setInterval(
-				this.tick,
-				Math.floor(this.duration / this.levels.length)
-			);
-	}
-
-	finished(name, err, result) {
-		const callbacks = this.running.get(name);
-		this.running.delete(name);
-		if (this.duration > 0) {
-			this.data.set(name, [err, result]);
-			const levelData = this.levels[0];
-			this.count -= levelData.size;
-			levelData.add(name);
-			this.count += levelData.size;
-			this.ensureTick();
-		}
-		for (let i = 0; i < callbacks.length; i++) {
-			callbacks[i](err, result);
+const runCallbacks = (callbacks, err, result) => {
+	if (callbacks.length === 1) return callbacks[0](err, result);
+	let error;
+	for (const callback of callbacks) {
+		try {
+			callback(err, result);
+		} catch (e) {
+			if (!error) error = e;
 		}
 	}
+	callbacks.length = 0;
+	if (error) throw error;
+};
 
-	finishedSync(name, err, result) {
-		if (this.duration > 0) {
-			this.data.set(name, [err, result]);
-			const levelData = this.levels[0];
-			this.count -= levelData.size;
-			levelData.add(name);
-			this.count += levelData.size;
-			this.ensureTick();
-		}
+class OperationMergerBackend {
+	/**
+	 * @param {any} provider async method
+	 * @param {any} syncProvider sync method
+	 * @param {any} providerContext call context for the provider methods
+	 */
+	constructor(provider, syncProvider, providerContext) {
+		this._provider = provider;
+		this._syncProvider = syncProvider;
+		this._providerContext = providerContext;
+		this._activeAsyncOperations = new Map();
+
+		this.provide = this._provider
+			? (path, options, callback) => {
+					if (typeof options === "function") {
+						callback = options;
+						options = undefined;
+					}
+					if (options) {
+						return this._provider.call(
+							this._providerContext,
+							path,
+							options,
+							callback
+						);
+					}
+					if (typeof path !== "string") {
+						callback(new TypeError("path must be a string"));
+						return;
+					}
+					let callbacks = this._activeAsyncOperations.get(path);
+					if (callbacks) {
+						callbacks.push(callback);
+						return;
+					}
+					this._activeAsyncOperations.set(path, (callbacks = [callback]));
+					provider(path, (err, result) => {
+						this._activeAsyncOperations.delete(path);
+						runCallbacks(callbacks, err, result);
+					});
+			  }
+			: null;
+		this.provideSync = this._syncProvider
+			? (path, options) => {
+					return this._syncProvider.call(this._providerContext, path, options);
+			  }
+			: null;
 	}
 
-	provide(name, provider, callback) {
-		if (typeof name !== "string") {
+	purge() {}
+	purgeParent() {}
+}
+
+/*
+
+IDLE:
+	insert data: goto SYNC
+
+SYNC:
+	before provide: run ticks
+	event loop tick: goto ASYNC_ACTIVE
+
+ASYNC:
+	timeout: run tick, goto ASYNC_PASSIVE
+
+ASYNC_PASSIVE:
+	before provide: run ticks
+
+IDLE --[insert data]--> SYNC --[event loop tick]--> ASYNC_ACTIVE --[interval tick]-> ASYNC_PASSIVE
+                                                          ^                             |
+                                                          +---------[insert data]-------+
+*/
+
+const STORAGE_MODE_IDLE = 0;
+const STORAGE_MODE_SYNC = 1;
+const STORAGE_MODE_ASYNC = 2;
+
+class CacheBackend {
+	/**
+	 * @param {number} duration max cache duration of items
+	 * @param {any} provider async method
+	 * @param {any} syncProvider sync method
+	 * @param {any} providerContext call context for the provider methods
+	 */
+	constructor(duration, provider, syncProvider, providerContext) {
+		this._duration = duration;
+		this._provider = provider;
+		this._syncProvider = syncProvider;
+		this._providerContext = providerContext;
+		/** @type {Map<string, (function(Error, any): void)[]>} */
+		this._activeAsyncOperations = new Map();
+		/** @type {Map<string, { err: Error, result: any, level: Set<string> }>} */
+		this._data = new Map();
+		/** @type {Set<string>[]} */
+		this._levels = [];
+		for (let i = 0; i < 10; i++) this._levels.push(new Set());
+		for (let i = 5000; i < duration; i += 500) this._levels.push(new Set());
+		this._currentLevel = 0;
+		this._tickInterval = Math.floor(duration / this._levels.length);
+		/** @type {STORAGE_MODE_IDLE | STORAGE_MODE_SYNC | STORAGE_MODE_ASYNC} */
+		this._mode = STORAGE_MODE_IDLE;
+
+		/** @type {NodeJS.Timeout | undefined} */
+		this._timeout = undefined;
+		/** @type {number | undefined} */
+		this._nextDecay = undefined;
+
+		this.provide = this.provide.bind(this);
+		this.provideSync = this.provideSync.bind(this);
+	}
+
+	provide(path, options, callback) {
+		if (typeof options === "function") {
+			callback = options;
+			options = undefined;
+		}
+		if (typeof path !== "string") {
 			callback(new TypeError("path must be a string"));
 			return;
 		}
-		let running = this.running.get(name);
-		if (running) {
-			running.push(callback);
+		if (options) {
+			return this._provider.call(
+				this._providerContext,
+				path,
+				options,
+				callback
+			);
+		}
+
+		// When in sync mode we can move to async mode
+		if (this._mode === STORAGE_MODE_SYNC) {
+			this._enterAsyncMode();
+		}
+
+		// Check in cache
+		let cacheEntry = this._data.get(path);
+		if (cacheEntry !== undefined) {
+			if (cacheEntry.err) return callback(cacheEntry.err);
+			return callback(null, cacheEntry.result);
+		}
+
+		// Check if there is already the same operation running
+		let callbacks = this._activeAsyncOperations.get(path);
+		if (callbacks !== undefined) {
+			callbacks.push(callback);
 			return;
 		}
-		if (this.duration > 0) {
-			this.checkTicks();
-			const data = this.data.get(name);
-			if (data) {
-				return process.nextTick(() => {
-					callback.apply(null, data);
-				});
-			}
-		}
-		this.running.set(name, (running = [callback]));
-		provider(name, (err, result) => {
-			this.finished(name, err, result);
+		this._activeAsyncOperations.set(path, (callbacks = [callback]));
+
+		// Run the operation
+		this._provider.call(this._providerContext, path, (err, result) => {
+			this._activeAsyncOperations.delete(path);
+			this._storeResult(path, err, result);
+
+			// Enter async mode if not yet done
+			this._enterAsyncMode();
+
+			runCallbacks(callbacks, err, result);
 		});
 	}
 
-	provideSync(name, provider) {
-		if (typeof name !== "string") {
+	provideSync(path, options) {
+		if (typeof path !== "string") {
 			throw new TypeError("path must be a string");
 		}
-		if (this.duration > 0) {
-			this.checkTicks();
-			const data = this.data.get(name);
-			if (data) {
-				if (data[0]) throw data[0];
-				return data[1];
-			}
+		if (options) {
+			return this._syncProvider.call(this._providerContext, path, options);
 		}
+
+		// In sync mode we may have to decay some cache items
+		if (this._mode === STORAGE_MODE_SYNC) {
+			this._runDecays();
+		}
+
+		// Check in cache
+		let cacheEntry = this._data.get(path);
+		if (cacheEntry !== undefined) {
+			if (cacheEntry.err) throw cacheEntry.err;
+			return cacheEntry.result;
+		}
+
+		// Get all active async operations
+		// This sync operation will also complete them
+		const callbacks = this._activeAsyncOperations.get(path);
+		this._activeAsyncOperations.delete(path);
+
+		// Run the operation
+		// When in idle mode, we will enter sync mode
 		let result;
 		try {
-			result = provider(name);
-		} catch (e) {
-			this.finishedSync(name, e);
-			throw e;
+			result = this._syncProvider.call(this._providerContext, path);
+		} catch (err) {
+			this._storeResult(path, err, undefined);
+			this._enterSyncModeWhenIdle();
+			if (callbacks) runCallbacks(callbacks, err, undefined);
+			throw err;
 		}
-		this.finishedSync(name, null, result);
+		this._storeResult(path, undefined, result);
+		this._enterSyncModeWhenIdle();
+		if (callbacks) runCallbacks(callbacks, undefined, result);
 		return result;
-	}
-
-	tick() {
-		const decay = this.levels.pop();
-		for (let item of decay) {
-			this.data.delete(item);
-		}
-		this.count -= decay.size;
-		decay.clear();
-		this.levels.unshift(decay);
-		if (this.count === 0) {
-			if (this.interval) {
-				clearInterval(this.interval);
-			}
-
-			this.interval = null;
-			this.nextTick = null;
-			return true;
-		} else if (this.nextTick) {
-			this.nextTick += Math.floor(this.duration / this.levels.length);
-			const time = new Date().getTime();
-			if (this.nextTick > time) {
-				this.nextTick = null;
-				this.interval = setInterval(
-					this.tick,
-					Math.floor(this.duration / this.levels.length)
-				);
-				return true;
-			}
-		} else if (this.passive) {
-			if (this.interval) {
-				clearInterval(this.interval);
-			}
-
-			this.interval = null;
-			this.nextTick =
-				new Date().getTime() + Math.floor(this.duration / this.levels.length);
-		} else {
-			this.passive = true;
-		}
-	}
-
-	checkTicks() {
-		this.passive = false;
-		if (this.nextTick) {
-			while (!this.tick());
-		}
 	}
 
 	purge(what) {
 		if (!what) {
-			this.count = 0;
-			if (this.interval) {
-				clearInterval(this.interval);
+			if (this._mode !== STORAGE_MODE_IDLE) {
+				this._data.clear();
+				for (const level of this._levels) {
+					level.clear();
+				}
+				this._enterIdleMode();
 			}
-
-			this.nextTick = null;
-			this.data.clear();
-			this.levels.forEach(level => {
-				level.clear();
-			});
 		} else if (typeof what === "string") {
-			for (let key of this.data.keys()) {
-				if (key.startsWith(what)) this.data.delete(key);
+			for (let [key, data] of this._data) {
+				if (key.startsWith(what)) {
+					this._data.delete(key);
+					data.level.delete(key);
+				}
+			}
+			if (this._data.size === 0) {
+				this._enterIdleMode();
 			}
 		} else {
-			for (let i = what.length - 1; i >= 0; i--) {
-				this.purge(what[i]);
+			for (let [key, data] of this._data) {
+				for (const item of what) {
+					if (key.startsWith(item)) {
+						this._data.delete(key);
+						data.level.delete(key);
+						break;
+					}
+				}
+			}
+			if (this._data.size === 0) {
+				this._enterIdleMode();
 			}
 		}
 	}
 
 	purgeParent(what) {
 		if (!what) {
-			this.count = 0;
-			if (this.interval) {
-				clearInterval(this.interval);
-			}
-			this.nextTick = null;
-			this.data.clear();
-			this.levels.forEach(level => {
-				level.clear();
-			});
+			this.purge();
 		} else if (typeof what === "string") {
-			what = dirname(what);
-			for (let key of this.data.keys()) {
-				if (key.startsWith(what)) this.data.delete(key);
-			}
+			this.purge(dirname(what));
 		} else {
-			for (let i = what.length - 1; i >= 0; i--) {
-				this.purgeParent(what[i]);
+			const set = new Set();
+			for (const item of what) {
+				set.add(dirname(item));
 			}
+			this.purge(set);
 		}
 	}
+
+	_storeResult(path, err, result) {
+		if (this._data.has(path)) return;
+		const level = this._levels[this._currentLevel];
+		this._data.set(path, { err, result, level });
+		level.add(path);
+	}
+
+	_decayLevel() {
+		const nextLevel = (this._currentLevel + 1) % this._levels.length;
+		const decay = this._levels[nextLevel];
+		this._currentLevel = nextLevel;
+		for (let item of decay) {
+			this._data.delete(item);
+		}
+		decay.clear();
+		if (this._data.size === 0) {
+			this._enterIdleMode();
+		} else {
+			// @ts-ignore _nextDecay is always a number in sync mode
+			this._nextDecay += this._tickInterval;
+		}
+	}
+
+	_runDecays() {
+		while (
+			/** @type {number} */ (this._nextDecay) <= Date.now() &&
+			this._mode !== STORAGE_MODE_IDLE
+		) {
+			this._decayLevel();
+		}
+	}
+
+	_enterAsyncMode() {
+		let timeout = 0;
+		switch (this._mode) {
+			case STORAGE_MODE_ASYNC:
+				return;
+			case STORAGE_MODE_IDLE:
+				this._nextDecay = Date.now() + this._tickInterval;
+				timeout = this._tickInterval;
+				break;
+			case STORAGE_MODE_SYNC:
+				this._runDecays();
+				// @ts-ignore _runDecays may change the mode
+				if (this._mode === STORAGE_MODE_IDLE) return;
+				timeout = Math.max(
+					0,
+					/** @type {number} */ (this._nextDecay) - Date.now()
+				);
+				break;
+		}
+		this._mode = STORAGE_MODE_ASYNC;
+		const ref = setTimeout(() => {
+			this._mode = STORAGE_MODE_SYNC;
+			this._runDecays();
+		}, timeout);
+		if (ref.unref) ref.unref();
+		this._timeout = ref;
+	}
+
+	_enterSyncModeWhenIdle() {
+		if (this._mode === STORAGE_MODE_IDLE) {
+			this._mode = STORAGE_MODE_SYNC;
+			this._nextDecay = Date.now() + this._tickInterval;
+		}
+	}
+
+	_enterIdleMode() {
+		this._mode = STORAGE_MODE_IDLE;
+		this._nextDecay = undefined;
+		if (this._timeout) clearTimeout(this._timeout);
+	}
 }
+
+const createBackend = (duration, provider, syncProvider, providerContext) => {
+	if (duration > 0) {
+		return new CacheBackend(duration, provider, syncProvider, providerContext);
+	}
+	return new OperationMergerBackend(provider, syncProvider, providerContext);
+};
 
 module.exports = class CachedInputFileSystem {
 	constructor(fileSystem, duration) {
 		this.fileSystem = fileSystem;
-		this._statStorage = new Storage(duration);
-		this._readdirStorage = new Storage(duration);
-		this._readFileStorage = new Storage(duration);
-		this._readJsonStorage = new Storage(duration);
-		this._readlinkStorage = new Storage(duration);
 
-		this._stat = this.fileSystem.stat
-			? this.fileSystem.stat.bind(this.fileSystem)
-			: null;
-		if (!this._stat) this.stat = /** @type {any} */ (null);
+		this._statBackend = createBackend(
+			duration,
+			this.fileSystem.stat,
+			this.fileSystem.statSync,
+			this.fileSystem
+		);
+		this.stat = /** @type {FileSystem["stat"]} */ (this._statBackend.provide);
+		this.statSync = /** @type {SyncFileSystem["statSync"]} */ (this._statBackend.provideSync);
 
-		this._statSync = this.fileSystem.statSync
-			? this.fileSystem.statSync.bind(this.fileSystem)
-			: null;
-		if (!this._statSync) this.statSync = /** @type {any} */ (null);
+		this._readdirBackend = createBackend(
+			duration,
+			this.fileSystem.readdir,
+			this.fileSystem.readdirSync,
+			this.fileSystem
+		);
+		this.readdir = /** @type {FileSystem["readdir"]} */ (this._readdirBackend.provide);
+		this.readdirSync = /** @type {SyncFileSystem["readdirSync"]} */ (this._readdirBackend.provideSync);
 
-		this._readdir = this.fileSystem.readdir
-			? this.fileSystem.readdir.bind(this.fileSystem)
-			: null;
-		if (!this._readdir) this.readdir = /** @type {any} */ (null);
+		this._readFileBackend = createBackend(
+			duration,
+			this.fileSystem.readFile,
+			this.fileSystem.readFileSync,
+			this.fileSystem
+		);
+		this.readFile = /** @type {FileSystem["readFile"]} */ (this._readFileBackend.provide);
+		this.readFileSync = /** @type {SyncFileSystem["readFileSync"]} */ (this._readFileBackend.provideSync);
 
-		this._readdirSync = this.fileSystem.readdirSync
-			? this.fileSystem.readdirSync.bind(this.fileSystem)
-			: null;
-		if (!this._readdirSync) this.readdirSync = /** @type {any} */ (null);
+		this._readJsonBackend = createBackend(
+			duration,
+			this.fileSystem.readJson ||
+				(this.readFile &&
+					((path, callback) => {
+						// @ts-ignore
+						this.readFile(path, (err, buffer) => {
+							if (err) return callback(err);
+							if (!buffer || buffer.length === 0)
+								return callback(new Error("No file content"));
+							let data;
+							try {
+								data = JSON.parse(buffer.toString("utf-8"));
+							} catch (e) {
+								return callback(e);
+							}
+							callback(null, data);
+						});
+					})),
+			this.fileSystem.readJsonSync ||
+				(this.readFileSync &&
+					(path => {
+						const buffer = this.readFileSync(path);
+						const data = JSON.parse(buffer.toString("utf-8"));
+						return data;
+					})),
+			this.fileSystem
+		);
+		this.readJson = /** @type {FileSystem["readJson"]} */ (this._readJsonBackend.provide);
+		this.readJsonSync = /** @type {SyncFileSystem["readJsonSync"]} */ (this._readJsonBackend.provideSync);
 
-		this._readFile = this.fileSystem.readFile
-			? this.fileSystem.readFile.bind(this.fileSystem)
-			: null;
-		if (!this._readFile) this.readFile = /** @type {any} */ (null);
-
-		this._readFileSync = this.fileSystem.readFileSync
-			? this.fileSystem.readFileSync.bind(this.fileSystem)
-			: null;
-		if (!this._readFileSync) this.readFileSync = /** @type {any} */ (null);
-
-		if (this.fileSystem.readJson) {
-			this._readJson = this.fileSystem.readJson.bind(this.fileSystem);
-		} else if (this.readFile) {
-			this._readJson = (path, callback) => {
-				this.readFile(path, (err, buffer) => {
-					if (err) return callback(err);
-					let data;
-					try {
-						data = JSON.parse(buffer.toString("utf-8"));
-					} catch (e) {
-						return callback(e);
-					}
-					callback(null, data);
-				});
-			};
-		} else {
-			this.readJson = /** @type {any} */ (null);
-		}
-		if (this.fileSystem.readJsonSync) {
-			this._readJsonSync = this.fileSystem.readJsonSync.bind(this.fileSystem);
-		} else if (this.readFileSync) {
-			this._readJsonSync = path => {
-				const buffer = this.readFileSync(path);
-				const data = JSON.parse(buffer.toString("utf-8"));
-				return data;
-			};
-		} else {
-			this.readJsonSync = /** @type {any} */ (null);
-		}
-
-		this._readlink = this.fileSystem.readlink
-			? this.fileSystem.readlink.bind(this.fileSystem)
-			: null;
-		if (!this._readlink) this.readlink = /** @type {any} */ (null);
-
-		this._readlinkSync = this.fileSystem.readlinkSync
-			? this.fileSystem.readlinkSync.bind(this.fileSystem)
-			: null;
-		if (!this._readlinkSync) this.readlinkSync = /** @type {any} */ (null);
-	}
-
-	stat(path, callback) {
-		this._statStorage.provide(path, this._stat, callback);
-	}
-
-	readdir(path, callback) {
-		this._readdirStorage.provide(path, this._readdir, callback);
-	}
-
-	readFile(path, callback) {
-		this._readFileStorage.provide(path, this._readFile, callback);
-	}
-
-	readJson(path, callback) {
-		this._readJsonStorage.provide(path, this._readJson, callback);
-	}
-
-	readlink(path, callback) {
-		this._readlinkStorage.provide(path, this._readlink, callback);
-	}
-
-	statSync(path) {
-		return this._statStorage.provideSync(path, this._statSync);
-	}
-
-	readdirSync(path) {
-		return this._readdirStorage.provideSync(path, this._readdirSync);
-	}
-
-	readFileSync(path) {
-		return this._readFileStorage.provideSync(path, this._readFileSync);
-	}
-
-	readJsonSync(path) {
-		return this._readJsonStorage.provideSync(path, this._readJsonSync);
-	}
-
-	readlinkSync(path) {
-		return this._readlinkStorage.provideSync(path, this._readlinkSync);
+		this._readlinkBackend = createBackend(
+			duration,
+			this.fileSystem.readlink,
+			this.fileSystem.readlinkSync,
+			this.fileSystem
+		);
+		this.readlink = /** @type {FileSystem["readlink"]} */ (this._readlinkBackend.provide);
+		this.readlinkSync = /** @type {SyncFileSystem["readlinkSync"]} */ (this._readlinkBackend.provideSync);
 	}
 
 	purge(what) {
-		this._statStorage.purge(what);
-		this._readdirStorage.purgeParent(what);
-		this._readFileStorage.purge(what);
-		this._readlinkStorage.purge(what);
-		this._readJsonStorage.purge(what);
+		this._statBackend.purge(what);
+		this._readdirBackend.purgeParent(what);
+		this._readFileBackend.purge(what);
+		this._readlinkBackend.purge(what);
+		this._readJsonBackend.purge(what);
 	}
 };

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -23,6 +23,13 @@ const {
  */
 
 /**
+ * @typedef {Object} FileSystemDirent
+ * @property {Buffer | string} name
+ * @property {function(): boolean} isDirectory
+ * @property {function(): boolean} isFile
+ */
+
+/**
  * @typedef {Object} PossibleFileSystemError
  * @property {string=} code
  * @property {number=} errno
@@ -31,11 +38,28 @@ const {
  */
 
 /**
+ * @template T
+ * @callback FileSystemCallback
+ * @param {PossibleFileSystemError & Error | null | undefined} err
+ * @param {T=} result
+ */
+
+/**
  * @typedef {Object} FileSystem
- * @property {function(string, function(PossibleFileSystemError & Error | null | undefined, Buffer | string=): void): void} readFile
- * @property {(function(string, function(PossibleFileSystemError & Error | null | undefined, object=): void): void)=} readJson
- * @property {function(string, function(PossibleFileSystemError & Error | null | undefined, Buffer | string=): void): void} readlink
- * @property {function(string, function(PossibleFileSystemError & Error | null | undefined, FileSystemStats=): void): void} stat
+ * @property {(function(string, FileSystemCallback<Buffer | string>): void) & function(string, object, FileSystemCallback<Buffer | string>): void} readFile
+ * @property {(function(string, FileSystemCallback<(Buffer | string)[] | FileSystemDirent[]>): void) & function(string, object, FileSystemCallback<(Buffer | string)[] | FileSystemDirent[]>): void} readdir
+ * @property {((function(string, FileSystemCallback<object>): void) & function(string, object, FileSystemCallback<object>): void)=} readJson
+ * @property {(function(string, FileSystemCallback<Buffer | string>): void) & function(string, object, FileSystemCallback<Buffer | string>): void} readlink
+ * @property {(function(string, FileSystemCallback<FileSystemStats>): void) & function(string, object, FileSystemCallback<Buffer | string>): void} stat
+ */
+
+/**
+ * @typedef {Object} SyncFileSystem
+ * @property {function(string, object=): Buffer | string} readFileSync
+ * @property {function(string, object=): (Buffer | string)[] | FileSystemDirent[]} readdirSync
+ * @property {(function(string, object=): object)=} readJsonSync
+ * @property {function(string, object=): Buffer | string} readlinkSync
+ * @property {function(string, object=): FileSystemStats} statSync
  */
 
 /**

--- a/test/pr-53.js
+++ b/test/pr-53.js
@@ -12,6 +12,7 @@ describe("pr-53", function() {
 			},
 			1000
 		);
+		if (!cfs.readJsonSync) throw new Error("readJsonSync must be available");
 		cfs.readJsonSync("xyz").should.be.eql("abcxyz");
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2017",
     "module": "commonjs",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017"],
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
@@ -13,5 +13,5 @@
     "types": ["node", "mocha"],
     "esModuleInterop": true
   },
-  "include": ["lib/**/*.js", "test/*.js"]
+  "include": ["lib/**/*.js", "test/*.js", "declarations.d.ts"]
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -9,16 +9,41 @@ import { AsyncSeriesBailHook, AsyncSeriesHook, SyncHook } from "tapable";
 declare class CachedInputFileSystem {
 	constructor(fileSystem?: any, duration?: any);
 	fileSystem: any;
-	stat(path?: any, callback?: any): void;
-	statSync(path?: any): any;
-	readdir(path?: any, callback?: any): void;
-	readdirSync(path?: any): any;
-	readFile(path?: any, callback?: any): void;
-	readFileSync(path?: any): any;
-	readJson(path?: any, callback?: any): void;
-	readJsonSync(path?: any): any;
-	readlink(path?: any, callback?: any): void;
-	readlinkSync(path?: any): any;
+	stat: {
+		(arg0: string, arg1: FileSystemCallback<FileSystemStats>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<string | Buffer>): void;
+	};
+	statSync: (arg0: string, arg1?: any) => FileSystemStats;
+	readdir: {
+		(
+			arg0: string,
+			arg1: FileSystemCallback<(string | Buffer)[] | (FileSystemDirent)[]>
+		): void;
+		(
+			arg0: string,
+			arg1: any,
+			arg2: FileSystemCallback<(string | Buffer)[] | (FileSystemDirent)[]>
+		): void;
+	};
+	readdirSync: (
+		arg0: string,
+		arg1?: any
+	) => (string | Buffer)[] | (FileSystemDirent)[];
+	readFile: {
+		(arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<string | Buffer>): void;
+	};
+	readFileSync: (arg0: string, arg1?: any) => string | Buffer;
+	readJson?: {
+		(arg0: string, arg1: FileSystemCallback<any>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<any>): void;
+	};
+	readJsonSync?: (arg0: string, arg1?: any) => any;
+	readlink: {
+		(arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<string | Buffer>): void;
+	};
+	readlinkSync: (arg0: string, arg1?: any) => string | Buffer;
 	purge(what?: any): void;
 }
 declare class CloneBasenamePlugin {
@@ -28,36 +53,46 @@ declare class CloneBasenamePlugin {
 	apply(resolver: Resolver): void;
 }
 declare interface FileSystem {
-	readFile: (
-		arg0: string,
-		arg1: (
-			arg0: undefined | null | (PossibleFileSystemError & Error),
-			arg1: undefined | string | Buffer
-		) => void
-	) => void;
+	readFile: {
+		(arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<string | Buffer>): void;
+	};
+	readdir: {
+		(
+			arg0: string,
+			arg1: FileSystemCallback<(string | Buffer)[] | (FileSystemDirent)[]>
+		): void;
+		(
+			arg0: string,
+			arg1: any,
+			arg2: FileSystemCallback<(string | Buffer)[] | (FileSystemDirent)[]>
+		): void;
+	};
 	readJson?:
 		| undefined
-		| ((
-				arg0: string,
-				arg1: (
-					arg0: undefined | null | (PossibleFileSystemError & Error),
-					arg1?: any
-				) => void
-		  ) => void);
-	readlink: (
-		arg0: string,
-		arg1: (
-			arg0: undefined | null | (PossibleFileSystemError & Error),
-			arg1: undefined | string | Buffer
-		) => void
-	) => void;
-	stat: (
-		arg0: string,
-		arg1: (
-			arg0: undefined | null | (PossibleFileSystemError & Error),
-			arg1: undefined | FileSystemStats
-		) => void
-	) => void;
+		| {
+				(arg0: string, arg1: FileSystemCallback<any>): void;
+				(arg0: string, arg1: any, arg2: FileSystemCallback<any>): void;
+		  };
+	readlink: {
+		(arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<string | Buffer>): void;
+	};
+	stat: {
+		(arg0: string, arg1: FileSystemCallback<FileSystemStats>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<string | Buffer>): void;
+	};
+}
+declare interface FileSystemCallback<T> {
+	(
+		err: undefined | null | (PossibleFileSystemError & Error),
+		result?: undefined | T
+	): any;
+}
+declare interface FileSystemDirent {
+	name: string | Buffer;
+	isDirectory: () => boolean;
+	isFile: () => boolean;
 }
 declare interface FileSystemStats {
 	isDirectory: () => boolean;


### PR DESCRIPTION
add sync mode (when only using sync fs operations)
checks cache invalidation based on Date.now()
fixes #229

async mode is entered once an async fs operation is used
checks cache invalidation based on a timeout
after the timeout it falls back to the sync mode

add separate backend for zero duration without caching (only merges operations)

add support for optional options argument of filesystem operations (uncached)

update typings