### PR TITLE
fix: process-browser.js

### DIFF
--- a/lib/util/process-browser.js
+++ b/lib/util/process-browser.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-exports.process = {
+moudle.exports = {
 	versions: {},
 	nextTick(fn) {
 		const args = Array.prototype.slice.call(arguments, 1);

--- a/lib/util/process-browser.js
+++ b/lib/util/process-browser.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-moudle.exports = {
+module.exports = {
 	versions: {},
 	nextTick(fn) {
 		const args = Array.prototype.slice.call(arguments, 1);


### PR DESCRIPTION
Fix browser bundling of the `process-browser.js` since it used as `require('process').versions` so the module itself is exported and not `process` as a key