### PR TITLE
fix: nonsensible intersection

### DIFF
--- a/lib/AliasFieldPlugin.js
+++ b/lib/AliasFieldPlugin.js
@@ -44,9 +44,7 @@ module.exports = class AliasFieldPlugin {
 				if (fieldData === null || typeof fieldData !== "object") {
 					if (resolveContext.log) {
 						resolveContext.log(
-							`Field '${
-								this.field
-							}' doesn't contain a valid alias configuration`,
+							`Field '${this.field}' doesn't contain a valid alias configuration`,
 						);
 					}
 					return callback();

--- a/lib/AliasPlugin.js
+++ b/lib/AliasPlugin.js
@@ -131,9 +131,7 @@ module.exports = class AliasPlugin {
 									return resolver.doResolve(
 										target,
 										obj,
-										`aliased with mapping '${item.name}': '${alias}' to '${
-											newRequestStr
-										}'`,
+										`aliased with mapping '${item.name}': '${alias}' to '${newRequestStr}'`,
 										resolveContext,
 										(err, result) => {
 											if (err) return callback(err);

--- a/lib/DescriptionFilePlugin.js
+++ b/lib/DescriptionFilePlugin.js
@@ -66,7 +66,9 @@ module.exports = class DescriptionFilePlugin {
 								}
 								return callback();
 							}
-							const relativePath = `.${path.slice(result.directory.length).replace(/\\/g, "/")}`;
+							const relativePath = `.${path
+								.slice(result.directory.length)
+								.replace(/\\/g, "/")}`;
 							/** @type {ResolveRequest} */
 							const obj = {
 								...request,
@@ -78,9 +80,7 @@ module.exports = class DescriptionFilePlugin {
 							resolver.doResolve(
 								target,
 								obj,
-								`using description file: ${result.path} (relative path: ${
-									relativePath
-								})`,
+								`using description file: ${result.path} (relative path: ${relativePath})`,
 								resolveContext,
 								(err, result) => {
 									if (err) return callback(err);

--- a/lib/DescriptionFileUtils.js
+++ b/lib/DescriptionFileUtils.js
@@ -185,7 +185,10 @@ function getField(content, field) {
 				current = null;
 				break;
 			}
-			current = /** @type {JsonObject} */ (current)[field[j]];
+			current = /** @type {JsonValue} */ (
+				/** @type {JsonObject} */
+				(current)[field[j]]
+			);
 		}
 		return current;
 	}

--- a/lib/LogInfoPlugin.js
+++ b/lib/LogInfoPlugin.js
@@ -49,9 +49,7 @@ module.exports = class LogInfoPlugin {
 				}
 				if (request.relativePath) {
 					log(
-						`${prefix}Relative path from description file is: ${
-							request.relativePath
-						}`,
+						`${prefix}Relative path from description file is: ${request.relativePath}`,
 					);
 				}
 				callback();

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -289,7 +289,7 @@ const {
 /** @typedef {string | number | boolean | null} JsonPrimitive */
 /** @typedef {JsonValue[]} JsonArray */
 /** @typedef {JsonPrimitive | JsonObject | JsonArray} JsonValue */
-/** @typedef {{[Key in string]?: JsonValue | undefined}} JsonObject */
+/** @typedef {{ [Key in string]?: JsonValue | undefined }} JsonObject */
 
 // eslint-disable-next-line jsdoc/require-property
 /** @typedef {object} Context */

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -289,7 +289,7 @@ const {
 /** @typedef {string | number | boolean | null} JsonPrimitive */
 /** @typedef {JsonValue[]} JsonArray */
 /** @typedef {JsonPrimitive | JsonObject | JsonArray} JsonValue */
-/** @typedef {{[Key in string]: JsonValue} & {[Key in string]?: JsonValue | undefined}} JsonObject */
+/** @typedef {{[Key in string]?: JsonValue | undefined}} JsonObject */
 
 // eslint-disable-next-line jsdoc/require-property
 /** @typedef {object} Context */
@@ -365,9 +365,9 @@ class Resolver {
 	static createStackEntry(hook, request) {
 		return `${hook.name}: (${request.path}) ${request.request || ""}${
 			request.query || ""
-		}${request.fragment || ""}${
-			request.directory ? " directory" : ""
-		}${request.module ? " module" : ""}`;
+		}${request.fragment || ""}${request.directory ? " directory" : ""}${
+			request.module ? " module" : ""
+		}`;
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lint:spellcheck": "cspell --no-must-find-files \"**/*.*\"",
     "fmt": "yarn fmt:base --loglevel warn --write",
     "fmt:check": "yarn fmt:base --check",
-    "fmt:base": "prettier --cache --ignore-unknown .",
+    "fmt:base": "node_modules/prettier/bin/prettier.cjs --cache --ignore-unknown .",
     "fix": "yarn fix:code && yarn fix:special",
     "fix:code": "yarn lint:code --fix",
     "fix:special": "node node_modules/tooling/inherit-types --write && node node_modules/tooling/format-file-header --write && node node_modules/tooling/generate-types --write",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "homepage": "http://github.com/webpack/enhanced-resolve",
   "scripts": {
     "prepare": "husky install",
-    "lint": "yarn lint:code && yarn lint:types && yarn lint:types-test && yarn lint:special && yarn lint:spellcheck",
+    "lint": "yarn lint:code && yarn lint:types && yarn lint:types-test && yarn lint:special && yarn fmt:check && yarn lint:spellcheck",
     "lint:code": "eslint --cache .",
     "lint:special": "node node_modules/tooling/lockfile-lint && node node_modules/tooling/inherit-types && node node_modules/tooling/format-file-header && node node_modules/tooling/generate-types",
     "lint:types": "tsc",
@@ -65,7 +65,7 @@
     "fix:code": "yarn lint:code --fix",
     "fix:special": "node node_modules/tooling/inherit-types --write && node node_modules/tooling/format-file-header --write && node node_modules/tooling/generate-types --write",
     "type-report": "rimraf coverage && yarn cover:types && yarn cover:report && open-cli coverage/lcov-report/index.html",
-    "pretest": "yarn lintqqq",
+    "pretest": "yarn lint",
     "test": "yarn test:coverage",
     "test:only": "jest",
     "test:watch": "yarn test:only --watch",

--- a/test/missing.test.js
+++ b/test/missing.test.js
@@ -87,9 +87,7 @@ describe("missing", () => {
 			resolve(testCase[0], testCase[1], { missingDependencies }, callback);
 		});
 
-		it(`should report error details exactly once when trying to resolve ${
-			testCase[1]
-		}`, (done) => {
+		it(`should report error details exactly once when trying to resolve ${testCase[1]}`, (done) => {
 			/**
 			 * @param {Error & { details: string } | null} err err
 			 * @param {string} _filename _filename

--- a/types.d.ts
+++ b/types.d.ts
@@ -542,7 +542,7 @@ declare interface Iterator<T, Z> {
 		i: number,
 	): void;
 }
-type JsonObject = { [index: string]: JsonValue } & {
+declare interface JsonObject {
 	[index: string]:
 		| undefined
 		| null
@@ -551,7 +551,7 @@ type JsonObject = { [index: string]: JsonValue } & {
 		| boolean
 		| JsonObject
 		| JsonValue[];
-};
+}
 type JsonValue = null | string | number | boolean | JsonObject | JsonValue[];
 declare interface KnownHooks {
 	/**


### PR DESCRIPTION
After upgrading to Webpack ^5.100.0 (https://github.com/lynx-family/lynx-stack/pull/1418), we got errors related with types:

```
- JsonObjectTypes[key]: string & Array<JsonValueTypes>
  - nonsensible intersection

- JsonObjectTypes[key]: number & Array<JsonValueTypes>
  - nonsensible intersection

- JsonObjectTypes[key]: false & Array<JsonValueTypes>
  - nonsensible intersection

- JsonObjectTypes[key]: true & Array<JsonValueTypes>
  - nonsensible intersection
```

See: https://github.com/lynx-family/lynx-stack/actions/runs/16744114403/job/47401398078