### PR TITLE
Update ResolverFactory.js

### DIFF
--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -118,7 +118,7 @@ function processPnpApiOption(option) {
 		/** @type {NodeJS.ProcessVersions & {pnp: string}} */ versions.pnp
 	) {
 		// @ts-ignore
-		return require("pnpapi"); // eslint-disable-line node/no-missing-require
+		return require("./PnpPlugin").PnpApiImpl; // eslint-disable-line node/no-missing-require
 	}
 
 	return option || null;


### PR DESCRIPTION
Issue #263 is preventing my company from upgrading to Webpack v5. This was the proposed fix that worked well for us so I created a PR.