### PR TITLE
Reduce memory footprint of storing fs erros in cache

### DIFF
--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -368,6 +368,19 @@ class CacheBackend {
 	 */
 	_storeResult(path, err, result) {
 		if (this._data.has(path)) return;
+
+		if (err) {
+			// Clone error object to be stored in cache to allow for the original
+			// error, and its internal representation to be picked up by GC. Thus
+			// reducing the memory footprint of caching such results in memory.
+			// Also, omitting expensive calculation of the stacktrace as it gets
+			// ignored most of the time anyway
+			const lightErrorProps = Object.getOwnPropertyDescriptors(err);
+			delete lightErrorProps.stack;
+
+			err = Object.create(Object.getPrototypeOf(err), lightErrorProps);
+		}
+
 		const level = this._levels[this._currentLevel];
 		this._data.set(path, { err, result, level });
 		level.add(path);


### PR DESCRIPTION
We are using `enhanced-resolve` together with `jest` test runner, and noticed substantial memory leaks using this combo. Further inspection revealed that original FS errors are retaining references to sandbox environments that jest creates to keep individual tests isolated from one another. These references occur in the internal representation of the `Error` object for lazy-computation of the `stack` property later in the process (when user code happens to read from it for the first time). 

Cloning the original error allows GC to collect that stack trace information and all retained objects that in turn helps to resolve the memory leak, and reduce the memory usage. One drawback to this is that the `stack` property would have to be computed eagerly, which comes at a cost of consuming more CPU. But since it's rarely required, and gets messed up due caching aspect of it anyway - a trade off has to be made to omit stack traces from the fs errors altogether. 