### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ const myResolver = ResolverFactory.createResolver({
 
 // resolve a file with the new resolver
 const context = {};
-const resolveContext = {};
 const lookupStartPath = "/Users/webpack/some/root/dir";
 const request = "./path/to-look-up.js";
-myResolver.resolve({}, lookupStartPath, request, resolveContext, (
+const resolveContext = {};
+myResolver.resolve(context, lookupStartPath, request, resolveContext, (
 	err /*Error*/,
 	filepath /*string*/
 ) => {


### PR DESCRIPTION
1. `context` is declared but not used. It probably should be passed to `myResolver.resolve`.
2. Sort the declarations based on `myResolver.resolve`'s arguments.