### PR TITLE
Fix argument name in error message

### DIFF
--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -263,7 +263,7 @@ class Resolver {
 		if (typeof path !== "string")
 			return callback(new Error("path argument is not a string"));
 		if (typeof request !== "string")
-			return callback(new Error("path argument is not a string"));
+			return callback(new Error("request argument is not a string"));
 		if (!resolveContext)
 			return callback(new Error("resolveContext argument is not set"));
 


### PR DESCRIPTION
The error message was referring to the `path` argument being not a string while it was the `request` argument being not a string.