### PR TITLE
fix: note the conditions under which the request couldn't be found

### DIFF
--- a/lib/ExportsFieldPlugin.js
+++ b/lib/ExportsFieldPlugin.js
@@ -114,9 +114,18 @@ module.exports = class ExportsFieldPlugin {
 				}
 
 				if (paths.length === 0) {
+					let conditions;
+					if (this.conditionNames.length > 1) {
+						const listFormat = new Intl.ListFormat("en", { type: "disjunction" });
+						conditions = `the conditions ${listFormat.format(this.conditionNames.map(c => `"${c}"`))}`;
+					} else if (this.conditionNames.length == 1) {
+						conditions = `the condition "${this.conditionNames[0]}"`;
+					} else {
+						conditions = "the conditions [empty]";
+					}
 					return callback(
 						new Error(
-							`Package path ${remainingRequest} is not exported from package ${request.descriptionFileRoot} (see exports field in ${request.descriptionFilePath})`,
+							`"${remainingRequest}" is not exported under ${conditions} from package ${request.descriptionFileRoot} (see exports field in ${request.descriptionFilePath})`,
 						),
 					);
 				}


### PR DESCRIPTION
i got really confused because there was an error saying something wasn't exported but it was - turns out it was just exported under the wrong conditions. this pr makes the error note the conditions it was expected to be exported under.