### PR TITLE
Revert "Revert "perf: utilize throwIfNoEntry in sync mode""

### DIFF
--- a/lib/DirectoryExistsPlugin.js
+++ b/lib/DirectoryExistsPlugin.js
@@ -32,7 +32,7 @@ module.exports = class DirectoryExistsPlugin {
 					const fs = resolver.fileSystem;
 					const directory = request.path;
 					if (!directory) return callback();
-					fs.stat(directory, (err, stat) => {
+					fs.stat(directory, { throwIfNoEntry: false }, (err, stat) => {
 						if (err || !stat) {
 							if (resolveContext.missingDependencies)
 								resolveContext.missingDependencies.add(directory);

--- a/lib/FileExistsPlugin.js
+++ b/lib/FileExistsPlugin.js
@@ -30,7 +30,7 @@ module.exports = class FileExistsPlugin {
 			.tapAsync("FileExistsPlugin", (request, resolveContext, callback) => {
 				const file = request.path;
 				if (!file) return callback();
-				fs.stat(file, (err, stat) => {
+				fs.stat(file, { throwIfNoEntry: false }, (err, stat) => {
 					if (err || !stat) {
 						if (resolveContext.missingDependencies)
 							resolveContext.missingDependencies.add(file);

--- a/lib/ModulesInHierarchicalDirectoriesPlugin.js
+++ b/lib/ModulesInHierarchicalDirectoriesPlugin.js
@@ -52,7 +52,7 @@ module.exports = class ModulesInHierarchicalDirectoriesPlugin {
 						 * @returns {void}
 						 */
 						(addr, callback) => {
-							fs.stat(addr, (err, stat) => {
+							fs.stat(addr, { throwIfNoEntry: false }, (err, stat) => {
 								if (!err && stat && stat.isDirectory()) {
 									/** @type {ResolveRequest} */
 									const obj = {

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -63,8 +63,8 @@ const {
  * @property {function(string, (ReaddirOptions | BufferEncoding | null | undefined | 'buffer' | DirentArrayCallback)=,  DirentArrayCallback=): void} readdir
  * @property {((function(string, FileSystemCallback<object>): void) & function(string, object, FileSystemCallback<object>): void)=} readJson
  * @property {(function(string, FileSystemCallback<Buffer | string>): void) & function(string, object, FileSystemCallback<Buffer | string>): void} readlink
- * @property {(function(string, FileSystemCallback<FileSystemStats>): void) & function(string, object, FileSystemCallback<Buffer | string>): void=} lstat
- * @property {(function(string, FileSystemCallback<FileSystemStats>): void) & function(string, object, FileSystemCallback<Buffer | string>): void} stat
+ * @property {(function(string, FileSystemCallback<FileSystemStats>): void) & function(string, object, FileSystemCallback<FileSystemStats>): void=} lstat
+ * @property {(function(string, FileSystemCallback<FileSystemStats>): void) & function(string, object, FileSystemCallback<FileSystemStats>): void} stat
  */
 
 /**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "process": "./lib/util/process-browser.js"
   },
   "dependencies": {
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "tapable": "^2.2.0"
   },
   "license": "MIT",

--- a/types.d.ts
+++ b/types.d.ts
@@ -38,7 +38,7 @@ declare class CachedInputFileSystem {
 		(
 			arg0: string,
 			arg1: object,
-			arg2: FileSystemCallback<string | Buffer>
+			arg2: FileSystemCallback<FileSystemStats>
 		): void;
 	};
 	lstatSync?: (arg0: string, arg1?: object) => FileSystemStats;
@@ -47,7 +47,7 @@ declare class CachedInputFileSystem {
 		(
 			arg0: string,
 			arg1: object,
-			arg2: FileSystemCallback<string | Buffer>
+			arg2: FileSystemCallback<FileSystemStats>
 		): void;
 	};
 	statSync: (arg0: string, arg1?: object) => FileSystemStats;
@@ -195,7 +195,7 @@ declare interface FileSystem {
 		(
 			arg0: string,
 			arg1: object,
-			arg2: FileSystemCallback<string | Buffer>
+			arg2: FileSystemCallback<FileSystemStats>
 		): void;
 	};
 	stat: {
@@ -203,7 +203,7 @@ declare interface FileSystem {
 		(
 			arg0: string,
 			arg1: object,
-			arg2: FileSystemCallback<string | Buffer>
+			arg2: FileSystemCallback<FileSystemStats>
 		): void;
 	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,10 +2052,10 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
-  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 has-flag@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Bringing https://github.com/webpack/enhanced-resolve/pull/324 back to life. Since performance improvements seem to be worth it. Perhaps this time it'd be better to cut a major release to prevent sudden breakages for folks who don't utilize lock files? 

These changes broke storybook last time around: https://github.com/webpack/enhanced-resolve/issues/362