### PR TITLE
chore: update `checkout`, `setup-node`, and `codecov` github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
           cache: yarn
@@ -26,13 +26,13 @@ jobs:
         node-version: [10.x, 12.x, 14.x, 16.x, 17.x]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
       - run: yarn --frozen-lockfile
       - run: yarn cover:ci
       - if: ${{ matrix.os != 'windows-latest' }}
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Update GitHub actions to use latest versions