### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/AliasPlugin.js
+++ b/lib/AliasPlugin.js
@@ -48,7 +48,7 @@ module.exports = class AliasPlugin {
 										: resolver.join(item.name, "_").slice(0, -1)
 								))
 						) {
-							const remainingRequest = innerRequest.substr(item.name.length);
+							const remainingRequest = innerRequest.slice(item.name.length);
 							const resolveWithAlias = (alias, callback) => {
 								if (alias === false) {
 									/** @type {ResolveRequest} */

--- a/lib/DescriptionFilePlugin.js
+++ b/lib/DescriptionFilePlugin.js
@@ -63,7 +63,7 @@ module.exports = class DescriptionFilePlugin {
 								return callback();
 							}
 							const relativePath =
-								"." + path.substr(result.directory.length).replace(/\\/g, "/");
+								"." + path.slice(result.directory.length).replace(/\\/g, "/");
 							const obj = {
 								...request,
 								descriptionFilePath: result.path,

--- a/lib/DescriptionFileUtils.js
+++ b/lib/DescriptionFileUtils.js
@@ -162,7 +162,7 @@ function cdUp(directory) {
 		j = directory.lastIndexOf("\\");
 	const p = i < 0 ? j : j < 0 ? i : i < j ? j : i;
 	if (p < 0) return null;
-	return directory.substr(0, p || 1);
+	return directory.slice(0, p || 1);
 }
 
 exports.loadDescriptionFile = loadDescriptionFile;

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -114,7 +114,7 @@ const {
  * @returns {string} in camel case
  */
 function toCamelCase(str) {
-	return str.replace(/-([a-z])/g, str => str.substr(1).toUpperCase());
+	return str.replace(/-([a-z])/g, str => str.slice(1).toUpperCase());
 }
 
 class Resolver {
@@ -170,14 +170,14 @@ class Resolver {
 		name = toCamelCase(name);
 		if (/^before/.test(name)) {
 			return /** @type {ResolveStepHook} */ (this.ensureHook(
-				name[6].toLowerCase() + name.substr(7)
+				name[6].toLowerCase() + name.slice(7)
 			).withOptions({
 				stage: -10
 			}));
 		}
 		if (/^after/.test(name)) {
 			return /** @type {ResolveStepHook} */ (this.ensureHook(
-				name[5].toLowerCase() + name.substr(6)
+				name[5].toLowerCase() + name.slice(6)
 			).withOptions({
 				stage: 10
 			}));
@@ -203,14 +203,14 @@ class Resolver {
 		name = toCamelCase(name);
 		if (/^before/.test(name)) {
 			return /** @type {ResolveStepHook} */ (this.getHook(
-				name[6].toLowerCase() + name.substr(7)
+				name[6].toLowerCase() + name.slice(7)
 			).withOptions({
 				stage: -10
 			}));
 		}
 		if (/^after/.test(name)) {
 			return /** @type {ResolveStepHook} */ (this.getHook(
-				name[5].toLowerCase() + name.substr(6)
+				name[5].toLowerCase() + name.slice(6)
 			).withOptions({
 				stage: 10
 			}));
@@ -465,7 +465,7 @@ class Resolver {
 			part.module = this.isModule(part.request);
 			part.directory = this.isDirectory(part.request);
 			if (part.directory) {
-				part.request = part.request.substr(0, part.request.length - 1);
+				part.request = part.request.slice(0, -1);
 			}
 		}
 

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -136,7 +136,7 @@ function normalizeAlias(alias) {
 
 				if (/\$$/.test(key)) {
 					obj.onlyModule = true;
-					obj.name = key.substr(0, key.length - 1);
+					obj.name = key.slice(0, -1);
 				}
 
 				return obj;

--- a/lib/getPaths.js
+++ b/lib/getPaths.js
@@ -11,12 +11,12 @@ module.exports = function getPaths(path) {
 	const paths = [path];
 	const segments = [parts[parts.length - 1]];
 	let part = parts[parts.length - 1];
-	path = path.substr(0, path.length - part.length - 1);
+	path = path.substring(0, path.length - part.length - 1);
 	for (let i = parts.length - 2; i > 2; i -= 2) {
 		paths.push(path);
 		part = parts[i];
-		path = path.substr(0, path.length - part.length) || "/";
-		segments.push(part.substr(0, part.length - 1));
+		path = path.substring(0, path.length - part.length) || "/";
+		segments.push(part.slice(0, -1));
 	}
 	part = parts[1];
 	segments.push(part);
@@ -32,6 +32,6 @@ module.exports.basename = function basename(path) {
 		j = path.lastIndexOf("\\");
 	const p = i < 0 ? j : j < 0 ? i : i < j ? j : i;
 	if (p < 0) return null;
-	const s = path.substr(p + 1);
+	const s = path.slice(p + 1);
 	return s;
 };

--- a/tooling/format-file-header.js
+++ b/tooling/format-file-header.js
@@ -149,7 +149,7 @@ for (const filePath of allFiles) {
 			const update = current.update(...match);
 			if (update !== match[0]) {
 				newContent =
-					newContent.substr(0, pos) +
+					newContent.slice(0, pos) +
 					update +
 					newContent.slice(pos + match[0].length);
 				pos += update.length;


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
