### PR TITLE
ci: use setup-node cache for Yarn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: yarn
       - run: yarn --frozen-lockfile
       - run: yarn lint
   test:
@@ -27,9 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - run: yarn --frozen-lockfile
       - run: yarn cover:ci
       - if: ${{ matrix.os != 'windows-latest' }}


### PR DESCRIPTION
Use the built-in action/cache for Yarn deps in CI