### PR TITLE
Fix `Cannot find module 'pnpapi'`

### DIFF
--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -117,8 +117,13 @@ function processPnpApiOption(option) {
 		option === undefined &&
 		/** @type {NodeJS.ProcessVersions & {pnp: string}} */ versions.pnp
 	) {
-		// @ts-ignore
-		return require("pnpapi"); // eslint-disable-line node/no-missing-require
+		try {
+			// @ts-ignore
+			return require("pnpapi"); // eslint-disable-line node/no-missing-require
+		} catch (e) {
+			// In some rare cases, versions.pnp might be set, but `pnpapi` might not resolve
+			return null;
+		}
 	}
 
 	return option || null;

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -117,13 +117,8 @@ function processPnpApiOption(option) {
 		option === undefined &&
 		/** @type {NodeJS.ProcessVersions & {pnp: string}} */ versions.pnp
 	) {
-		try {
-			// @ts-ignore
-			return require("pnpapi"); // eslint-disable-line node/no-missing-require
-		} catch (e) {
-			// In some rare cases, versions.pnp might be set, but `pnpapi` might not resolve
-			return null;
-		}
+		// @ts-ignore
+		return require("module").findPnpApi(process.cwd());
 	}
 
 	return option || null;


### PR DESCRIPTION
As discussed in https://github.com/webpack/enhanced-resolve/issues/263, there are some scenarios in which `pnpapi` is not currently resolvable (e.g. `Cannot find module 'pnpapi'`). This happens when using `jest` to execute tests that make use of `webpack`. Here is [an example stack trace](https://github.com/webpack/enhanced-resolve/issues/263#issuecomment-1061189768), and [here is a repo for reproduction](https://github.com/webpack/enhanced-resolve/issues/263#issuecomment-1079894555).

It's odd that `pnpapi` is not resolvable when the [Yarn documentation mentions that it should be resolvable if `process.versions.pnp` is set](https://yarnpkg.com/advanced/pnpapi#processversionspnp). ~I've tried various other ways of loading up `pnpapi` based on @arcanis' [comment here](https://github.com/yarnpkg/berry/issues/693#issuecomment-575389842) without any luck. For some reason, `require('module').pnpApiPath` is `undefined`.~ Actually, it _does_ work if you resort to `require("module").findPnpApi(process.cwd());`! I previously thought I'd tried that, but must have gotten something wrong when trying.