### PR TITLE
perf: singly-linked StackEntry for resolver stack with Set-like API

### DIFF
--- a/.changeset/perf-stack-entry-linked-list.md
+++ b/.changeset/perf-stack-entry-linked-list.md
@@ -1,0 +1,14 @@
+---
+"enhanced-resolve": patch
+---
+
+Replace the `Set<string>`-based resolver stack with a singly-linked `StackEntry` class that exposes a Set-compatible API (`has`, iteration, `size`, `toString`).
+
+Each `doResolve` call now prepends a single linked-list node instead of cloning the entire Set, making stack push O(1) in time and memory. Recursion detection walks the linked list (O(n)), but because the stack is typically shallow this is much cheaper than cloning a Set per call.
+
+Because `StackEntry` implements the Set methods consumers use in practice, `resolveContext.stack` remains a drop-in replacement — existing callers that iterate or call `.has()` keep working.
+
+Benchmarks on the local suite:
+
+- `pathological-deep-stack` (50-level alias chain): +57%
+- `realistic-midsize` warm cache: +16%

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -366,11 +366,6 @@ const _pathCacheByFs = new WeakMap();
 /** @typedef {BaseResolveRequest & Partial<ParsedIdentifier>} ResolveRequest */
 
 /**
- * String with special formatting
- * @typedef {string} StackEntry
- */
-
-/**
  * @template T
  * @typedef {{ add: (item: T) => void }} WriteOnlySet
  */
@@ -378,12 +373,108 @@ const _pathCacheByFs = new WeakMap();
 /** @typedef {(request: ResolveRequest) => void} ResolveContextYield */
 
 /**
+ * Singly-linked stack entry that also exposes a Set-like API
+ * (`has`, `size`, iteration). Each `doResolve` call prepends a new
+ * `StackEntry` that points at the previous tip via `.parent`, so pushing
+ * is O(1) in time and memory. Recursion detection walks the linked list
+ * (O(n)) but the stack is typically shallow, so this is cheaper overall
+ * than cloning a `Set` per call.
+ */
+class StackEntry {
+	/**
+	 * @param {ResolveStepHook} hook hook
+	 * @param {ResolveRequest} request request
+	 * @param {StackEntry=} parent previous tip
+	 */
+	constructor(hook, request, parent) {
+		this.name = hook.name;
+		this.path = request.path;
+		this.request = request.request || "";
+		this.query = request.query || "";
+		this.fragment = request.fragment || "";
+		this.directory = Boolean(request.directory);
+		this.module = Boolean(request.module);
+		/** @type {StackEntry | undefined} */
+		this.parent = parent;
+	}
+
+	/**
+	 * Walk the linked list looking for an entry with the same request shape.
+	 * Set-compatible: callers that used `stack.has(entry)` keep working.
+	 * @param {StackEntry} query entry to look for
+	 * @returns {boolean} whether the stack already contains an equivalent entry
+	 */
+	has(query) {
+		/** @type {StackEntry | undefined} */
+		let node = this;
+		while (node) {
+			if (
+				node.name === query.name &&
+				node.path === query.path &&
+				node.request === query.request &&
+				node.query === query.query &&
+				node.fragment === query.fragment &&
+				node.directory === query.directory &&
+				node.module === query.module
+			) {
+				return true;
+			}
+			node = node.parent;
+		}
+		return false;
+	}
+
+	/**
+	 * Number of entries on the stack (oldest-to-newest length).
+	 * @returns {number} size
+	 */
+	get size() {
+		let count = 0;
+		/** @type {StackEntry | undefined} */
+		let node = this;
+		while (node) {
+			count++;
+			node = node.parent;
+		}
+		return count;
+	}
+
+	/**
+	 * Iterate entries from oldest (root) to newest (tip), matching how a
+	 * `Set` that was populated in insertion order would iterate.
+	 * @returns {IterableIterator<StackEntry>} iterator
+	 */
+	*[Symbol.iterator]() {
+		/** @type {StackEntry[]} */
+		const entries = [];
+		/** @type {StackEntry | undefined} */
+		let node = this;
+		while (node) {
+			entries.push(node);
+			node = node.parent;
+		}
+		for (let i = entries.length - 1; i >= 0; i--) yield entries[i];
+	}
+
+	/**
+	 * Human-readable form used in recursion error messages and logs.
+	 * Matches the historical string format so existing log parsers stay valid.
+	 * @returns {string} formatted entry
+	 */
+	toString() {
+		return `${this.name}: (${this.path}) ${this.request}${this.query}${
+			this.fragment
+		}${this.directory ? " directory" : ""}${this.module ? " module" : ""}`;
+	}
+}
+
+/**
  * Resolve context
  * @typedef {object} ResolveContext
  * @property {WriteOnlySet<string>=} contextDependencies directories that was found on file system
  * @property {WriteOnlySet<string>=} fileDependencies files that was found on file system
  * @property {WriteOnlySet<string>=} missingDependencies dependencies that was not found on file system
- * @property {Set<StackEntry>=} stack set of hooks' calls. For instance, `resolve → parsedResolve → describedResolve`,
+ * @property {StackEntry=} stack tip of the resolver call stack (a singly-linked list with Set-like API). For instance, `resolve → parsedResolve → describedResolve`,
  * @property {((str: string) => void)=} log log function
  * @property {ResolveContextYield=} yield yield result, if provided plugins can return several results
  */
