### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ node_js:
   - "10"
 script: npm run travis
 
+arch:
+   - amd64
+   - ppc64le
+   
 after_success:
   - bash <(curl -s https://codecov.io/bash) -X gcov


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.