### PR TITLE
perf: precompile AliasPlugin options to speed up huge alias lists

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -102,6 +102,8 @@ export default function register(bench, { caseName, caseDir, fixtureDir }) {
 | `failed-resolution`       | Error path: missing files and packages, walks the full pipeline before reporting the miss                    |
 | `concurrent-batch`        | 15 resolves through `Promise.all`, exercising in-flight request de-duplication                               |
 | `large-alias-list`        | 50 non-matching + 8 matching aliases, stresses AliasPlugin's linear scan                                     |
+| `huge-alias-list`         | 300 non-matching + 8 matching aliases, match near end — monorepo-scale AliasPlugin scan                      |
+| `huge-alias-miss`         | 300 aliases + requests that never match any — pure per-option overhead, no `doResolve` recursion             |
 | `multiple-modules`        | `modules: [shared, vendor, node_modules]` mix of root + hierarchical directories                             |
 | `mixed-conditions`        | Nested condition map (browser/worker/node/development/production/...) under 4 condition configurations       |
 | `exports-patterns-many`   | Package with 6 wildcard subpath exports × 4 leaves per prefix — pattern-matcher stress                       |

--- a/benchmark/cases/huge-alias-list/fixture/package.json
+++ b/benchmark/cases/huge-alias-list/fixture/package.json
@@ -1,0 +1,1 @@
+{"name":"huge-alias-list-fixture","version":"1.0.0"}

--- a/benchmark/cases/huge-alias-list/fixture/src/index.js
+++ b/benchmark/cases/huge-alias-list/fixture/src/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-list/fixture/src/target/a.js
+++ b/benchmark/cases/huge-alias-list/fixture/src/target/a.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-list/fixture/src/target/b.js
+++ b/benchmark/cases/huge-alias-list/fixture/src/target/b.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-list/fixture/src/target/c.js
+++ b/benchmark/cases/huge-alias-list/fixture/src/target/c.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-list/fixture/src/target/d.js
+++ b/benchmark/cases/huge-alias-list/fixture/src/target/d.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-list/fixture/src/target/e.js
+++ b/benchmark/cases/huge-alias-list/fixture/src/target/e.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-list/fixture/src/target/f.js
+++ b/benchmark/cases/huge-alias-list/fixture/src/target/f.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-list/fixture/src/target/g.js
+++ b/benchmark/cases/huge-alias-list/fixture/src/target/g.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-list/fixture/src/target/h.js
+++ b/benchmark/cases/huge-alias-list/fixture/src/target/h.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-list/index.bench.mjs
+++ b/benchmark/cases/huge-alias-list/index.bench.mjs
@@ -1,0 +1,69 @@
+/*
+ * huge-alias-list
+ *
+ * Scales `large-alias-list` up to the PR-438 territory: projects with several
+ * hundred alias entries in the webpack config (monorepos, generated aliases
+ * from a workspace graph, etc.). Every resolve has to linearly walk the full
+ * alias list, so this case is particularly sensitive to per-option work
+ * (string concat, split, closure creation) inside AliasPlugin's scan.
+ */
+
+import fs from "fs";
+import path from "path";
+import enhanced from "../../../lib/index.js";
+
+const { ResolverFactory, CachedInputFileSystem } = enhanced;
+
+const PARALLEL_ALIASES = 300;
+
+/**
+ * @param {import('tinybench').Bench} bench
+ * @param {{ fixtureDir: string }} ctx
+ */
+export default function register(bench, { fixtureDir }) {
+	const fileSystem = new CachedInputFileSystem(fs, 4000);
+
+	const aliases = [];
+	for (let i = 0; i < PARALLEL_ALIASES; i++) {
+		aliases.push({
+			name: `unused-alias-${i}`,
+			alias: path.join(fixtureDir, "src/target/a.js"),
+		});
+	}
+	for (const f of ["a", "b", "c", "d", "e", "f", "g", "h"]) {
+		aliases.push({
+			name: `t-${f}`,
+			alias: path.join(fixtureDir, `src/target/${f}.js`),
+		});
+	}
+
+	const resolver = ResolverFactory.createResolver({
+		fileSystem,
+		extensions: [".js"],
+		alias: aliases,
+	});
+
+	const from = path.join(fixtureDir, "src");
+
+	// Requests match aliases positioned at the tail of the list so every
+	// resolve walks the full 300-entry array before finding a hit.
+	const requests = ["t-a", "t-b", "t-c", "t-d", "t-e", "t-f", "t-g", "t-h"];
+
+	const resolve = (req) =>
+		new Promise((resolve, reject) => {
+			resolver.resolve({}, from, req, {}, (err, result) => {
+				if (err) return reject(err);
+				if (!result) return reject(new Error(`no result for ${req}`));
+				resolve(result);
+			});
+		});
+
+	bench.add(
+		`huge-alias-list: ${PARALLEL_ALIASES}+8 aliases, match near end`,
+		async () => {
+			for (const req of requests) {
+				await resolve(req);
+			}
+		},
+	);
+}

--- a/benchmark/cases/huge-alias-miss/fixture/package.json
+++ b/benchmark/cases/huge-alias-miss/fixture/package.json
@@ -1,0 +1,1 @@
+{"name":"huge-alias-miss-fixture","version":"1.0.0"}

--- a/benchmark/cases/huge-alias-miss/fixture/src/index.js
+++ b/benchmark/cases/huge-alias-miss/fixture/src/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-miss/fixture/src/target/a.js
+++ b/benchmark/cases/huge-alias-miss/fixture/src/target/a.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-miss/fixture/src/target/b.js
+++ b/benchmark/cases/huge-alias-miss/fixture/src/target/b.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-miss/fixture/src/target/c.js
+++ b/benchmark/cases/huge-alias-miss/fixture/src/target/c.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/benchmark/cases/huge-alias-miss/index.bench.mjs
+++ b/benchmark/cases/huge-alias-miss/index.bench.mjs
@@ -1,0 +1,64 @@
+/*
+ * huge-alias-miss
+ *
+ * Companion to `huge-alias-list` for the other common shape in big configs:
+ * plain relative requests that do NOT match any alias entry. AliasPlugin
+ * still walks the entire alias list before falling through, so the miss path
+ * is the purest measurement of per-option overhead (the matching branch never
+ * runs, no `doResolve` recursion).
+ */
+
+import fs from "fs";
+import path from "path";
+import enhanced from "../../../lib/index.js";
+
+const { ResolverFactory, CachedInputFileSystem } = enhanced;
+
+const PARALLEL_ALIASES = 300;
+
+/**
+ * @param {import('tinybench').Bench} bench
+ * @param {{ fixtureDir: string }} ctx
+ */
+export default function register(bench, { fixtureDir }) {
+	const fileSystem = new CachedInputFileSystem(fs, 4000);
+
+	const aliases = [];
+	for (let i = 0; i < PARALLEL_ALIASES; i++) {
+		aliases.push({
+			name: `unused-alias-${i}`,
+			alias: path.join(fixtureDir, "src/target/a.js"),
+		});
+	}
+
+	const resolver = ResolverFactory.createResolver({
+		fileSystem,
+		extensions: [".js"],
+		alias: aliases,
+	});
+
+	const from = path.join(fixtureDir, "src");
+
+	// Relative requests that never match any alias — the resolver walks the
+	// full 300-entry list twice (once for `fallback`, once for `alias`) before
+	// falling through to normal resolution.
+	const requests = ["./index", "./target/a", "./target/b", "./target/c"];
+
+	const resolve = (req) =>
+		new Promise((resolve, reject) => {
+			resolver.resolve({}, from, req, {}, (err, result) => {
+				if (err) return reject(err);
+				if (!result) return reject(new Error(`no result for ${req}`));
+				resolve(result);
+			});
+		});
+
+	bench.add(
+		`huge-alias-miss: ${PARALLEL_ALIASES} aliases, no match`,
+		async () => {
+			for (const req of requests) {
+				await resolve(req);
+			}
+		},
+	);
+}

--- a/lib/AliasPlugin.js
+++ b/lib/AliasPlugin.js
@@ -10,7 +10,7 @@
 /** @typedef {string | string[] | false} Alias */
 /** @typedef {{ alias: Alias, name: string, onlyModule?: boolean }} AliasOption */
 
-const { aliasResolveHandler } = require("./AliasUtils");
+const { aliasResolveHandler, compileAliasOptions } = require("./AliasUtils");
 
 module.exports = class AliasPlugin {
 	/**
@@ -30,13 +30,14 @@ module.exports = class AliasPlugin {
 	 */
 	apply(resolver) {
 		const target = resolver.ensureHook(this.target);
+		const compiled = compileAliasOptions(resolver, this.options);
 
 		resolver
 			.getHook(this.source)
 			.tapAsync("AliasPlugin", (request, resolveContext, callback) => {
 				aliasResolveHandler(
 					resolver,
-					this.options,
+					compiled,
 					target,
 					request,
 					resolveContext,

--- a/lib/AliasUtils.js
+++ b/lib/AliasUtils.js
@@ -27,14 +27,19 @@ const { PathType, getType } = require("./util/path");
  * @property {string | null} wildcardSuffix substring after the single "*" in `name`, null when no wildcard
  */
 
+const EMPTY_COMPILED_OPTIONS = /** @type {CompiledAliasOption[]} */ ([]);
+
 /**
  * Precompute per-option strings used on every resolve so the hot path in
  * `aliasResolveHandler` does no string concatenation / split work per entry.
+ * Called once per plugin apply — the returned array is stable for the
+ * lifetime of the resolver.
  * @param {Resolver} resolver resolver
  * @param {AliasOption[]} options options
  * @returns {CompiledAliasOption[]} compiled options
  */
 function compileAliasOptions(resolver, options) {
+	if (options.length === 0) return EMPTY_COMPILED_OPTIONS;
 	const result = Array.from({ length: options.length });
 	for (let i = 0; i < options.length; i++) {
 		const item = options[i];
@@ -82,10 +87,9 @@ function aliasResolveHandler(
 	resolveContext,
 	callback,
 ) {
+	if (options.length === 0) return callback();
 	const innerRequest = request.request || request.path;
 	if (!innerRequest) return callback();
-
-	const hasRequest = Boolean(request.request);
 
 	forEachBail(
 		options,
@@ -96,7 +100,7 @@ function aliasResolveHandler(
 			const matchRequest =
 				innerRequest === item.name ||
 				(!item.onlyModule &&
-					(hasRequest
+					(request.request
 						? innerRequest.startsWith(item.nameWithSlash)
 						: item.absolutePath !== null &&
 							innerRequest.startsWith(item.absolutePath)));

--- a/lib/AliasUtils.js
+++ b/lib/AliasUtils.js
@@ -16,10 +16,58 @@ const { PathType, getType } = require("./util/path");
 /** @typedef {string | string[] | false} Alias */
 /** @typedef {{ alias: Alias, name: string, onlyModule?: boolean }} AliasOption */
 
+/**
+ * @typedef {object} CompiledAliasOption
+ * @property {string} name original alias name
+ * @property {string} nameWithSlash name + "/" — precomputed to avoid per-resolve concat
+ * @property {Alias} alias alias target(s)
+ * @property {boolean} onlyModule normalized onlyModule flag
+ * @property {string | null} absolutePath absolute form of `name` (with slash ending), null when not absolute
+ * @property {string | null} wildcardPrefix substring before the single "*" in `name`, null when no wildcard
+ * @property {string | null} wildcardSuffix substring after the single "*" in `name`, null when no wildcard
+ */
+
+/**
+ * Precompute per-option strings used on every resolve so the hot path in
+ * `aliasResolveHandler` does no string concatenation / split work per entry.
+ * @param {Resolver} resolver resolver
+ * @param {AliasOption[]} options options
+ * @returns {CompiledAliasOption[]} compiled options
+ */
+function compileAliasOptions(resolver, options) {
+	const result = Array.from({ length: options.length });
+	for (let i = 0; i < options.length; i++) {
+		const item = options[i];
+		const { name } = item;
+		let absolutePath = null;
+		const type = getType(name);
+		if (type === PathType.AbsolutePosix || type === PathType.AbsoluteWin) {
+			absolutePath = resolver.join(name, "_").slice(0, -1);
+		}
+		const firstStar = name.indexOf("*");
+		let wildcardPrefix = null;
+		let wildcardSuffix = null;
+		if (firstStar !== -1 && !name.includes("*", firstStar + 1)) {
+			wildcardPrefix = name.slice(0, firstStar);
+			wildcardSuffix = name.slice(firstStar + 1);
+		}
+		result[i] = {
+			name,
+			nameWithSlash: `${name}/`,
+			alias: item.alias,
+			onlyModule: Boolean(item.onlyModule),
+			absolutePath,
+			wildcardPrefix,
+			wildcardSuffix,
+		};
+	}
+	return result;
+}
+
 /** @typedef {(err?: null | Error, result?: null | ResolveRequest) => void} InnerCallback */
 /**
  * @param {Resolver} resolver resolver
- * @param {AliasOption[]} options options
+ * @param {CompiledAliasOption[]} options compiled options
  * @param {ResolveStepHook} target target
  * @param {ResolveRequest} request request
  * @param {ResolveContext} resolveContext resolve context
@@ -37,27 +85,7 @@ function aliasResolveHandler(
 	const innerRequest = request.request || request.path;
 	if (!innerRequest) return callback();
 
-	/**
-	 * @param {string} maybeAbsolutePath path
-	 * @returns {null | string} absolute path with slash ending
-	 */
-	const getAbsolutePathWithSlashEnding = (maybeAbsolutePath) => {
-		const type = getType(maybeAbsolutePath);
-		if (type === PathType.AbsolutePosix || type === PathType.AbsoluteWin) {
-			return resolver.join(maybeAbsolutePath, "_").slice(0, -1);
-		}
-		return null;
-	};
-	/**
-	 * @param {string} path path
-	 * @param {string} maybeSubPath sub path
-	 * @returns {boolean} true, if path is sub path
-	 */
-	const isSubPath = (path, maybeSubPath) => {
-		const absolutePath = getAbsolutePathWithSlashEnding(maybeSubPath);
-		if (!absolutePath) return false;
-		return path.startsWith(absolutePath);
-	};
+	const hasRequest = Boolean(request.request);
 
 	forEachBail(
 		options,
@@ -68,18 +96,12 @@ function aliasResolveHandler(
 			const matchRequest =
 				innerRequest === item.name ||
 				(!item.onlyModule &&
-					(request.request
-						? innerRequest.startsWith(`${item.name}/`)
-						: isSubPath(innerRequest, item.name)));
+					(hasRequest
+						? innerRequest.startsWith(item.nameWithSlash)
+						: item.absolutePath !== null &&
+							innerRequest.startsWith(item.absolutePath)));
 
-			// Wildcard detection via indexOf avoids allocating a split-result
-			// array on every alias check — the common `{ name, alias }` shape
-			// has no '*' at all and the split's output would be thrown away.
-			// Matches the original `split("*").length === 2` semantics: exactly
-			// one '*' required.
-			const firstStar = item.onlyModule ? -1 : item.name.indexOf("*");
-			const matchWildcard =
-				firstStar !== -1 && !item.name.includes("*", firstStar + 1);
+			const matchWildcard = !item.onlyModule && item.wildcardPrefix !== null;
 
 			if (matchRequest || matchWildcard) {
 				/**
@@ -103,23 +125,19 @@ function aliasResolveHandler(
 
 					let newRequestStr;
 
-					if (matchWildcard) {
-						// firstStar is guaranteed >= 0 here. Only slice the prefix
-						// and suffix when we actually reach the wildcard branch;
-						// the non-wildcard path (the dominant case) never needs
-						// either of these strings.
-						const prefix = item.name.slice(0, firstStar);
-						const suffix = item.name.slice(firstStar + 1);
-						if (
-							innerRequest.startsWith(prefix) &&
-							innerRequest.endsWith(suffix)
-						) {
-							const match = innerRequest.slice(
-								prefix.length,
-								innerRequest.length - suffix.length,
-							);
-							newRequestStr = alias.toString().replace("*", match);
-						}
+					if (
+						matchWildcard &&
+						innerRequest.startsWith(
+							/** @type {string} */ (item.wildcardPrefix),
+						) &&
+						innerRequest.endsWith(/** @type {string} */ (item.wildcardSuffix))
+					) {
+						const match = innerRequest.slice(
+							/** @type {string} */ (item.wildcardPrefix).length,
+							innerRequest.length -
+								/** @type {string} */ (item.wildcardSuffix).length,
+						);
+						newRequestStr = alias.toString().replace("*", match);
 					}
 
 					if (
@@ -182,3 +200,4 @@ function aliasResolveHandler(
 }
 
 module.exports.aliasResolveHandler = aliasResolveHandler;
+module.exports.compileAliasOptions = compileAliasOptions;

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -382,7 +382,7 @@ const _pathCacheByFs = new WeakMap();
 
 /**
  * @typedef {object} TsconfigPathsData
- * @property {AliasOption[]} alias tsconfig file data
+ * @property {import("./AliasUtils").CompiledAliasOption[]} alias tsconfig file data
  * @property {string[]} modules tsconfig file data
  */
 

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { aliasResolveHandler } = require("./AliasUtils");
+const { aliasResolveHandler, compileAliasOptions } = require("./AliasUtils");
 const { modulesResolveHandler } = require("./ModulesUtils");
 const { readJson } = require("./util/fs");
 const { PathType: _PathType, isSubPath, normalize } = require("./util/path");
@@ -144,7 +144,7 @@ function tsconfigPathsToResolveOptions(configDir, paths, resolver, baseUrl) {
 	}
 
 	return {
-		alias,
+		alias: compileAliasOptions(resolver, alias),
 		modules,
 	};
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -176,6 +176,42 @@ declare class CloneBasenamePlugin {
 		  >;
 	apply(resolver: Resolver): void;
 }
+declare interface CompiledAliasOption {
+	/**
+	 * original alias name
+	 */
+	name: string;
+
+	/**
+	 * name + "/" — precomputed to avoid per-resolve concat
+	 */
+	nameWithSlash: string;
+
+	/**
+	 * alias target(s)
+	 */
+	alias: Alias;
+
+	/**
+	 * normalized onlyModule flag
+	 */
+	onlyModule: boolean;
+
+	/**
+	 * absolute form of `name` (with slash ending), null when not absolute
+	 */
+	absolutePath: null | string;
+
+	/**
+	 * substring before the single "*" in `name`, null when no wildcard
+	 */
+	wildcardPrefix: null | string;
+
+	/**
+	 * substring after the single "*" in `name`, null when no wildcard
+	 */
+	wildcardSuffix: null | string;
+}
 type Context = KnownContext & Record<any, any>;
 declare interface Dirent<T extends string | Buffer = string> {
 	/**
@@ -1723,7 +1759,7 @@ declare interface TsconfigPathsData {
 	/**
 	 * tsconfig file data
 	 */
-	alias: AliasOption[];
+	alias: CompiledAliasOption[];
 
 	/**
 	 * tsconfig file data


### PR DESCRIPTION
Hoists per-option strings (nameWithSlash, absolutePath, wildcardPrefix/Suffix)
out of the hot AliasPlugin scan into AliasUtils#compileAliasOptions, invoked
once per resolver in AliasPlugin#apply (and in TsconfigPathsPlugin when a
paths map is built). The per-resolve loop then runs with no string concat,
no name.split("*"), and no resolver.join per unmatched entry - the cost that
dominated projects with hundreds of webpack aliases (see #438).

Adds two benchmark cases covering the monorepo-scale scenario:
- huge-alias-list: 300 non-matching + 8 matching aliases, match near end
- huge-alias-miss: 300 aliases + requests that never match any

Local wall-clock numbers (Node 22, tinybench):
                            before    after    delta
  huge-alias-list           225 ops   405 ops  +80%
  huge-alias-miss           453 ops   893 ops  +97%
  large-alias-list          653 ops   856 ops  +31%

https://claude.ai/code/session_01ERSdt7j3dKwd9MxNbuuXnm