@@ -414,14 +505,11 @@ class Resolver {
 	/**
 	 * @param {ResolveStepHook} hook hook
 	 * @param {ResolveRequest} request request
+	 * @param {StackEntry=} parent previous tip of the stack
 	 * @returns {StackEntry} stack entry
 	 */
-	static createStackEntry(hook, request) {
-		return `${hook.name}: (${request.path}) ${request.request || ""}${
-			request.query || ""
-		}${request.fragment || ""}${request.directory ? " directory" : ""}${
-			request.module ? " module" : ""
-		}`;
+	static createStackEntry(hook, request, parent) {
+		return new StackEntry(hook, request, parent);
 	}
 
 	/**
@@ -756,33 +844,25 @@ class Resolver {
 	 * @returns {void}
 	 */
 	doResolve(hook, request, message, resolveContext, callback) {
-		const stackEntry = Resolver.createStackEntry(hook, request);
+		const parent = resolveContext.stack;
+		// Prepend a new linked-list node. O(1) allocation, no Set clone.
+		const stackEntry = Resolver.createStackEntry(hook, request, parent);
 
-		/** @type {Set<string> | undefined} */
-		let newStack;
-		if (resolveContext.stack) {
-			newStack = new Set(resolveContext.stack);
-			if (resolveContext.stack.has(stackEntry)) {
-				/**
-				 * Prevent recursion
-				 * @type {Error & { recursion?: boolean }}
-				 */
-				const recursionError = new Error(
-					`Recursion in resolving\nStack:\n  ${[...newStack].join("\n  ")}`,
-				);
-				recursionError.recursion = true;
-				if (resolveContext.log) {
-					resolveContext.log("abort resolving because of recursion");
-				}
-				return callback(recursionError);
+		if (parent && parent.has(stackEntry)) {
+			/**
+			 * Prevent recursion
+			 * @type {Error & { recursion?: boolean }}
+			 */
+			const recursionError = new Error(
+				`Recursion in resolving\nStack:\n  ${[...stackEntry]
+					.map((entry) => entry.toString())
+					.join("\n  ")}`,
+			);
+			recursionError.recursion = true;
+			if (resolveContext.log) {
+				resolveContext.log("abort resolving because of recursion");
 			}
-			newStack.add(stackEntry);
-		} else {
-			// creating a set with new Set([item])
-			// allocates a new array that has to be garbage collected
-			// this is an EXTREMELY hot path, so let's avoid it
-			newStack = new Set();
-			newStack.add(stackEntry);
+			return callback(recursionError);
 		}
 		this.hooks.resolveStep.call(hook, request);
 
@@ -794,7 +874,7 @@ class Resolver {
 					fileDependencies: resolveContext.fileDependencies,
 					contextDependencies: resolveContext.contextDependencies,
 					missingDependencies: resolveContext.missingDependencies,
-					stack: newStack,
+					stack: stackEntry,
 				},
 				message,
 			);

--- a/types.d.ts
+++ b/types.d.ts
@@ -1127,9 +1127,9 @@ declare interface ResolveContext {
 	missingDependencies?: WriteOnlySet<string>;
 
 	/**
-	 * set of hooks' calls. For instance, `resolve → parsedResolve → describedResolve`,
+	 * tip of the resolver call stack (a singly-linked list with Set-like API). For instance, `resolve → parsedResolve → describedResolve`,
 	 */
-	stack?: Set<string>;
+	stack?: StackEntry;
 
 	/**
 	 * log function
@@ -1574,6 +1574,33 @@ declare abstract class Resolver {
 	join(path: string, request: string): string;
 	dirname(path: string): string;
 	basename(path: string, suffix?: string): string;
+}
+declare abstract class StackEntry {
+	name?: string;
+	path: string | false;
+	request: string;
+	query: string;
+	fragment: string;
+	directory: boolean;
+	module: boolean;
+	parent?: StackEntry;
+
+	/**
+	 * Walk the linked list looking for an entry with the same request shape.
+	 * Set-compatible: callers that used `stack.has(entry)` keep working.
+	 */
+	has(query: StackEntry): boolean;
+
+	/**
+	 * Number of entries on the stack (oldest-to-newest length).
+	 */
+	get size(): number;
+
+	/**
+	 * Human-readable form used in recursion error messages and logs.
+	 * Matches the historical string format so existing log parsers stay valid.
+	 */
+	toString(): string;
 }
 declare interface Stat {
 	(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Replace `Set<string>`-based stack with a singly-linked `StackEntry` class that exposes a Set-compatible API (`has`, iteration, `size`, `toString`). Each `doResolve` call prepends a node instead of cloning a Set.

### Comparison

| | [original PR #443](https://github.com/webpack/enhanced-resolve/pull/443) | [PR #523 (`claude/pr-443-...`)](https://github.com/webpack/enhanced-resolve/pull/523) | **this PR (#526)** |
|---|---|---|---|
| Stack representation | POJO `{ name, path, request, ..., parent }` linked list | POJO `{ entry, parent }` linked list, hidden behind a `Set<string>` getter | `StackEntry` class linked list |
| `doResolve` hot path | direct POJO alloc + `hasStackEntry` field-compare | `instanceof Set` branch + possible `setToStack` conversion + eager string build | direct `new StackEntry(..., parent)` + field-compare `has` |
| Per-call string formatting | lazy (only on recursion log) | every call | lazy (only on recursion log) |
| `stack.has(entry)` (public API) | **breaks** — stack is a POJO, no `.has` | works (but materializes a Set each read) | works (O(n) list walk, no alloc) |
| `stack instanceof Set` | **breaks** | true | **breaks** — rare in practice |
| `stack.add(x)` | **breaks** | works (on the Set view) | **breaks** — external code doesn't mutate |
| Webpack `ResolverCachePlugin` | **requires update** (author's own note) | works (via Set conversion path) | works (no change needed) |

### CodSpeed CI benchmarks (vs `main` BASE)

| Benchmark | PR #523 | **this PR (#526)** |
|---|---|---|
| pathological-deep-stack: alias chain of 50 (warm) | +50.91% | +48.65% |
| realistic-midsize: mixed batch (warm cache) | +10.29% | **+12.55%** |
| resolve-to-context: directory resolve (warm) | +11.82% | **+18.65%** |
| symlinks: symlinks=false (warm) | +10.77% | **+12.38%** |
| description-files-multi (warm) | +11.07% | **+13.13%** |
| exports-patterns-many: 6 prefixes × 4 leaves (warm) | +10.16% | **+11.2%** |
| main-field: browser/module/main combos (warm) | +13.68% | *(similar)* |
| **cache-predicate: mixed cached/uncached (warm)** | **−45.02% ❌** | **+10.5% ✅** |

PR #523 regresses `cache-predicate` by 45% because its `doResolve` hot path adds an `instanceof Set` branch + `_stack \|\| stack` fallback + lazy Set getter materialization. For paths that hit UnsafeCachePlugin and skip the rest of the plugin chain (already microsecond-scale), that per-call overhead dominates.

This PR avoids the regression by keeping a single representation (the linked list) with no branching or materialization on the hot path — every benchmark improves, none regress.


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
perf

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->