### PR TITLE
fix: avoid OOM in CachedInputFileSystem when duration is Infinity

### DIFF
--- a/.changeset/serious-zebras-cross.md
+++ b/.changeset/serious-zebras-cross.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Avoid OOM in CachedInputFileSystem when duration is Infinity.

--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -203,7 +203,11 @@ class CacheBackend {
 		/** @type {Set<string>[]} */
 		this._levels = [];
 		for (let i = 0; i < 10; i++) this._levels.push(new Set());
-		for (let i = 5000; i < duration; i += 500) this._levels.push(new Set());
+		if (duration !== Infinity) {
+			for (let i = 5000; i < duration; i += 500) {
+				this._levels.push(new Set());
+			}
+		}
 		this._currentLevel = 0;
 		this._tickInterval = Math.floor(duration / this._levels.length);
 		/** @type {STORAGE_MODE_IDLE | STORAGE_MODE_SYNC | STORAGE_MODE_ASYNC} */
@@ -492,6 +496,11 @@ class CacheBackend {
 				break;
 		}
 		this._mode = STORAGE_MODE_ASYNC;
+		// When duration is Infinity, cache entries never expire, so there
+		// is no need to schedule a decay timer.
+		if (this._duration === Infinity) {
+			return;
+		}
 		const ref = setTimeout(() => {
 			this._mode = STORAGE_MODE_SYNC;
 			this._runDecays();

--- a/test/CachedInputFileSystem.test.js
+++ b/test/CachedInputFileSystem.test.js
@@ -476,6 +476,68 @@ describe("cachedInputFileSystem CacheBackend", () => {
 	});
 });
 
+describe("cachedInputFileSystem CacheBackend with Infinity duration", () => {
+	let fs;
+
+	beforeEach(() => {
+		fs = new CachedInputFileSystem(
+			{
+				stat(path, options, callback) {
+					if (!callback) {
+						callback = options;
+						options = undefined;
+					}
+					setTimeout(
+						callback.bind(null, null, {
+							path,
+							options,
+						}),
+						100,
+					);
+				},
+				// @ts-expect-error for tests
+				statSync(path, options) {
+					return {
+						path,
+						options,
+					};
+				},
+			},
+			Infinity,
+		);
+	});
+
+	afterEach(() => {
+		fs.purge();
+	});
+
+	it("should not crash the constructor with Infinity", () => {
+		expect(fs).toBeDefined();
+	});
+
+	it("should cache accesses forever", (done) => {
+		fs.stat("a", (err, result) => {
+			result.a = true;
+			fs.stat("a", (err, result) => {
+				expect(result.a).toBeDefined();
+				setTimeout(() => {
+					fs.stat("a", (err, result) => {
+						expect(result.a).toBeDefined();
+						done();
+					});
+				}, 100);
+			});
+		});
+	});
+
+	it("should cache sync accesses forever", () => {
+		const result = fs.statSync("a");
+		result.a = true;
+		const result2 = fs.statSync("a");
+		expect(result2.a).toBeDefined();
+	});
+});
+
 describe("cachedInputFileSystem CacheBackend and Node.JS filesystem", () => {
 	let fs;
 


### PR DESCRIPTION
When `duration` is `Infinity`, the constructor's level-allocation loop
(`for (let i = 5000; i < duration; i += 500)`) never terminates, which
crashes the process with an out-of-memory error before any file is even
resolved. Additionally, scheduling a decay `setTimeout` with an infinite
timeout would be meaningless (and clamped by Node).

Guard both the level allocation and the async decay timer so that passing
`Infinity` yields a never-expiring cache, as users would expect.

Closes webpack/enhanced-resolve#368