### PR TITLE
feat: parseIdentifier fast path for requests without \0

### DIFF
--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -7,19 +7,61 @@
 
 const PATH_QUERY_FRAGMENT_REGEXP =
 	/^(#?(?:\0.|[^?#\0])*)(\?(?:\0.|[^#\0])*)?(#.*)?$/;
+const ZERO_ESCAPE_REGEXP = /\0(.)/g;
 
 /**
  * @param {string} identifier identifier
  * @returns {[string, string, string]|null} parsed identifier
  */
 function parseIdentifier(identifier) {
+	if (!identifier) {
+		return null;
+	}
+
+	const firstEscape = identifier.indexOf("\0");
+	if (firstEscape < 0) {
+		// Fast path for inputs that don't use \0 escaping.
+		const queryStart = identifier.indexOf("?");
+		// Start at index 1 to ignore a possible leading hash.
+		const fragmentStart = identifier.indexOf("#", 1);
+
+		if (fragmentStart < 0) {
+			if (queryStart < 0) {
+				// No fragment, no query
+				return [identifier, "", ""];
+			}
+			// Query, no fragment
+			return [
+				identifier.slice(0, queryStart),
+				identifier.slice(queryStart),
+				""
+			];
+		}
+
+		if (queryStart < 0 || fragmentStart < queryStart) {
+			// Fragment, no query
+			return [
+				identifier.slice(0, fragmentStart),
+				"",
+				identifier.slice(fragmentStart)
+			];
+		}
+
+		// Query and fragment
+		return [
+			identifier.slice(0, queryStart),
+			identifier.slice(queryStart, fragmentStart),
+			identifier.slice(fragmentStart)
+		];
+	}
+
 	const match = PATH_QUERY_FRAGMENT_REGEXP.exec(identifier);
 
 	if (!match) return null;
 
 	return [
-		match[1].replace(/\0(.)/g, "$1"),
-		match[2] ? match[2].replace(/\0(.)/g, "$1") : "",
+		match[1].replace(ZERO_ESCAPE_REGEXP, "$1"),
+		match[2] ? match[2].replace(ZERO_ESCAPE_REGEXP, "$1") : "",
 		match[3] || ""
 	];
 }

--- a/test/identifier.test.js
+++ b/test/identifier.test.js
@@ -53,6 +53,10 @@ describe("parse identifier. edge cases", () => {
 		{
 			input: "path/#/not/a/hash?not-a-query",
 			expected: ["path/", "", "#/not/a/hash?not-a-query"]
+		},
+		{
+			input: "#\0?\0#ab\0\0c?\0#\0\0query#?#\0fragment",
+			expected: ["#?#ab\0c", "?#\0query", "#?#\0fragment"]
 		}
 	];
 


### PR DESCRIPTION
Adds a fast path to `parseIdentifier` that avoids the overhead of regex processing when the input does not contain a null character. Improves performance of `parseIdentifier` by ~75% for typical usage on NodeJS 18.19.1.

Before:
![image](https://github.com/user-attachments/assets/eb7ad940-1f67-43d0-ba28-f723fa4d90e4)

After:
![image](https://github.com/user-attachments/assets/03c8998b-3b2e-40ad-ba75-b30cd2d63acf)

Adds additional unit tests to `parseIdentifier` for NULL-escaped strings.
