### PR TITLE
fix: improve typescript defs

### DIFF
--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -17,6 +17,10 @@ const {
 
 /** @typedef {import("./ResolverFactory").ResolveOptions} ResolveOptions */
 
+/** @typedef {Error & {details?: string}} ErrorWithDetail */
+
+/** @typedef {(err: ErrorWithDetail|null, res?: string|false, req?: ResolveRequest) => void} ResolveCallback */
+
 /**
  * @typedef {Object} FileSystemStats
  * @property {function(): boolean} isDirectory
@@ -254,7 +258,7 @@ class Resolver {
 	 * @param {string} path context path
 	 * @param {string} request request string
 	 * @param {ResolveContext} resolveContext resolve context
-	 * @param {function(Error | null, (string|false)=, ResolveRequest=): void} callback callback function
+	 * @param {ResolveCallback} callback callback function
 	 * @returns {void}
 	 */
 	resolve(context, path, request, resolveContext, callback) {
@@ -304,7 +308,7 @@ class Resolver {
 
 		const finishWithoutResolve = log => {
 			/**
-			 * @type {Error & {details?: string}}
+			 * @type {ErrorWithDetail}
 			 */
 			const error = new Error("Can't " + message);
 			error.details = log.join("\n");

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ const ResolverFactory = require("./ResolverFactory");
 /** @typedef {import("./PnpPlugin").PnpApiImpl} PnpApi */
 /** @typedef {import("./Resolver")} Resolver */
 /** @typedef {import("./Resolver").FileSystem} FileSystem */
+/** @typedef {import("./Resolver").ResolveCallback} ResolveCallback */
 /** @typedef {import("./Resolver").ResolveContext} ResolveContext */
 /** @typedef {import("./Resolver").ResolveRequest} ResolveRequest */
 /** @typedef {import("./ResolverFactory").Plugin} Plugin */
@@ -28,19 +29,42 @@ const asyncResolver = ResolverFactory.createResolver({
 	extensions: [".js", ".json", ".node"],
 	fileSystem: nodeFileSystem
 });
-function resolve(context, path, request, resolveContext, callback) {
-	if (typeof context === "string") {
-		callback = resolveContext;
-		resolveContext = request;
-		request = path;
-		path = context;
-		context = nodeContext;
-	}
-	if (typeof callback !== "function") {
-		callback = resolveContext;
-	}
-	asyncResolver.resolve(context, path, request, resolveContext, callback);
-}
+
+/**
+ * @type {{
+ * (context: object, path: string, request: string, resolveContext: ResolveContext, callback: ResolveCallback): void;
+ * (context: object, path: string, request: string, callback: ResolveCallback): void;
+ * (path: string, request: string, resolveContext: ResolveContext, callback: ResolveCallback): void;
+ * (path: string, request: string, callback: ResolveCallback): void;
+ * }}
+ */
+const resolve =
+	/**
+	 * @param {object|string} context
+	 * @param {string} path
+	 * @param {string|ResolveContext|ResolveCallback} request
+	 * @param {ResolveContext|ResolveCallback=} resolveContext
+	 * @param {ResolveCallback=} callback
+	 */
+	(context, path, request, resolveContext, callback) => {
+		if (typeof context === "string") {
+			callback = /** @type {ResolveCallback} */ (resolveContext);
+			resolveContext = /** @type {ResolveContext} */ (request);
+			request = path;
+			path = context;
+			context = nodeContext;
+		}
+		if (typeof callback !== "function") {
+			callback = /** @type {ResolveCallback} */ (resolveContext);
+		}
+		asyncResolver.resolve(
+			context,
+			path,
+			/** @type {string} */ (request),
+			/** @type {ResolveContext} */ (resolveContext),
+			/** @type {ResolveCallback} */ (callback)
+		);
+	};
 
 const syncResolver = ResolverFactory.createResolver({
 	conditionNames: ["node"],
@@ -48,21 +72,43 @@ const syncResolver = ResolverFactory.createResolver({
 	useSyncFileSystemCalls: true,
 	fileSystem: nodeFileSystem
 });
-function resolveSync(context, path, request) {
-	if (typeof context === "string") {
-		request = path;
-		path = context;
-		context = nodeContext;
-	}
-	return syncResolver.resolveSync(context, path, request);
-}
 
+/**
+ * @type {{
+ * (context: object, path: string, request: string): string|false;
+ * (path: string, request: string): string|false;
+ * }}
+ */
+const resolveSync =
+	/**
+	 * @param {object|string} context
+	 * @param {string} path
+	 * @param {string=} request
+	 */
+	(context, path, request) => {
+		if (typeof context === "string") {
+			request = path;
+			path = context;
+			context = nodeContext;
+		}
+		return syncResolver.resolveSync(
+			context,
+			path,
+			/** @type {string} */ (request)
+		);
+	};
+
+/** @typedef {Omit<ResolveOptions, "fileSystem"> & Partial<Pick<ResolveOptions, "fileSystem">>} ResolveOptionsOptionalFS */
+
+/**
+ * @param {ResolveOptionsOptionalFS} options Resolver options
+ * @returns {typeof resolve} Resolver function
+ */
 function create(options) {
-	options = {
+	const resolver = ResolverFactory.createResolver({
 		fileSystem: nodeFileSystem,
 		...options
-	};
-	const resolver = ResolverFactory.createResolver(options);
+	});
 	return function (context, path, request, resolveContext, callback) {
 		if (typeof context === "string") {
 			callback = resolveContext;
@@ -78,13 +124,19 @@ function create(options) {
 	};
 }
 
+/**
+ * @param {ResolveOptionsOptionalFS} options Resolver options
+ * @returns {{
+ *	(context: object, path: string, request: string): string|false;
+ *	(path: string, request: string): string|false;
+ * }} Resolver function
+ */
 function createSync(options) {
-	options = {
+	const resolver = ResolverFactory.createResolver({
 		useSyncFileSystemCalls: true,
 		fileSystem: nodeFileSystem,
 		...options
-	};
-	const resolver = ResolverFactory.createResolver(options);
+	});
 	return function (context, path, request) {
 		if (typeof context === "string") {
 			request = path;

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,18 @@ const ResolverFactory = require("./ResolverFactory");
 /** @typedef {import("./Resolver").ResolveRequest} ResolveRequest */
 /** @typedef {import("./ResolverFactory").Plugin} Plugin */
 /** @typedef {import("./ResolverFactory").UserResolveOptions} ResolveOptions */
+/** @typedef {{
+ * (context: object, path: string, request: string, resolveContext: ResolveContext, callback: ResolveCallback): void;
+ * (context: object, path: string, request: string, callback: ResolveCallback): void;
+ * (path: string, request: string, resolveContext: ResolveContext, callback: ResolveCallback): void;
+ * (path: string, request: string, callback: ResolveCallback): void;
+ * }} ResolveFunctionAsync
+ */
+/** @typedef {{
+ * (context: object, path: string, request: string): string|false;
+ * (path: string, request: string): string|false;
+ * }} ResolveFunction
+ */
 
 const nodeFileSystem = new CachedInputFileSystem(fs, 4000);
 
@@ -31,12 +43,7 @@ const asyncResolver = ResolverFactory.createResolver({
 });
 
 /**
- * @type {{
- * (context: object, path: string, request: string, resolveContext: ResolveContext, callback: ResolveCallback): void;
- * (context: object, path: string, request: string, callback: ResolveCallback): void;
- * (path: string, request: string, resolveContext: ResolveContext, callback: ResolveCallback): void;
- * (path: string, request: string, callback: ResolveCallback): void;
- * }}
+ * @type {ResolveFunctionAsync}
  */
 const resolve =
 	/**
@@ -74,10 +81,7 @@ const syncResolver = ResolverFactory.createResolver({
 });
 
 /**
- * @type {{
- * (context: object, path: string, request: string): string|false;
- * (path: string, request: string): string|false;
- * }}
+ * @type {ResolveFunction}
  */
 const resolveSync =
 	/**
@@ -102,34 +106,44 @@ const resolveSync =
 
 /**
  * @param {ResolveOptionsOptionalFS} options Resolver options
- * @returns {typeof resolve} Resolver function
+ * @returns {ResolveFunctionAsync} Resolver function
  */
 function create(options) {
 	const resolver = ResolverFactory.createResolver({
 		fileSystem: nodeFileSystem,
 		...options
 	});
+	/**
+	 * @param {object|string} context Custom context
+	 * @param {string} path Base path
+	 * @param {string|ResolveContext|ResolveCallback} request String to resolve
+	 * @param {ResolveContext|ResolveCallback=} resolveContext Resolve context
+	 * @param {ResolveCallback=} callback Result callback
+	 */
 	return function (context, path, request, resolveContext, callback) {
 		if (typeof context === "string") {
-			callback = resolveContext;
-			resolveContext = request;
+			callback = /** @type {ResolveCallback} */ (resolveContext);
+			resolveContext = /** @type {ResolveContext} */ (request);
 			request = path;
 			path = context;
 			context = nodeContext;
 		}
 		if (typeof callback !== "function") {
-			callback = resolveContext;
+			callback = /** @type {ResolveCallback} */ (resolveContext);
 		}
-		resolver.resolve(context, path, request, resolveContext, callback);
+		resolver.resolve(
+			context,
+			path,
+			/** @type {string} */ (request),
+			/** @type {ResolveContext} */ (resolveContext),
+			callback
+		);
 	};
 }
 
 /**
  * @param {ResolveOptionsOptionalFS} options Resolver options
- * @returns {{
- *	(context: object, path: string, request: string): string|false;
- *	(path: string, request: string): string|false;
- * }} Resolver function
+ * @returns {ResolveFunction} Resolver function
  */
 function createSync(options) {
 	const resolver = ResolverFactory.createResolver({

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -35,7 +35,7 @@ function testResolve(name, context, moduleName, result) {
 			resolve(context, moduleName, function (err, filename) {
 				if (err) return done(err);
 				should.exist(filename);
-				filename.should.equal(result);
+				/** @type {string} */ (filename).should.equal(result);
 				done();
 			});
 		});
@@ -48,7 +48,7 @@ function testResolveContext(name, context, moduleName, result) {
 			asyncContextResolve(context, moduleName, function (err, filename) {
 				if (err) done(err);
 				should.exist(filename);
-				filename.should.equal(result);
+				/** @type {string} */ (filename).should.equal(result);
 				done();
 			});
 		});
@@ -269,7 +269,7 @@ describe("resolve", function () {
 			function (err, filename) {
 				if (err) done(err);
 				should.exist(filename);
-				filename.should.equal(
+				/** @type {string} */ (filename).should.equal(
 					path.resolve(issue238, "./src/common/config/myObjectFile.js")
 				);
 				done();
@@ -281,7 +281,9 @@ describe("resolve", function () {
 		preferRelativeResolve(fixtures, "main1.js", function (err, filename) {
 			if (err) done(err);
 			should.exist(filename);
-			filename.should.equal(path.join(fixtures, "main1.js"));
+			/** @type {string} */ (filename).should.equal(
+				path.join(fixtures, "main1.js")
+			);
 			done();
 		});
 	});
@@ -290,29 +292,46 @@ describe("resolve", function () {
 		preferRelativeResolve(fixtures, "m1/a.js", function (err, filename) {
 			if (err) done(err);
 			should.exist(filename);
-			filename.should.equal(path.join(fixtures, "node_modules", "m1", "a.js"));
+			/** @type {string} */ (filename).should.equal(
+				path.join(fixtures, "node_modules", "m1", "a.js")
+			);
 			done();
 		});
 	});
 
 	it("should not crash when passing undefined as path", done => {
-		resolve(fixtures, undefined, err => {
-			err.should.be.instanceof(Error);
-			done();
-		});
+		resolve(
+			fixtures,
+			/** @type {string} */ (/** @type {unknown} */ (undefined)),
+			err => {
+				/** @type {Error} */ (err).should.be.instanceof(Error);
+				done();
+			}
+		);
 	});
 
 	it("should not crash when passing undefined as context", done => {
-		resolve({}, undefined, "./test/resolve.js", err => {
-			err.should.be.instanceof(Error);
-			done();
-		});
+		resolve(
+			{},
+			/** @type {string} */ (/** @type {unknown} */ (undefined)),
+			"./test/resolve.js",
+			err => {
+				/** @type {Error} */ (err).should.be.instanceof(Error);
+				done();
+			}
+		);
 	});
 
 	it("should not crash when passing undefined everywhere", done => {
-		resolve(undefined, undefined, undefined, undefined, err => {
-			err.should.be.instanceof(Error);
-			done();
-		});
+		resolve(
+			/** @type {object} */ (undefined),
+			/** @type {string} */ (/** @type {unknown} */ (undefined)),
+			/** @type {string} */ (/** @type {unknown} */ (undefined)),
+			/** @type {object} */ (/** @type {unknown} */ (undefined)),
+			err => {
+				/** @type {Error} */ (err).should.be.instanceof(Error);
+				done();
+			}
+		);
 	});
 });

--- a/test/simple.js
+++ b/test/simple.js
@@ -22,8 +22,10 @@ describe("simple", function () {
 						new Error([err.message, err.stack, err.details].join("\n"))
 					);
 				should.exist(filename);
-				filename.should.have.type("string");
-				filename.should.be.eql(path.join(__dirname, "..", "lib", "index.js"));
+				/** @type {string} */ (filename).should.have.type("string");
+				/** @type {string} */ (filename).should.be.eql(
+					path.join(__dirname, "..", "lib", "index.js")
+				);
 				done();
 			});
 		});

--- a/test/symlink.js
+++ b/test/symlink.js
@@ -214,15 +214,19 @@ describe("symlink", function () {
 				resolve(pathToIt[0], pathToIt[1], function (err, filename) {
 					if (err) return done(err);
 					should.exist(filename);
-					filename.should.have.type("string");
-					filename.should.be.eql(path.join(__dirname, "..", "lib", "index.js"));
+					/** @type {string} */ (filename).should.have.type("string");
+					/** @type {string} */ (filename).should.be.eql(
+						path.join(__dirname, "..", "lib", "index.js")
+					);
 					resolveWithoutSymlinks(pathToIt[0], pathToIt[1], function (
 						err,
 						filename
 					) {
 						if (err) return done(err);
-						filename.should.have.type("string");
-						filename.should.be.eql(path.resolve(pathToIt[0], pathToIt[1]));
+						/** @type {string} */ (filename).should.have.type("string");
+						/** @type {string} */ (filename).should.be.eql(
+							path.resolve(pathToIt[0], pathToIt[1])
+						);
 						done();
 					});
 				});

--- a/types.d.ts
+++ b/types.d.ts
@@ -91,6 +91,7 @@ declare class CloneBasenamePlugin {
 	target: any;
 	apply(resolver: Resolver): void;
 }
+type ErrorWithDetail = Error & { details?: string };
 declare interface ExtensionAliasOption {
 	alias: string | string[];
 	extension: string;
@@ -250,6 +251,8 @@ declare interface ResolveOptions {
 	preferRelative: boolean;
 	preferAbsolute: boolean;
 }
+type ResolveOptionsOptionalFS = Omit<UserResolveOptions, "fileSystem"> &
+	Partial<Pick<UserResolveOptions, "fileSystem">>;
 type ResolveRequest = BaseResolveRequest & Partial<ParsedIdentifier>;
 declare abstract class Resolver {
 	fileSystem: FileSystem;
@@ -300,9 +303,9 @@ declare abstract class Resolver {
 		request: string,
 		resolveContext: ResolveContext,
 		callback: (
-			arg0: null | Error,
-			arg1?: string | false,
-			arg2?: ResolveRequest
+			err: null | ErrorWithDetail,
+			res?: string | false,
+			req?: ResolveRequest
 		) => void
 	): void;
 	doResolve(
@@ -468,31 +471,101 @@ declare interface WriteOnlySet<T> {
 	add: (T?: any) => void;
 }
 declare function exports(
-	context?: any,
-	path?: any,
-	request?: any,
-	resolveContext?: any,
-	callback?: any
+	context: object,
+	path: string,
+	request: string,
+	resolveContext: ResolveContext,
+	callback: (
+		err: null | ErrorWithDetail,
+		res?: string | false,
+		req?: ResolveRequest
+	) => void
+): void;
+declare function exports(
+	context: object,
+	path: string,
+	request: string,
+	callback: (
+		err: null | ErrorWithDetail,
+		res?: string | false,
+		req?: ResolveRequest
+	) => void
+): void;
+declare function exports(
+	path: string,
+	request: string,
+	resolveContext: ResolveContext,
+	callback: (
+		err: null | ErrorWithDetail,
+		res?: string | false,
+		req?: ResolveRequest
+	) => void
+): void;
+declare function exports(
+	path: string,
+	request: string,
+	callback: (
+		err: null | ErrorWithDetail,
+		res?: string | false,
+		req?: ResolveRequest
+	) => void
 ): void;
 declare namespace exports {
-	export const sync: (
-		context?: any,
-		path?: any,
-		request?: any
-	) => string | false;
+	export const sync: {
+		(context: object, path: string, request: string): string | false;
+		(path: string, request: string): string | false;
+	};
 	export function create(
-		options?: any
-	): (
-		context?: any,
-		path?: any,
-		request?: any,
-		resolveContext?: any,
-		callback?: any
-	) => void;
+		options: ResolveOptionsOptionalFS
+	): {
+		(
+			context: object,
+			path: string,
+			request: string,
+			resolveContext: ResolveContext,
+			callback: (
+				err: null | ErrorWithDetail,
+				res?: string | false,
+				req?: ResolveRequest
+			) => void
+		): void;
+		(
+			context: object,
+			path: string,
+			request: string,
+			callback: (
+				err: null | ErrorWithDetail,
+				res?: string | false,
+				req?: ResolveRequest
+			) => void
+		): void;
+		(
+			path: string,
+			request: string,
+			resolveContext: ResolveContext,
+			callback: (
+				err: null | ErrorWithDetail,
+				res?: string | false,
+				req?: ResolveRequest
+			) => void
+		): void;
+		(
+			path: string,
+			request: string,
+			callback: (
+				err: null | ErrorWithDetail,
+				res?: string | false,
+				req?: ResolveRequest
+			) => void
+		): void;
+	};
 	export namespace create {
 		export const sync: (
-			options?: any
-		) => (context?: any, path?: any, request?: any) => string | false;
+			options: ResolveOptionsOptionalFS
+		) => {
+			(context: object, path: string, request: string): string | false;
+			(path: string, request: string): string | false;
+		};
 	}
 	export namespace ResolverFactory {
 		export let createResolver: (options: UserResolveOptions) => Resolver;
@@ -502,10 +575,16 @@ declare namespace exports {
 		iterator?: any,
 		callback?: any
 	) => any;
+	export type ResolveCallback = (
+		err: null | ErrorWithDetail,
+		res?: string | false,
+		req?: ResolveRequest
+	) => void;
 	export {
 		CachedInputFileSystem,
 		CloneBasenamePlugin,
 		LogInfoPlugin,
+		ResolveOptionsOptionalFS,
 		PnpApiImpl as PnpApi,
 		Resolver,
 		FileSystem,

--- a/types.d.ts
+++ b/types.d.ts
@@ -218,6 +218,52 @@ declare interface ResolveContext {
 	 */
 	yield?: (arg0: ResolveRequest) => void;
 }
+declare interface ResolveFunction {
+	(context: object, path: string, request: string): string | false;
+	(path: string, request: string): string | false;
+}
+declare interface ResolveFunctionAsync {
+	(
+		context: object,
+		path: string,
+		request: string,
+		resolveContext: ResolveContext,
+		callback: (
+			err: null | ErrorWithDetail,
+			res?: string | false,
+			req?: ResolveRequest
+		) => void
+	): void;
+	(
+		context: object,
+		path: string,
+		request: string,
+		callback: (
+			err: null | ErrorWithDetail,
+			res?: string | false,
+			req?: ResolveRequest
+		) => void
+	): void;
+	(
+		path: string,
+		request: string,
+		resolveContext: ResolveContext,
+		callback: (
+			err: null | ErrorWithDetail,
+			res?: string | false,
+			req?: ResolveRequest
+		) => void
+	): void;
+	(
+		path: string,
+		request: string,
+		callback: (
+			err: null | ErrorWithDetail,
+			res?: string | false,
+			req?: ResolveRequest
+		) => void
+	): void;
+}
 declare interface ResolveOptions {
 	alias: AliasOption[];
 	fallback: AliasOption[];
@@ -511,61 +557,12 @@ declare function exports(
 	) => void
 ): void;
 declare namespace exports {
-	export const sync: {
-		(context: object, path: string, request: string): string | false;
-		(path: string, request: string): string | false;
-	};
+	export const sync: ResolveFunction;
 	export function create(
 		options: ResolveOptionsOptionalFS
-	): {
-		(
-			context: object,
-			path: string,
-			request: string,
-			resolveContext: ResolveContext,
-			callback: (
-				err: null | ErrorWithDetail,
-				res?: string | false,
-				req?: ResolveRequest
-			) => void
-		): void;
-		(
-			context: object,
-			path: string,
-			request: string,
-			callback: (
-				err: null | ErrorWithDetail,
-				res?: string | false,
-				req?: ResolveRequest
-			) => void
-		): void;
-		(
-			path: string,
-			request: string,
-			resolveContext: ResolveContext,
-			callback: (
-				err: null | ErrorWithDetail,
-				res?: string | false,
-				req?: ResolveRequest
-			) => void
-		): void;
-		(
-			path: string,
-			request: string,
-			callback: (
-				err: null | ErrorWithDetail,
-				res?: string | false,
-				req?: ResolveRequest
-			) => void
-		): void;
-	};
+	): ResolveFunctionAsync;
 	export namespace create {
-		export const sync: (
-			options: ResolveOptionsOptionalFS
-		) => {
-			(context: object, path: string, request: string): string | false;
-			(path: string, request: string): string | false;
-		};
+		export const sync: (options: ResolveOptionsOptionalFS) => ResolveFunction;
 	}
 	export namespace ResolverFactory {
 		export let createResolver: (options: UserResolveOptions) => Resolver;
@@ -591,7 +588,9 @@ declare namespace exports {
 		ResolveContext,
 		ResolveRequest,
 		Plugin,
-		UserResolveOptions as ResolveOptions
+		UserResolveOptions as ResolveOptions,
+		ResolveFunctionAsync,
+		ResolveFunction
 	};
 }
 


### PR DESCRIPTION
fixes #356 

i need some help with the overloads here i think.

you can see the strong types now mean a bunch of tests need to cast things too... im not sure there's a clean way to type the callback function strongly and not have to do those casts. the compiler is right: the result could be undefined if there's an error.