### PR TITLE
resolve PnP at the location of node_modules in the modules option

### DIFF
--- a/lib/PnpPlugin.js
+++ b/lib/PnpPlugin.js
@@ -51,6 +51,19 @@ module.exports = class PnpPlugin {
 						});
 					}
 				} catch (error) {
+					if (
+						error.code === "MODULE_NOT_FOUND" &&
+						error.pnpCode === "UNDECLARED_DEPENDENCY"
+					) {
+						// This is not a PnP managed dependency.
+						// Try to continue resolving with our alternatives
+						if (resolveContext.log) {
+							resolveContext.log(`request is not managed by the pnpapi`);
+							for (const line of error.message.split("\n").filter(Boolean))
+								resolveContext.log(`  ${line}`);
+						}
+						return callback();
+					}
 					return callback(error);
 				}
 

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -375,15 +375,17 @@ exports.createResolver = function(options) {
 			new SelfReferencePlugin("raw-module", exportsField, "resolve-as-module")
 		);
 	});
-	if (pnpApi) {
-		plugins.push(new PnpPlugin("raw-module", pnpApi, "relative"));
-	}
 	modules.forEach(item => {
-		if (Array.isArray(item))
+		if (Array.isArray(item)) {
 			plugins.push(
 				new ModulesInHierachicDirectoriesPlugin("raw-module", item, "module")
 			);
-		else plugins.push(new ModulesInRootPlugin("raw-module", item, "module"));
+			if (item.includes("node_modules") && pnpApi) {
+				plugins.push(new PnpPlugin("raw-module", pnpApi, "relative"));
+			}
+		} else {
+			plugins.push(new ModulesInRootPlugin("raw-module", item, "module"));
+		}
 	});
 
 	// module

--- a/test/fixtures/pnp-a/m2/a.js
+++ b/test/fixtures/pnp-a/m2/a.js
@@ -1,0 +1,3 @@
+module.exports = function a() {
+	return "This is nested m1/a";
+};


### PR DESCRIPTION
fallback to other alternatives when PnP reports an undeclared dependency

fixes vercel/next.js#16892