### PR TITLE
fix: find the `pnpapi` the `issuer` belongs to

### DIFF
--- a/lib/PnpPlugin.js
+++ b/lib/PnpPlugin.js
@@ -18,11 +18,13 @@ module.exports = class PnpPlugin {
 	 * @param {string | ResolveStepHook} source source
 	 * @param {PnpApiImpl} pnpApi pnpApi
 	 * @param {string | ResolveStepHook} target target
+	 * @param {string | ResolveStepHook} alternateTarget alternateTarget
 	 */
-	constructor(source, pnpApi, target) {
+	constructor(source, pnpApi, target, alternateTarget) {
 		this.source = source;
 		this.pnpApi = pnpApi;
 		this.target = target;
+		this.alternateTarget = alternateTarget;
 	}
 
 	/**
@@ -32,6 +34,7 @@ module.exports = class PnpPlugin {
 	apply(resolver) {
 		/** @type {ResolveStepHook} */
 		const target = resolver.ensureHook(this.target);
+		const alternateTarget = resolver.ensureHook(this.alternateTarget);
 		resolver
 			.getHook(this.source)
 			.tapAsync("PnpPlugin", (request, resolveContext, callback) => {
@@ -59,13 +62,19 @@ module.exports = class PnpPlugin {
 					if (resolution === null) {
 						// This is either not a PnP managed issuer or it's a Node builtin
 						// Try to continue resolving with our alternatives
-						if (resolveContext.log) {
-							resolveContext.log(`issuer is not managed by the pnpapi`);
-						}
-						// FIXME: In Webpack this stops the resolution at
-						// https://github.com/webpack/enhanced-resolve/blob/029d3e2ce802ef5181355bf64f14f6d0d819ed66/lib/ConditionalPlugin.js#L52-L53
-						// instead of continuing with the alternatives
-						return callback();
+						resolver.doResolve(
+							alternateTarget,
+							request,
+							"issuer is not managed by a pnpapi",
+							resolveContext,
+							(err, result) => {
+								if (err) return callback(err);
+								if (result) return callback(null, result);
+								// Skip alternatives
+								return callback(null, null);
+							}
+						);
+						return;
 					}
 
 					if (resolveContext.fileDependencies) {

--- a/lib/PnpPlugin.js
+++ b/lib/PnpPlugin.js
@@ -50,9 +50,9 @@ module.exports = class PnpPlugin {
 				const packageName = packageMatch[0];
 				const innerRequest = `.${req.slice(packageName.length)}`;
 
-				/** @type {string|undefined} */
+				/** @type {string|undefined|null} */
 				let resolution;
-				/** @type {string|undefined} */
+				/** @type {string|undefined|null} */
 				let apiResolution;
 				try {
 					resolution = this.pnpApi.resolveToUnqualified(packageName, issuer, {

--- a/lib/PnpPlugin.js
+++ b/lib/PnpPlugin.js
@@ -10,7 +10,7 @@
 /** @typedef {import("./Resolver").ResolveRequest} ResolveRequest */
 /**
  * @typedef {Object} PnpApiImpl
- * @property {function(string, string, object): string} resolveToUnqualified
+ * @property {function(string, string, object): string | null} resolveToUnqualified
  */
 
 module.exports = class PnpPlugin {
@@ -55,6 +55,19 @@ module.exports = class PnpPlugin {
 					resolution = this.pnpApi.resolveToUnqualified(packageName, issuer, {
 						considerBuiltins: false
 					});
+
+					if (resolution === null) {
+						// This is either not a PnP managed issuer or it's a Node builtin
+						// Try to continue resolving with our alternatives
+						if (resolveContext.log) {
+							resolveContext.log(`issuer is not managed by the pnpapi`);
+						}
+						// FIXME: In Webpack this stops the resolution at
+						// https://github.com/webpack/enhanced-resolve/blob/029d3e2ce802ef5181355bf64f14f6d0d819ed66/lib/ConditionalPlugin.js#L52-L53
+						// instead of continuing with the alternatives
+						return callback();
+					}
+
 					if (resolveContext.fileDependencies) {
 						apiResolution = this.pnpApi.resolveToUnqualified("pnpapi", issuer, {
 							considerBuiltins: false

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -469,7 +469,7 @@ exports.createResolver = function (options) {
 				);
 
 				plugins.push(
-					new ModulesInHierachicDirectoriesPlugin(
+					new ModulesInHierarchicalDirectoriesPlugin(
 						"alternate-raw-module",
 						["node_modules"],
 						"module"

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -126,7 +126,9 @@ function processPnpApiOption(option) {
 		option === undefined &&
 		/** @type {NodeJS.ProcessVersions & {pnp: string}} */ versions.pnp
 	) {
-		const _findPnpApi = /** @type {function(string): PnpApi | null}} */ (findPnpApi);
+		const _findPnpApi = /** @type {function(string): PnpApi | null}} */ (
+			findPnpApi
+		);
 		if (_findPnpApi) {
 			return {
 				resolveToUnqualified(request, issuer, opts) {

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -5,7 +5,6 @@
 
 "use strict";
 
-const findPnpApi = require("module").findPnpApi;
 const versions = require("process").versions;
 const Resolver = require("./Resolver");
 const { getType, PathType } = require("./util/path");
@@ -126,13 +125,18 @@ function processPnpApiOption(option) {
 		option === undefined &&
 		/** @type {NodeJS.ProcessVersions & {pnp: string}} */ versions.pnp
 	) {
-		const _findPnpApi = /** @type {function(string): PnpApi | null}} */ (
-			findPnpApi
-		);
+		const _findPnpApi =
+			/** @type {function(string): PnpApi | null}} */
+			(
+				// @ts-ignore
+				require("module").findPnpApi
+			);
+
 		if (_findPnpApi) {
 			return {
 				resolveToUnqualified(request, issuer, opts) {
 					const pnpapi = _findPnpApi(issuer);
+
 					if (!pnpapi) {
 						// Issuer isn't managed by PnP
 						return null;

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -318,6 +318,7 @@ exports.createResolver = function (options) {
 	resolver.ensureHook("normalResolve");
 	resolver.ensureHook("internal");
 	resolver.ensureHook("rawModule");
+	resolver.ensureHook("alternateRawModule");
 	resolver.ensureHook("module");
 	resolver.ensureHook("resolveAsModule");
 	resolver.ensureHook("undescribedResolveInPackage");
@@ -459,7 +460,20 @@ exports.createResolver = function (options) {
 					)
 				);
 				plugins.push(
-					new PnpPlugin("raw-module", pnpApi, "undescribed-resolve-in-package")
+					new PnpPlugin(
+						"raw-module",
+						pnpApi,
+						"undescribed-resolve-in-package",
+						"alternate-raw-module"
+					)
+				);
+
+				plugins.push(
+					new ModulesInHierachicDirectoriesPlugin(
+						"alternate-raw-module",
+						["node_modules"],
+						"module"
+					)
 				);
 			} else {
 				plugins.push(

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const versions = require("process").versions;
+const findPnpApi = require("module").findPnpApi;
 const Resolver = require("./Resolver");
 const { getType, PathType } = require("./util/path");
 
@@ -125,8 +126,20 @@ function processPnpApiOption(option) {
 		option === undefined &&
 		/** @type {NodeJS.ProcessVersions & {pnp: string}} */ versions.pnp
 	) {
-		// @ts-ignore
-		return require("pnpapi"); // eslint-disable-line node/no-missing-require
+		const _findPnpApi = /** @type {function(string): PnpApi | null}} */ (findPnpApi);
+		if (_findPnpApi) {
+			return {
+				resolveToUnqualified(request, issuer, opts) {
+					const pnpapi = _findPnpApi(issuer);
+					if (!pnpapi) {
+						// Issuer isn't managed by PnP
+						return null;
+					}
+
+					return pnpapi.resolveToUnqualified(request, issuer, opts);
+				}
+			};
+		}
 	}
 
 	return option || null;

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -5,8 +5,8 @@
 
 "use strict";
 
-const versions = require("process").versions;
 const findPnpApi = require("module").findPnpApi;
+const versions = require("process").versions;
 const Resolver = require("./Resolver");
 const { getType, PathType } = require("./util/path");
 

--- a/lib/util/module-browser.js
+++ b/lib/util/module-browser.js
@@ -1,0 +1,8 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "LICENSE"
   ],
   "browser": {
-    "pnpapi": false,
-    "process": "./lib/util/process-browser.js"
+    "process": "./lib/util/process-browser.js",
+    "module": "./lib/util/module-browser.js"
   },
   "dependencies": {
     "graceful-fs": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "enhanced-resolve",
   "version": "5.15.0",
-  "packageManager": "yarn@1.22.19",
   "author": "Tobias Koppers @sokra",
   "description": "Offers a async require.resolve function. It's highly configurable.",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "enhanced-resolve",
   "version": "5.15.0",
+  "packageManager": "yarn@1.22.19",
   "author": "Tobias Koppers @sokra",
   "description": "Offers a async require.resolve function. It's highly configurable.",
   "files": [

--- a/test/pnp.test.js
+++ b/test/pnp.test.js
@@ -264,7 +264,7 @@ describe("pnp", () => {
 			{},
 			(err, result) => {
 				if (err) return done(err);
-				result.should.equal(
+				expect(result).toEqual(
 					path.resolve(__dirname, "fixtures/node_modules/m2/b.js")
 				);
 				done();

--- a/test/pnp.test.js
+++ b/test/pnp.test.js
@@ -260,11 +260,13 @@ describe("pnp", () => {
 		resolver.resolve(
 			{},
 			path.resolve(__dirname, "fixtures"),
-			"m2/a.js",
+			"m2/b.js",
 			{},
 			(err, result) => {
 				if (err) return done(err);
-				result.should.equal(path.resolve(fixture, "../pnp-a/m2/a.js"));
+				result.should.equal(
+					path.resolve(__dirname, "fixtures/node_modules/m2/b.js")
+				);
 				done();
 			}
 		);

--- a/types.d.ts
+++ b/types.d.ts
@@ -289,7 +289,7 @@ type Plugin =
 	| { apply: (arg0: Resolver) => void }
 	| ((this: Resolver, arg1: Resolver) => void);
 declare interface PnpApiImpl {
-	resolveToUnqualified: (arg0: string, arg1: string, arg2: object) => string;
+	resolveToUnqualified: (arg0: string, arg1: string, arg2: object) => string | null;
 }
 declare interface PossibleFileSystemError {
 	code?: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -289,7 +289,11 @@ type Plugin =
 	| { apply: (arg0: Resolver) => void }
 	| ((this: Resolver, arg1: Resolver) => void);
 declare interface PnpApiImpl {
-	resolveToUnqualified: (arg0: string, arg1: string, arg2: object) => string | null;
+	resolveToUnqualified: (
+		arg0: string,
+		arg1: string,
+		arg2: object
+	) => null | string;
 }
 declare interface PossibleFileSystemError {
 	code?: string;


### PR DESCRIPTION
**What's the problem this PR addresses?**

- In some cases `enhanced-resolve` is outside the control of the `pnpapi` and can't require it
- The `issuer` might not belong to the same `pnpapi` as `enhanced-resolve`
- The `issuer` might not belong to a `pnpapi` at all and should use the `node_modules` resolution instead

Fixes https://github.com/arcanis/pnp-webpack-plugin/issues/32 for Webpack 5

**How did you fix it?**

Use `module.findPnpApi` to locate the correct `pnpapi` for the `issuer`, if a `pnpapi` isn't found continue the normal resolution