### PR TITLE
perf: utilize throwIfNoEntry in sync mode

### DIFF
--- a/lib/DirectoryExistsPlugin.js
+++ b/lib/DirectoryExistsPlugin.js
@@ -32,7 +32,7 @@ module.exports = class DirectoryExistsPlugin {
 					const fs = resolver.fileSystem;
 					const directory = request.path;
 					if (!directory) return callback();
-					fs.stat(directory, (err, stat) => {
+					fs.stat(directory, { throwIfNoEntry: false }, (err, stat) => {
 						if (err || !stat) {
 							if (resolveContext.missingDependencies)
 								resolveContext.missingDependencies.add(directory);

--- a/lib/FileExistsPlugin.js
+++ b/lib/FileExistsPlugin.js
@@ -30,7 +30,7 @@ module.exports = class FileExistsPlugin {
 			.tapAsync("FileExistsPlugin", (request, resolveContext, callback) => {
 				const file = request.path;
 				if (!file) return callback();
-				fs.stat(file, (err, stat) => {
+				fs.stat(file, { throwIfNoEntry: false }, (err, stat) => {
 					if (err || !stat) {
 						if (resolveContext.missingDependencies)
 							resolveContext.missingDependencies.add(file);

--- a/lib/ModulesInHierarchicalDirectoriesPlugin.js
+++ b/lib/ModulesInHierarchicalDirectoriesPlugin.js
@@ -46,7 +46,7 @@ module.exports = class ModulesInHierarchicalDirectoriesPlugin {
 					forEachBail(
 						addrs,
 						(addr, callback) => {
-							fs.stat(addr, (err, stat) => {
+							fs.stat(addr, { throwIfNoEntry: false }, (err, stat) => {
 								if (!err && stat && stat.isDirectory()) {
 									const obj = {
 										...request,

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -51,8 +51,8 @@ const {
  * @property {(function(string, FileSystemCallback<(Buffer | string)[] | FileSystemDirent[]>): void) & function(string, object, FileSystemCallback<(Buffer | string)[] | FileSystemDirent[]>): void} readdir
  * @property {((function(string, FileSystemCallback<object>): void) & function(string, object, FileSystemCallback<object>): void)=} readJson
  * @property {(function(string, FileSystemCallback<Buffer | string>): void) & function(string, object, FileSystemCallback<Buffer | string>): void} readlink
- * @property {(function(string, FileSystemCallback<FileSystemStats>): void) & function(string, object, FileSystemCallback<Buffer | string>): void=} lstat
- * @property {(function(string, FileSystemCallback<FileSystemStats>): void) & function(string, object, FileSystemCallback<Buffer | string>): void} stat
+ * @property {(function(string, FileSystemCallback<FileSystemStats>): void) & function(string, object, FileSystemCallback<FileSystemStats>): void=} lstat
+ * @property {(function(string, FileSystemCallback<FileSystemStats>): void) & function(string, object, FileSystemCallback<FileSystemStats>): void} stat
  */
 
 /**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "process": "./lib/util/process-browser.js"
   },
   "dependencies": {
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "tapable": "^2.2.0"
   },
   "license": "MIT",

--- a/types.d.ts
+++ b/types.d.ts
@@ -32,7 +32,7 @@ declare class CachedInputFileSystem {
 		(
 			arg0: string,
 			arg1: object,
-			arg2: FileSystemCallback<string | Buffer>
+			arg2: FileSystemCallback<FileSystemStats>
 		): void;
 	};
 	lstatSync?: (arg0: string, arg1?: object) => FileSystemStats;
@@ -41,7 +41,7 @@ declare class CachedInputFileSystem {
 		(
 			arg0: string,
 			arg1: object,
-			arg2: FileSystemCallback<string | Buffer>
+			arg2: FileSystemCallback<FileSystemStats>
 		): void;
 	};
 	statSync: (arg0: string, arg1?: object) => FileSystemStats;
@@ -135,7 +135,7 @@ declare interface FileSystem {
 		(
 			arg0: string,
 			arg1: object,
-			arg2: FileSystemCallback<string | Buffer>
+			arg2: FileSystemCallback<FileSystemStats>
 		): void;
 	};
 	stat: {
@@ -143,7 +143,7 @@ declare interface FileSystem {
 		(
 			arg0: string,
 			arg1: object,
-			arg2: FileSystemCallback<string | Buffer>
+			arg2: FileSystemCallback<FileSystemStats>
 		): void;
 	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,15 +1519,10 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-graceful-fs@^4.1.15, graceful-fs@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
-  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
-
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
-  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 growl@1.10.5:
   version "1.10.5"


### PR DESCRIPTION
Resolves https://github.com/webpack/enhanced-resolve/issues/316

Additionally fixing a few types and updating graceful-fs to support the new option. Thankfully, `stat` being null (vs throwing) is already being handled correctly.

cc @alexander-akait - graceful-fs has been updated now so this is unblocked