### PR TITLE
Avoid creating a new array inside doResolve.

### DIFF
--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -692,7 +692,11 @@ class Resolver {
 			}
 			newStack.add(stackEntry);
 		} else {
-			newStack = new Set([stackEntry]);
+			// creating a set with new Set([item])
+			// allocates a new array that has to be garbage collected
+			// this is an EXTREMELY hot path, so let's avoid it
+			newStack = new Set();
+			newStack.add(stackEntry);
 		}
 		this.hooks.resolveStep.call(hook, request);
 


### PR DESCRIPTION
This is a minor optimization that avoids allocating immediately dereferenced arrays when creating a new stack inside `doResolve`. In the build that I'm testing against, this is called >750k times, which means that we're allocating ~32mb of array data to the heap that's then spent in GC.

It's hard to find optimizations in webpack's codebase, but from my debugging we're spending more time in GC than in any other function.

Here's a jsperf comparing these two ways of creating a one item set:
https://jsperf.app/vureri 

And a screenshot of the output for me:
<img width="979" alt="image" src="https://github.com/user-attachments/assets/36d4d6bc-f347-4232-a6be-e0aaccdf9345">
