### PR TITLE
fix: use cache for exports and imports plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 21.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            if ('${{ matrix.os }}' === 'macos-latest' && '${{ matrix['node-version'] }}' === '10.x') {
+            if ('${{ matrix.os }}' === 'macos-latest' && ('${{ matrix['node-version'] }}' === '10.x' || '${{ matrix['node-version'] }}' === '12.x' || '${{ matrix['node-version'] }}' === '14.x')) {
               return "x64"
             } else {
               return ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        id: calculate_architecture
+        with:
+          result-encoding: string
+          script: |
+            if ('${{ matrix.os }}' === 'macos-latest' && '${{ matrix['node-version'] }}' === '10.x') {
+              return "x64"
+            } else {
+              return ''
+            }
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          architecture: ${{ steps.calculate_architecture.outputs.result }}
           cache: yarn
       - name: Install dependencies
         run: |

--- a/lib/ExportsFieldPlugin.js
+++ b/lib/ExportsFieldPlugin.js
@@ -5,7 +5,6 @@
 
 "use strict";
 
-const path = require("path");
 const DescriptionFileUtils = require("./DescriptionFileUtils");
 const forEachBail = require("./forEachBail");
 const { processExportsField } = require("./util/entrypoints");
@@ -137,7 +136,7 @@ module.exports = class ExportsFieldPlugin {
 						const obj = {
 							...request,
 							request: undefined,
-							path: path.join(
+							path: resolver.join(
 								/** @type {string} */ (request.descriptionFileRoot),
 								relativePath
 							),

--- a/lib/ImportsFieldPlugin.js
+++ b/lib/ImportsFieldPlugin.js
@@ -5,7 +5,6 @@
 
 "use strict";
 
-const path = require("path");
 const DescriptionFileUtils = require("./DescriptionFileUtils");
 const forEachBail = require("./forEachBail");
 const { processImportsField } = require("./util/entrypoints");
@@ -143,7 +142,7 @@ module.exports = class ImportsFieldPlugin {
 								const obj = {
 									...request,
 									request: undefined,
-									path: path.join(
+									path: resolver.join(
 										/** @type {string} */ (request.descriptionFileRoot),
 										path_
 									),


### PR DESCRIPTION
/cc @vankop Do you know why we use `path` here instead our cachable version?

We can improve perf just using it