### PR TITLE
chore: add cSpell commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "special-lint-fix": "node node_modules/tooling/inherit-types --write && node node_modules/tooling/format-file-header --write && node node_modules/tooling/generate-types --write",
     "pretty": "prettier --loglevel warn --write \"lib/**/*.{js,json}\" \"test/*.js\"",
     "pretest": "yarn lint",
-    "spelling": "cspell \"**/*.*\"",
+    "spelling": "cspell \"**\"",
     "test:only": "jest",
     "test:watch": "yarn test:only -- --watch",
     "test:coverage": "yarn test:only -- --collectCoverageFrom=\"lib/**/*.js\" --coverage",
@@ -62,6 +62,7 @@
     "prepare": "husky install"
   },
   "lint-staged": {
+    "*": "cspell",
     "*.js": "eslint --cache"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*": "cspell",
+    "*": "cspell --no-must-find-files",
     "*.js": "eslint --cache"
   },
   "repository": {


### PR DESCRIPTION
Since it is now being run on all files, it can be run as part of the pre-commit hook to check locally