### PR TITLE
feat: export type SyncFileSystem and type BaseFileSystem

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,8 @@ const ResolverFactory = require("./ResolverFactory");
 /** @typedef {import("./PnpPlugin").PnpApiImpl} PnpApi */
 /** @typedef {import("./Resolver")} Resolver */
 /** @typedef {import("./Resolver").FileSystem} FileSystem */
+/** @typedef {import("./Resolver").SyncFileSystem} SyncFileSystem */
+/** @typedef {import("./CachedInputFileSystem").BaseFileSystem} BaseFileSystem */
 /** @typedef {import("./Resolver").ResolveCallback} ResolveCallback */
 /** @typedef {import("./Resolver").ResolveContext} ResolveContext */
 /** @typedef {import("./Resolver").ResolveRequest} ResolveRequest */

--- a/types.d.ts
+++ b/types.d.ts
@@ -1123,6 +1123,8 @@ declare namespace exports {
 		PnpApi,
 		Resolver,
 		FileSystem,
+		SyncFileSystem,
+		BaseFileSystem,
 		ResolveContext,
 		ResolveRequest,
 		Plugin,


### PR DESCRIPTION
Fix #447

I also exported `BaseFileSystem` since it is widely used in the `CachedInputFileSystem` class.