### PR TITLE
fix: give precedence to pnp over node_modules, close #288

### DIFF
--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -399,14 +399,14 @@ exports.createResolver = function (options) {
 	});
 	modules.forEach(item => {
 		if (Array.isArray(item)) {
-			plugins.push(
-				new ModulesInHierachicDirectoriesPlugin("raw-module", item, "module")
-			);
 			if (item.includes("node_modules") && pnpApi) {
 				plugins.push(
 					new PnpPlugin("raw-module", pnpApi, "undescribed-resolve-in-package")
 				);
 			}
+			plugins.push(
+				new ModulesInHierachicDirectoriesPlugin("raw-module", item, "module")
+			);
 		} else {
 			plugins.push(new ModulesInRootPlugin("raw-module", item, "module"));
 		}

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -401,12 +401,20 @@ exports.createResolver = function (options) {
 		if (Array.isArray(item)) {
 			if (item.includes("node_modules") && pnpApi) {
 				plugins.push(
+					new ModulesInHierachicDirectoriesPlugin(
+						"raw-module",
+						item.filter(i => i !== "node_modules"),
+						"module"
+					)
+				);
+				plugins.push(
 					new PnpPlugin("raw-module", pnpApi, "undescribed-resolve-in-package")
 				);
+			} else {
+				plugins.push(
+					new ModulesInHierachicDirectoriesPlugin("raw-module", item, "module")
+				);
 			}
-			plugins.push(
-				new ModulesInHierachicDirectoriesPlugin("raw-module", item, "module")
-			);
 		} else {
 			plugins.push(new ModulesInRootPlugin("raw-module", item, "module"));
 		}

--- a/test/pnp.js
+++ b/test/pnp.js
@@ -68,7 +68,11 @@ describe("pnp", () => {
 				alias: path.resolve(fixture, "pkg")
 			},
 			pnpApi,
-			modules: ["node_modules", path.resolve(fixture, "../pnp-a")]
+			modules: [
+				"alternative-modules",
+				"node_modules",
+				path.resolve(fixture, "../pnp-a")
+			]
 		});
 	});
 	it("should resolve by going through the pnp api", done => {
@@ -173,15 +177,35 @@ describe("pnp", () => {
 		);
 	});
 	it("should prefer pnp resolves over normal modules", done => {
-		pnpApi.mocks.set("m1", path.resolve(fixture, "pkg"));
+		pnpApi.mocks.set("m1", path.resolve(fixture, "../node_modules/m2"));
 		resolver.resolve(
 			{},
 			path.resolve(__dirname, "fixtures"),
-			"m1/a.js",
+			"m1/b.js",
 			{},
-			err => {
-				if (err) return done();
-				done(new Error("Resolved by normal modules"));
+			(err, result) => {
+				if (err) return done(err);
+				result.should.equal(path.resolve(fixture, "../node_modules/m2/b.js"));
+				done();
+			}
+		);
+	});
+	it("should prefer alternative module directories over pnp", done => {
+		pnpApi.mocks.set("m1", path.resolve(fixture, "../node_modules/m2"));
+		resolver.resolve(
+			{},
+			path.resolve(__dirname, "fixtures/prefer-pnp"),
+			"m1/b.js",
+			{},
+			(err, result) => {
+				if (err) return done(err);
+				result.should.equal(
+					path.resolve(
+						__dirname,
+						"fixtures/prefer-pnp/alternative-modules/m1/b.js"
+					)
+				);
+				done();
 			}
 		);
 	});

--- a/test/pnp.js
+++ b/test/pnp.js
@@ -172,17 +172,16 @@ describe("pnp", () => {
 			}
 		);
 	});
-	it("should prefer normal modules over pnp resolves", done => {
+	it("should prefer pnp resolves over normal modules", done => {
 		pnpApi.mocks.set("m1", path.resolve(fixture, "pkg"));
 		resolver.resolve(
 			{},
 			path.resolve(__dirname, "fixtures"),
 			"m1/a.js",
 			{},
-			(err, result) => {
-				if (err) return done(err);
-				result.should.equal(path.resolve(fixture, "../node_modules/m1/a.js"));
-				done();
+			err => {
+				if (err) return done();
+				done(new Error("Resolved by normal modules"));
 			}
 		);
 	});


### PR DESCRIPTION
Fixes https://github.com/webpack/enhanced-resolve/issues/288.

Ideally, node_modules should not even be considered if the pnp api is enabled, however it looks like that's intentional according to https://github.com/webpack/enhanced-resolve/issues/273