### PR TITLE
fix: fix always-false condition

### DIFF
--- a/lib/ExportsFieldPlugin.js
+++ b/lib/ExportsFieldPlugin.js
@@ -155,7 +155,7 @@ module.exports = class ExportsFieldPlugin {
 
 						if (
 							invalidSegmentRegEx.exec(relativePath.slice(2)) !== null &&
-							deprecatedInvalidSegmentRegEx.test(relativePath.slice(2)) !== null
+							deprecatedInvalidSegmentRegEx.test(relativePath.slice(2))
 						) {
 							if (paths.length === i) {
 								return callback(


### PR DESCRIPTION
Fixes: RegExp.test never returns null 
```js
(method) RegExp.test(string: string): boolean
Returns a Boolean value that indicates whether or not a pattern exists in a searched string.

@param string — String on which to perform the search.```