### PR TITLE
feat: monomorphic ResolveRequest object

### DIFF
--- a/lib/AliasFieldPlugin.js
+++ b/lib/AliasFieldPlugin.js
@@ -68,8 +68,25 @@ module.exports = class AliasFieldPlugin {
 				if (data === false) {
 					/** @type {ResolveRequest} */
 					const ignoreObj = {
-						...request,
-						path: false
+						path: false,
+						context: request.context,
+						descriptionFilePath: request.descriptionFilePath,
+						descriptionFileRoot: request.descriptionFileRoot,
+						descriptionFileData: request.descriptionFileData,
+						relativePath: request.relativePath,
+						ignoreSymlinks: request.ignoreSymlinks,
+						fullySpecified: request.fullySpecified,
+						__innerRequest: request.__innerRequest,
+						__innerRequest_request: request.__innerRequest_request,
+						__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+						request: request.request,
+						query: request.query,
+						fragment: request.fragment,
+						module: request.module,
+						directory: request.directory,
+						file: request.file,
+						internal: request.internal
 					};
 					if (typeof resolveContext.yield === "function") {
 						resolveContext.yield(ignoreObj);
@@ -79,10 +96,25 @@ module.exports = class AliasFieldPlugin {
 				}
 				/** @type {ResolveRequest} */
 				const obj = {
-					...request,
 					path: /** @type {string} */ (request.descriptionFileRoot),
+					context: request.context,
+					descriptionFilePath: request.descriptionFilePath,
+					descriptionFileRoot: request.descriptionFileRoot,
+					descriptionFileData: request.descriptionFileData,
+					relativePath: request.relativePath,
+					ignoreSymlinks: request.ignoreSymlinks,
+					fullySpecified: false,
+					__innerRequest: request.__innerRequest,
+					__innerRequest_request: request.__innerRequest_request,
+					__innerRequest_relativePath: request.__innerRequest_relativePath,
+
 					request: /** @type {string} */ (data),
-					fullySpecified: false
+					query: request.query,
+					fragment: request.fragment,
+					module: request.module,
+					directory: request.directory,
+					file: request.file,
+					internal: request.internal
 				};
 				resolver.doResolve(
 					target,

--- a/lib/AliasPlugin.js
+++ b/lib/AliasPlugin.js
@@ -124,9 +124,26 @@ module.exports = class AliasPlugin {
 									shouldStop = true;
 									/** @type {ResolveRequest} */
 									const obj = {
-										...request,
+										path: request.path,
+										context: request.context,
+										descriptionFilePath: request.descriptionFilePath,
+										descriptionFileRoot: request.descriptionFileRoot,
+										descriptionFileData: request.descriptionFileData,
+										relativePath: request.relativePath,
+										ignoreSymlinks: request.ignoreSymlinks,
+										fullySpecified: false,
+										__innerRequest: request.__innerRequest,
+										__innerRequest_request: request.__innerRequest_request,
+										__innerRequest_relativePath:
+											request.__innerRequest_relativePath,
+
 										request: newRequestStr,
-										fullySpecified: false
+										query: request.query,
+										fragment: request.fragment,
+										module: request.module,
+										directory: request.directory,
+										file: request.file,
+										internal: request.internal
 									};
 									return resolver.doResolve(
 										target,

--- a/lib/AliasPlugin.js
+++ b/lib/AliasPlugin.js
@@ -85,8 +85,26 @@ module.exports = class AliasPlugin {
 								if (alias === false) {
 									/** @type {ResolveRequest} */
 									const ignoreObj = {
-										...request,
-										path: false
+										path: false,
+										context: request.context,
+										descriptionFilePath: request.descriptionFilePath,
+										descriptionFileRoot: request.descriptionFileRoot,
+										descriptionFileData: request.descriptionFileData,
+										relativePath: request.relativePath,
+										ignoreSymlinks: request.ignoreSymlinks,
+										fullySpecified: request.fullySpecified,
+										__innerRequest: request.__innerRequest,
+										__innerRequest_request: request.__innerRequest_request,
+										__innerRequest_relativePath:
+											request.__innerRequest_relativePath,
+
+										request: request.request,
+										query: request.query,
+										fragment: request.fragment,
+										module: request.module,
+										directory: request.directory,
+										file: request.file,
+										internal: request.internal
 									};
 									if (typeof resolveContext.yield === "function") {
 										resolveContext.yield(ignoreObj);

--- a/lib/AppendPlugin.js
+++ b/lib/AppendPlugin.js
@@ -32,10 +32,26 @@ module.exports = class AppendPlugin {
 			.tapAsync("AppendPlugin", (request, resolveContext, callback) => {
 				/** @type {ResolveRequest} */
 				const obj = {
-					...request,
 					path: request.path + this.appending,
+					context: request.context,
+					descriptionFilePath: request.descriptionFilePath,
+					descriptionFileRoot: request.descriptionFileRoot,
+					descriptionFileData: request.descriptionFileData,
 					relativePath:
-						request.relativePath && request.relativePath + this.appending
+						request.relativePath && request.relativePath + this.appending,
+					ignoreSymlinks: request.ignoreSymlinks,
+					fullySpecified: request.fullySpecified,
+					__innerRequest: request.__innerRequest,
+					__innerRequest_request: request.__innerRequest_request,
+					__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+					request: request.request,
+					query: request.query,
+					fragment: request.fragment,
+					module: request.module,
+					directory: request.directory,
+					file: request.file,
+					internal: request.internal
 				};
 				resolver.doResolve(
 					target,

--- a/lib/CloneBasenamePlugin.js
+++ b/lib/CloneBasenamePlugin.js
@@ -35,11 +35,27 @@ module.exports = class CloneBasenamePlugin {
 				const filePath = resolver.join(requestPath, filename);
 				/** @type {ResolveRequest} */
 				const obj = {
-					...request,
 					path: filePath,
+					context: request.context,
+					descriptionFilePath: request.descriptionFilePath,
+					descriptionFileRoot: request.descriptionFileRoot,
+					descriptionFileData: request.descriptionFileData,
 					relativePath:
 						request.relativePath &&
-						resolver.join(request.relativePath, filename)
+						resolver.join(request.relativePath, filename),
+					ignoreSymlinks: request.ignoreSymlinks,
+					fullySpecified: request.fullySpecified,
+					__innerRequest: request.__innerRequest,
+					__innerRequest_request: request.__innerRequest_request,
+					__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+					request: request.request,
+					query: request.query,
+					fragment: request.fragment,
+					module: request.module,
+					directory: request.directory,
+					file: request.file,
+					internal: request.internal
 				};
 				resolver.doResolve(
 					target,

--- a/lib/DescriptionFilePlugin.js
+++ b/lib/DescriptionFilePlugin.js
@@ -67,11 +67,26 @@ module.exports = class DescriptionFilePlugin {
 								"." + path.slice(result.directory.length).replace(/\\/g, "/");
 							/** @type {ResolveRequest} */
 							const obj = {
-								...request,
+								path: request.path,
+								context: request.context,
 								descriptionFilePath: result.path,
-								descriptionFileData: result.content,
 								descriptionFileRoot: result.directory,
-								relativePath: relativePath
+								descriptionFileData: result.content,
+								relativePath,
+								ignoreSymlinks: request.ignoreSymlinks,
+								fullySpecified: request.fullySpecified,
+								__innerRequest: request.__innerRequest,
+								__innerRequest_request: request.__innerRequest_request,
+								__innerRequest_relativePath:
+									request.__innerRequest_relativePath,
+
+								request: request.request,
+								query: request.query,
+								fragment: request.fragment,
+								module: request.module,
+								directory: request.directory,
+								file: request.file,
+								internal: request.internal
 							};
 							resolver.doResolve(
 								target,

--- a/lib/ExportsFieldPlugin.js
+++ b/lib/ExportsFieldPlugin.js
@@ -164,15 +164,28 @@ module.exports = class ExportsFieldPlugin {
 
 						/** @type {ResolveRequest} */
 						const obj = {
-							...request,
-							request: undefined,
 							path: resolver.join(
 								/** @type {string} */ (request.descriptionFileRoot),
 								relativePath
 							),
+							context: request.context,
+							descriptionFilePath: request.descriptionFilePath,
+							descriptionFileRoot: request.descriptionFileRoot,
+							descriptionFileData: request.descriptionFileData,
 							relativePath,
+							ignoreSymlinks: request.ignoreSymlinks,
+							fullySpecified: request.fullySpecified,
+							__innerRequest: request.__innerRequest,
+							__innerRequest_request: request.__innerRequest_request,
+							__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+							request: undefined,
 							query,
-							fragment
+							fragment,
+							module: request.module,
+							directory: request.directory,
+							file: request.file,
+							internal: request.internal
 						};
 
 						resolver.doResolve(

--- a/lib/ExtensionAliasPlugin.js
+++ b/lib/ExtensionAliasPlugin.js
@@ -52,9 +52,25 @@ module.exports = class ExtensionAliasPlugin {
 					return resolver.doResolve(
 						target,
 						{
-							...request,
+							path: request.path,
+							context: request.context,
+							descriptionFilePath: request.descriptionFilePath,
+							descriptionFileRoot: request.descriptionFileRoot,
+							descriptionFileData: request.descriptionFileData,
+							relativePath: request.relativePath,
+							ignoreSymlinks: request.ignoreSymlinks,
+							fullySpecified: true,
+							__innerRequest: request.__innerRequest,
+							__innerRequest_request: request.__innerRequest_request,
+							__innerRequest_relativePath: request.__innerRequest_relativePath,
+
 							request: newRequest,
-							fullySpecified: true
+							query: request.query,
+							fragment: request.fragment,
+							module: request.module,
+							directory: request.directory,
+							file: request.file,
+							internal: request.internal
 						},
 						`aliased from extension alias with mapping '${extension}' to '${alias}'`,
 						resolveContext,

--- a/lib/ImportsFieldPlugin.js
+++ b/lib/ImportsFieldPlugin.js
@@ -158,15 +158,29 @@ module.exports = class ImportsFieldPlugin {
 
 								/** @type {ResolveRequest} */
 								const obj = {
-									...request,
-									request: undefined,
 									path: resolver.join(
 										/** @type {string} */ (request.descriptionFileRoot),
 										path_
 									),
+									context: request.context,
+									descriptionFilePath: request.descriptionFilePath,
+									descriptionFileRoot: request.descriptionFileRoot,
+									descriptionFileData: request.descriptionFileData,
 									relativePath: path_,
+									ignoreSymlinks: request.ignoreSymlinks,
+									fullySpecified: request.fullySpecified,
+									__innerRequest: request.__innerRequest,
+									__innerRequest_request: request.__innerRequest_request,
+									__innerRequest_relativePath:
+										request.__innerRequest_relativePath,
+
+									request: undefined,
 									query,
-									fragment
+									fragment,
+									module: request.module,
+									directory: request.directory,
+									file: request.file,
+									internal: request.internal
 								};
 
 								resolver.doResolve(

--- a/lib/JoinRequestPartPlugin.js
+++ b/lib/JoinRequestPartPlugin.js
@@ -56,17 +56,31 @@ module.exports = class JoinRequestPartPlugin {
 					}
 					/** @type {ResolveRequest} */
 					const obj = {
-						...request,
 						path: resolver.join(
 							/** @type {string} */
 							(request.path),
 							moduleName
 						),
+						context: request.context,
+						descriptionFilePath: request.descriptionFilePath,
+						descriptionFileRoot: request.descriptionFileRoot,
+						descriptionFileData: request.descriptionFileData,
 						relativePath:
 							request.relativePath &&
 							resolver.join(request.relativePath, moduleName),
+						ignoreSymlinks: request.ignoreSymlinks,
+						fullySpecified,
+						__innerRequest: request.__innerRequest,
+						__innerRequest_request: request.__innerRequest_request,
+						__innerRequest_relativePath: request.__innerRequest_relativePath,
+
 						request: remainingRequest,
-						fullySpecified
+						query: request.query,
+						fragment: request.fragment,
+						module: request.module,
+						directory: request.directory,
+						file: request.file,
+						internal: request.internal
 					};
 					resolver.doResolve(target, obj, null, resolveContext, callback);
 				}

--- a/lib/JoinRequestPlugin.js
+++ b/lib/JoinRequestPlugin.js
@@ -32,12 +32,27 @@ module.exports = class JoinRequestPlugin {
 				const requestRequest = /** @type {string} */ (request.request);
 				/** @type {ResolveRequest} */
 				const obj = {
-					...request,
 					path: resolver.join(requestPath, requestRequest),
+					context: request.context,
+					descriptionFilePath: request.descriptionFilePath,
+					descriptionFileRoot: request.descriptionFileRoot,
+					descriptionFileData: request.descriptionFileData,
 					relativePath:
 						request.relativePath &&
 						resolver.join(request.relativePath, requestRequest),
-					request: undefined
+					ignoreSymlinks: request.ignoreSymlinks,
+					fullySpecified: request.fullySpecified,
+					__innerRequest: request.__innerRequest,
+					__innerRequest_request: request.__innerRequest_request,
+					__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+					request: undefined,
+					query: request.query,
+					fragment: request.fragment,
+					module: request.module,
+					directory: request.directory,
+					file: request.file,
+					internal: request.internal
 				};
 				resolver.doResolve(target, obj, null, resolveContext, callback);
 			});

--- a/lib/MainFieldPlugin.js
+++ b/lib/MainFieldPlugin.js
@@ -15,8 +15,6 @@ const DescriptionFileUtils = require("./DescriptionFileUtils");
 
 /** @typedef {{name: string|Array<string>, forceRelative: boolean}} MainFieldOptions */
 
-const alreadyTriedMainField = Symbol("alreadyTriedMainField");
-
 module.exports = class MainFieldPlugin {
 	/**
 	 * @param {string | ResolveStepHook} source source
@@ -40,9 +38,8 @@ module.exports = class MainFieldPlugin {
 			.tapAsync("MainFieldPlugin", (request, resolveContext, callback) => {
 				if (
 					request.path !== request.descriptionFileRoot ||
-					/** @type {ResolveRequest & { [alreadyTriedMainField]?: string }} */
-					(request)[alreadyTriedMainField] === request.descriptionFilePath ||
-					!request.descriptionFilePath
+					!request.descriptionFilePath ||
+					!request.descriptionFileData
 				)
 					return callback();
 				const filename = path.basename(request.descriptionFilePath);
@@ -50,7 +47,7 @@ module.exports = class MainFieldPlugin {
 					/** @type {string|null|undefined} */
 					(
 						DescriptionFileUtils.getField(
-							/** @type {JsonObject} */ (request.descriptionFileData),
+							request.descriptionFileData,
 							this.options.name
 						)
 					);
@@ -65,13 +62,27 @@ module.exports = class MainFieldPlugin {
 				}
 				if (this.options.forceRelative && !/^\.\.?\//.test(mainModule))
 					mainModule = "./" + mainModule;
-				/** @type {ResolveRequest & { [alreadyTriedMainField]?: string }} */
+				/** @type {ResolveRequest} */
 				const obj = {
-					...request,
+					path: request.path,
+					context: request.context,
+					descriptionFilePath: request.descriptionFilePath,
+					descriptionFileRoot: request.descriptionFileRoot,
+					descriptionFileData: request.descriptionFileData,
+					relativePath: request.relativePath,
+					ignoreSymlinks: request.ignoreSymlinks,
+					fullySpecified: request.fullySpecified,
+					__innerRequest: request.__innerRequest,
+					__innerRequest_request: request.__innerRequest_request,
+					__innerRequest_relativePath: request.__innerRequest_relativePath,
+
 					request: mainModule,
+					query: request.query,
+					fragment: request.fragment,
 					module: false,
 					directory: mainModule.endsWith("/"),
-					[alreadyTriedMainField]: request.descriptionFilePath
+					file: request.file,
+					internal: request.internal
 				};
 				return resolver.doResolve(
 					target,

--- a/lib/MainFieldPlugin.js
+++ b/lib/MainFieldPlugin.js
@@ -33,13 +33,17 @@ module.exports = class MainFieldPlugin {
 	 */
 	apply(resolver) {
 		const target = resolver.ensureHook(this.target);
+		/** @type {WeakSet<JsonObject>} */
+		const failedMainFields = new WeakSet();
 		resolver
 			.getHook(this.source)
 			.tapAsync("MainFieldPlugin", (request, resolveContext, callback) => {
+				const { descriptionFileData } = request;
 				if (
 					request.path !== request.descriptionFileRoot ||
 					!request.descriptionFilePath ||
-					!request.descriptionFileData
+					!descriptionFileData ||
+					failedMainFields.has(descriptionFileData)
 				)
 					return callback();
 				const filename = path.basename(request.descriptionFilePath);
@@ -47,7 +51,7 @@ module.exports = class MainFieldPlugin {
 					/** @type {string|null|undefined} */
 					(
 						DescriptionFileUtils.getField(
-							request.descriptionFileData,
+							descriptionFileData,
 							this.options.name
 						)
 					);
@@ -68,7 +72,7 @@ module.exports = class MainFieldPlugin {
 					context: request.context,
 					descriptionFilePath: request.descriptionFilePath,
 					descriptionFileRoot: request.descriptionFileRoot,
-					descriptionFileData: request.descriptionFileData,
+					descriptionFileData: descriptionFileData,
 					relativePath: request.relativePath,
 					ignoreSymlinks: request.ignoreSymlinks,
 					fullySpecified: request.fullySpecified,
@@ -94,7 +98,12 @@ module.exports = class MainFieldPlugin {
 						" in " +
 						filename,
 					resolveContext,
-					callback
+					(err, result) => {
+						if (err) return callback(err);
+						if (result) return callback(null, result);
+						failedMainFields.add(descriptionFileData);
+						callback();
+					}
 				);
 			});
 	}

--- a/lib/ModulesInHierarchicalDirectoriesPlugin.js
+++ b/lib/ModulesInHierarchicalDirectoriesPlugin.js
@@ -56,10 +56,26 @@ module.exports = class ModulesInHierarchicalDirectoriesPlugin {
 								if (!err && stat && stat.isDirectory()) {
 									/** @type {ResolveRequest} */
 									const obj = {
-										...request,
 										path: addr,
+										context: request.context,
+										descriptionFilePath: request.descriptionFilePath,
+										descriptionFileRoot: request.descriptionFileRoot,
+										descriptionFileData: request.descriptionFileData,
+										relativePath: request.relativePath,
+										ignoreSymlinks: request.ignoreSymlinks,
+										fullySpecified: request.fullySpecified,
+										__innerRequest: request.__innerRequest,
+										__innerRequest_request: request.__innerRequest_request,
+										__innerRequest_relativePath:
+											request.__innerRequest_relativePath,
+
 										request: "./" + request.request,
-										module: false
+										query: request.query,
+										fragment: request.fragment,
+										module: false,
+										directory: request.directory,
+										file: request.file,
+										internal: request.internal
 									};
 									const message = "looking for modules in " + addr;
 									return resolver.doResolve(

--- a/lib/ModulesInRootPlugin.js
+++ b/lib/ModulesInRootPlugin.js
@@ -32,10 +32,25 @@ module.exports = class ModulesInRootPlugin {
 			.tapAsync("ModulesInRootPlugin", (request, resolveContext, callback) => {
 				/** @type {ResolveRequest} */
 				const obj = {
-					...request,
 					path: this.path,
+					context: request.context,
+					descriptionFilePath: request.descriptionFilePath,
+					descriptionFileRoot: request.descriptionFileRoot,
+					descriptionFileData: request.descriptionFileData,
+					relativePath: request.relativePath,
+					ignoreSymlinks: request.ignoreSymlinks,
+					fullySpecified: request.fullySpecified,
+					__innerRequest: request.__innerRequest,
+					__innerRequest_request: request.__innerRequest_request,
+					__innerRequest_relativePath: request.__innerRequest_relativePath,
+
 					request: "./" + request.request,
-					module: false
+					query: request.query,
+					fragment: request.fragment,
+					module: false,
+					directory: request.directory,
+					file: request.file,
+					internal: request.internal
 				};
 				resolver.doResolve(
 					target,

--- a/lib/ParsePlugin.js
+++ b/lib/ParsePlugin.js
@@ -12,12 +12,12 @@
 module.exports = class ParsePlugin {
 	/**
 	 * @param {string | ResolveStepHook} source source
-	 * @param {Partial<ResolveRequest>} requestOptions request options
+	 * @param {boolean | undefined} fullySpecified override value for request.fullySpecified
 	 * @param {string | ResolveStepHook} target target
 	 */
-	constructor(source, requestOptions, target) {
+	constructor(source, fullySpecified, target) {
 		this.source = source;
-		this.requestOptions = requestOptions;
+		this.fullySpecified = fullySpecified;
 		this.target = target;
 	}
 
@@ -31,14 +31,34 @@ module.exports = class ParsePlugin {
 			.getHook(this.source)
 			.tapAsync("ParsePlugin", (request, resolveContext, callback) => {
 				const parsed = resolver.parse(/** @type {string} */ (request.request));
+				// Using an object literal here with properties in a predictable order, in testing
+				// improves performance of this function by 90%.
+				// Note that this means that custom properties must be part of `request.context`.
 				/** @type {ResolveRequest} */
-				const obj = { ...request, ...parsed, ...this.requestOptions };
-				if (request.query && !parsed.query) {
-					obj.query = request.query;
-				}
-				if (request.fragment && !parsed.fragment) {
-					obj.fragment = request.fragment;
-				}
+				const obj = {
+					path: request.path,
+					context: request.context,
+					descriptionFilePath: request.descriptionFilePath,
+					descriptionFileRoot: request.descriptionFileRoot,
+					descriptionFileData: request.descriptionFileData,
+					relativePath: request.relativePath,
+					ignoreSymlinks: request.ignoreSymlinks,
+					fullySpecified: this.fullySpecified,
+					__innerRequest: request.__innerRequest,
+					__innerRequest_request: request.__innerRequest_request,
+					__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+					request: parsed.request,
+					// If parsed.query and request.query are both falsy, prefer parsed.query
+					query: parsed.query || request.query || parsed.query,
+					// If parsed.fragment and request.fragment are both falsy, prefer parsed.fragment
+					fragment: parsed.fragment || request.fragment || parsed.fragment,
+					module: parsed.module,
+					directory: parsed.directory,
+					file: parsed.file,
+					internal: parsed.internal
+				};
+
 				if (parsed && resolveContext.log) {
 					if (parsed.module) resolveContext.log("Parsed request is a module");
 					if (parsed.directory)

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -349,9 +349,9 @@ exports.createResolver = function (options) {
 	resolver.hooks.newInteralResolve = resolver.hooks.newInternalResolve;
 
 	// resolve
-	for (const { source, resolveOptions } of [
-		{ source: "resolve", resolveOptions: { fullySpecified } },
-		{ source: "internal-resolve", resolveOptions: { fullySpecified: false } }
+	for (const { source, fullySpecified: overrideFullySpecified } of [
+		{ source: "resolve", fullySpecified },
+		{ source: "internal-resolve", fullySpecified: false }
 	]) {
 		if (unsafeCache) {
 			plugins.push(
@@ -364,10 +364,16 @@ exports.createResolver = function (options) {
 				)
 			);
 			plugins.push(
-				new ParsePlugin(`new-${source}`, resolveOptions, "parsed-resolve")
+				new ParsePlugin(
+					`new-${source}`,
+					overrideFullySpecified,
+					"parsed-resolve"
+				)
 			);
 		} else {
-			plugins.push(new ParsePlugin(source, resolveOptions, "parsed-resolve"));
+			plugins.push(
+				new ParsePlugin(source, overrideFullySpecified, "parsed-resolve")
+			);
 		}
 	}
 

--- a/lib/ResultPlugin.js
+++ b/lib/ResultPlugin.js
@@ -24,7 +24,27 @@ module.exports = class ResultPlugin {
 		this.source.tapAsync(
 			"ResultPlugin",
 			(request, resolverContext, callback) => {
-				const obj = { ...request };
+				const obj = {
+					path: request.path,
+					context: request.context,
+					descriptionFilePath: request.descriptionFilePath,
+					descriptionFileRoot: request.descriptionFileRoot,
+					descriptionFileData: request.descriptionFileData,
+					relativePath: request.relativePath,
+					ignoreSymlinks: request.ignoreSymlinks,
+					fullySpecified: request.fullySpecified,
+					__innerRequest: request.__innerRequest,
+					__innerRequest_request: request.__innerRequest_request,
+					__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+					request: request.request,
+					query: request.query,
+					fragment: request.fragment,
+					module: request.module,
+					directory: request.directory,
+					file: request.file,
+					internal: request.internal
+				};
 				if (resolverContext.log)
 					resolverContext.log("reporting result " + obj.path);
 				resolver.hooks.result.callAsync(obj, resolverContext, err => {

--- a/lib/RootsPlugin.js
+++ b/lib/RootsPlugin.js
@@ -48,9 +48,25 @@ class RootsPlugin {
 						const path = resolver.join(root, req.slice(1));
 						/** @type {ResolveRequest} */
 						const obj = {
-							...request,
 							path,
-							relativePath: request.relativePath && path
+							context: request.context,
+							descriptionFilePath: request.descriptionFilePath,
+							descriptionFileRoot: request.descriptionFileRoot,
+							descriptionFileData: request.descriptionFileData,
+							relativePath: request.relativePath && path,
+							ignoreSymlinks: request.ignoreSymlinks,
+							fullySpecified: request.fullySpecified,
+							__innerRequest: request.__innerRequest,
+							__innerRequest_request: request.__innerRequest_request,
+							__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+							request: request.request,
+							query: request.query,
+							fragment: request.fragment,
+							module: request.module,
+							directory: request.directory,
+							file: request.file,
+							internal: request.internal
 						};
 						resolver.doResolve(
 							target,

--- a/lib/SelfReferencePlugin.js
+++ b/lib/SelfReferencePlugin.js
@@ -61,10 +61,25 @@ module.exports = class SelfReferencePlugin {
 					const remainingRequest = `.${req.slice(name.length)}`;
 					/** @type {ResolveRequest} */
 					const obj = {
-						...request,
-						request: remainingRequest,
 						path: /** @type {string} */ (request.descriptionFileRoot),
-						relativePath: "."
+						context: request.context,
+						descriptionFilePath: request.descriptionFilePath,
+						descriptionFileRoot: request.descriptionFileRoot,
+						descriptionFileData: request.descriptionFileData,
+						relativePath: ".",
+						ignoreSymlinks: request.ignoreSymlinks,
+						fullySpecified: request.fullySpecified,
+						__innerRequest: request.__innerRequest,
+						__innerRequest_request: request.__innerRequest_request,
+						__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+						request: remainingRequest,
+						query: request.query,
+						fragment: request.fragment,
+						module: request.module,
+						directory: request.directory,
+						file: request.file,
+						internal: request.internal
 					};
 
 					resolver.doResolve(

--- a/lib/SymlinkPlugin.js
+++ b/lib/SymlinkPlugin.js
@@ -83,8 +83,25 @@ module.exports = class SymlinkPlugin {
 						});
 						/** @type {ResolveRequest} */
 						const obj = {
-							...request,
-							path: result
+							path: result,
+							context: request.context,
+							descriptionFilePath: request.descriptionFilePath,
+							descriptionFileRoot: request.descriptionFileRoot,
+							descriptionFileData: request.descriptionFileData,
+							relativePath: request.relativePath,
+							ignoreSymlinks: request.ignoreSymlinks,
+							fullySpecified: request.fullySpecified,
+							__innerRequest: request.__innerRequest,
+							__innerRequest_request: request.__innerRequest_request,
+							__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+							request: request.request,
+							query: request.query,
+							fragment: request.fragment,
+							module: request.module,
+							directory: request.directory,
+							file: request.file,
+							internal: request.internal
 						};
 						resolver.doResolve(
 							target,

--- a/lib/UseFilePlugin.js
+++ b/lib/UseFilePlugin.js
@@ -37,11 +37,27 @@ module.exports = class UseFilePlugin {
 
 				/** @type {ResolveRequest} */
 				const obj = {
-					...request,
 					path: filePath,
+					context: request.context,
+					descriptionFilePath: request.descriptionFilePath,
+					descriptionFileRoot: request.descriptionFileRoot,
+					descriptionFileData: request.descriptionFileData,
 					relativePath:
 						request.relativePath &&
-						resolver.join(request.relativePath, this.filename)
+						resolver.join(request.relativePath, this.filename),
+					ignoreSymlinks: request.ignoreSymlinks,
+					fullySpecified: request.fullySpecified,
+					__innerRequest: request.__innerRequest,
+					__innerRequest_request: request.__innerRequest_request,
+					__innerRequest_relativePath: request.__innerRequest_relativePath,
+
+					request: request.request,
+					query: request.query,
+					fragment: request.fragment,
+					module: request.module,
+					directory: request.directory,
+					file: request.file,
+					internal: request.internal
 				};
 				resolver.doResolve(
 					target,


### PR DESCRIPTION
Improves performance all-up (especially in `ParsePlugin`, `JoinRequestPlugin`, `JoinRequestPartPlugin`) by ensuring that the `ResolveRequest` object always has a constant shape.

Additionally, creating the object via a direct object literal is _significantly_ faster than creating it via object spread.

Testing on NodeJS 18.19.1, this had the following impact for a local webpack build.
Before:
![image](https://github.com/user-attachments/assets/57daefe8-25c8-43c9-b9a7-0e1b30cc29f0)
![image](https://github.com/user-attachments/assets/6ff4ce67-ff90-4c12-877d-7bfe6d7a22be)

After:
![image](https://github.com/user-attachments/assets/ea41898e-d11a-41e5-bced-39c83e852f2b)
![image](https://github.com/user-attachments/assets/bff96b87-64aa-4392-b4da-42a46e349b09)
