### PR TITLE
feat: allow default condition to be anywhere

### DIFF
--- a/lib/util/entrypoints.js
+++ b/lib/util/entrypoints.js
@@ -464,17 +464,11 @@ function conditionalMapping(conditionalMapping_, conditionNames) {
 
 	loop: while (lookup.length > 0) {
 		const [mapping, conditions, j] = lookup[lookup.length - 1];
-		const last = conditions.length - 1;
 
 		for (let i = j; i < conditions.length; i++) {
 			const condition = conditions[i];
 
-			// assert default. Could be last only
-			if (i !== last) {
-				if (condition === "default") {
-					throw new Error("Default condition should be last one");
-				}
-			} else if (condition === "default") {
+			if (condition === "default") {
 				const innerMapping = mapping[condition];
 				// is nested
 				if (isConditionalMapping(innerMapping)) {

--- a/test/exportsField.test.js
+++ b/test/exportsField.test.js
@@ -543,7 +543,7 @@ describe("Process exports field", function exportsField() {
 		},
 		{
 			name: "Direct mapping #7",
-			expect: new Error(), // Default is first one
+			expect: ["./src/index.js"], // Default is first one
 			suite: [
 				{
 					".": {

--- a/test/importsField.test.js
+++ b/test/importsField.test.js
@@ -451,7 +451,7 @@ describe("Process imports field", function exportsField() {
 		},
 		{
 			name: "Direct mapping #7",
-			expect: new Error(), // Default is first one
+			expect: ["./src/index.js"], // Default is first one
 			suite: [
 				{
 					"#a": {
@@ -1309,7 +1309,6 @@ describe("ImportsFieldPlugin", () => {
 				fs.rmdirSync(dir);
 				if (err) return done(err);
 				if (!result) return done(new Error("No result"));
-				console.log(result);
 				expect(result).toEqual(file);
 				done();
 			});


### PR DESCRIPTION
### Description
This aligns the "default" condition behaviour with Node.Js. Specifically, this allows the "default" condition to be found anywhere in the "exports" without throwing an error.

### Related Issues:
- https://github.com/webpack/enhanced-resolve/issues/421
- https://github.com/eslint-community/eslint-plugin-n/issues/242
- https://github.com/oxc-project/oxc-resolver/issues/160

---

fixes #421 