### PR TITLE
feature: enforceExtension when extensions contain empty string

### DIFF
--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -190,7 +190,12 @@ function createOptions(options) {
 		descriptionFiles: Array.from(
 			new Set(options.descriptionFiles || ["package.json"])
 		),
-		enforceExtension: options.enforceExtension || false,
+		enforceExtension:
+			options.enforceExtension === undefined
+				? options.extensions && options.extensions.includes("")
+					? true
+					: false
+				: options.enforceExtension,
 		extensions: new Set(options.extensions || [".js", ".json", ".node"]),
 		fileSystem: options.useSyncFileSystemCalls
 			? new SyncAsyncFileSystemDecorator(

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -11,6 +11,17 @@ const resolver = ResolverFactory.createResolver({
 	fileSystem: nodeFileSystem
 });
 
+const resolver2 = ResolverFactory.createResolver({
+	extensions: [".ts", "", ".js"],
+	fileSystem: nodeFileSystem
+});
+
+const resolver3 = ResolverFactory.createResolver({
+	extensions: [".ts", "", ".js"],
+	enforceExtension: false,
+	fileSystem: nodeFileSystem
+});
+
 const fixture = path.resolve(__dirname, "fixtures", "extensions");
 
 describe("extensions", function () {
@@ -67,6 +78,20 @@ describe("extensions", function () {
 		resolver.resolve({}, fixture, "module.js/", {}, (err, result) => {
 			if (!err) throw new Error("No error");
 			err.should.be.instanceof(Error);
+			done();
+		});
+	});
+	it("should default enforceExtension to true when extensions includes an empty string", function (done) {
+		const missingDependencies = new Set();
+		resolver2.resolve({}, fixture, "./foo", { missingDependencies }, () => {
+			missingDependencies.should.not.containEql(fixture + "/foo");
+			done();
+		});
+	});
+	it("should respect enforceExtension when extensions includes an empty string", function (done) {
+		const missingDependencies = new Set();
+		resolver3.resolve({}, fixture, "./foo", { missingDependencies }, () => {
+			missingDependencies.should.containEql(fixture + "/foo");
 			done();
 		});
 	});

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -84,14 +84,14 @@ describe("extensions", function () {
 	it("should default enforceExtension to true when extensions includes an empty string", function (done) {
 		const missingDependencies = new Set();
 		resolver2.resolve({}, fixture, "./foo", { missingDependencies }, () => {
-			missingDependencies.should.not.containEql(fixture + "/foo");
+			missingDependencies.should.not.containEql(path.resolve(fixture, "foo"));
 			done();
 		});
 	});
 	it("should respect enforceExtension when extensions includes an empty string", function (done) {
 		const missingDependencies = new Set();
 		resolver3.resolve({}, fixture, "./foo", { missingDependencies }, () => {
-			missingDependencies.should.containEql(fixture + "/foo");
+			missingDependencies.should.containEql(path.resolve(fixture, "foo"));
 			done();
 		});
 	});


### PR DESCRIPTION
enforceExtension should default to true when extensions contain empty string

requested by @sokra to complement webpack pull request:
feat: accept empty string in config.resolve.extensions
https://github.com/webpack/webpack/pull/12613

- tests added
- no conflict with existing tests
- no conflict with webpack