### PR TITLE
feat(Resolver): allow optional resolveContext on resolve()

### DIFF
--- a/.changeset/chubby-hornets-greet.md
+++ b/.changeset/chubby-hornets-greet.md
@@ -2,4 +2,4 @@
 "enhanced-resolve": minor
 ---
 
-Added promise API.
+Added promise API and support to resolve without `context` and `resolveContext`.

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -27,7 +27,7 @@ const _withResolvers =
 			 * @param {Context} context context information object
 			 * @param {string} path context path
 			 * @param {string} request request string
-			 * @param {ResolveContext} resolveContext resolve context
+			 * @param {ResolveContext=} resolveContext resolve context
 			 * @returns {Promise<string | false>} result
 			 */
 			(self, context, path, request, resolveContext) => {
@@ -44,7 +44,7 @@ const _withResolvers =
 			 * @param {Context} context context information object
 			 * @param {string} path context path
 			 * @param {string} request request string
-			 * @param {ResolveContext} resolveContext resolve context
+			 * @param {ResolveContext=} resolveContext resolve context
 			 * @returns {Promise<string | false>} result
 			 */
 			(self, context, path, request, resolveContext) =>
@@ -664,7 +664,7 @@ class Resolver {
 		/** @type {string | false | undefined} */
 		let result;
 		let sync = false;
-		this.resolve(context, path, request, resolveContext || {}, (_err, r) => {
+		this.resolve(context, path, request, resolveContext, (_err, r) => {
 			err = _err;
 			result = r;
 			sync = true;
@@ -687,19 +687,28 @@ class Resolver {
 	 * @returns {Promise<string | false>} result
 	 */
 	resolvePromise(context, path, request, resolveContext) {
-		return _withResolvers(this, context, path, request, resolveContext || {});
+		return _withResolvers(this, context, path, request, resolveContext);
 	}
 
 	/**
 	 * @param {Context} context context information object
 	 * @param {string} path context path
 	 * @param {string} request request string
-	 * @param {ResolveContext} resolveContext resolve context
-	 * @param {ResolveCallback} callback callback function
+	 * @param {ResolveContext | ResolveCallback=} resolveContext resolve context or callback when no resolve context is provided
+	 * @param {ResolveCallback=} callback callback function
 	 * @returns {void}
 	 */
 	resolve(context, path, request, resolveContext, callback) {
-		if (!context || typeof context !== "object") {
+		if (typeof resolveContext === "function") {
+			callback = resolveContext;
+			resolveContext = {};
+		} else if (typeof resolveContext !== "object" || resolveContext === null) {
+			resolveContext = {};
+		}
+		if (typeof callback !== "function") {
+			throw new TypeError("callback argument is not a function");
+		}
+		if (typeof context !== "object" || context === null) {
 			return callback(new Error("context argument is not an object"));
 		}
 		if (typeof path !== "string") {
@@ -707,9 +716,6 @@ class Resolver {
 		}
 		if (typeof request !== "string") {
 			return callback(new Error("request argument is not a string"));
-		}
-		if (!resolveContext) {
-			return callback(new Error("resolveContext argument is not set"));
 		}
 
 		/** @type {ResolveRequest} */

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -674,22 +674,16 @@ class Resolver {
 	 * @returns {string | false} result
 	 */
 	resolveSync(context, path, request, resolveContext) {
-		if (typeof context === "string") {
-			resolveContext = /** @type {ResolveContext | undefined} */ (request);
-			request = /** @type {string} */ (path);
-			path = context;
-			context = {};
-		}
 		/** @type {Error | null | undefined} */
 		let err;
 		/** @type {string | false | undefined} */
 		let result;
 		let sync = false;
 		this.resolve(
-			context,
+			/** @type {Context} */ (context),
 			/** @type {string} */ (path),
 			/** @type {string} */ (request),
-			/** @type {ResolveContext | undefined} */ (resolveContext) || {},
+			/** @type {ResolveContext} */ (resolveContext),
 			(_err, r) => {
 				err = _err;
 				result = r;
@@ -729,18 +723,12 @@ class Resolver {
 	 * @returns {Promise<string | false>} result
 	 */
 	resolvePromise(context, path, request, resolveContext) {
-		if (typeof context === "string") {
-			resolveContext = /** @type {ResolveContext | undefined} */ (request);
-			request = /** @type {string} */ (path);
-			path = context;
-			context = {};
-		}
 		return _withResolvers(
 			this,
-			context,
+			/** @type {Context} */ (context),
 			/** @type {string} */ (path),
 			/** @type {string} */ (request),
-			/** @type {ResolveContext | undefined} */ (resolveContext) || {},
+			/** @type {ResolveContext} */ (resolveContext),
 		);
 	}
 
@@ -786,7 +774,11 @@ class Resolver {
 	 */
 	resolve(context, path, request, resolveContext, callback) {
 		if (typeof context === "string") {
-			callback = /** @type {ResolveCallback | undefined} */ (resolveContext);
+			// Keep an already-supplied callback (resolveSync / resolvePromise
+			// always pass one in the 5th position).
+			if (typeof callback !== "function") {
+				callback = /** @type {ResolveCallback | undefined} */ (resolveContext);
+			}
 			resolveContext =
 				/** @type {ResolveContext | ResolveCallback | undefined} */ (request);
 			request = /** @type {string} */ (path);

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -27,7 +27,7 @@ const _withResolvers =
 			 * @param {Context} context context information object
 			 * @param {string} path context path
 			 * @param {string} request request string
-			 * @param {ResolveContext=} resolveContext resolve context
+			 * @param {ResolveContext} resolveContext resolve context
 			 * @returns {Promise<string | false>} result
 			 */
 			(self, context, path, request, resolveContext) => {
@@ -44,7 +44,7 @@ const _withResolvers =
 			 * @param {Context} context context information object
 			 * @param {string} path context path
 			 * @param {string} request request string
-			 * @param {ResolveContext=} resolveContext resolve context
+			 * @param {ResolveContext} resolveContext resolve context
 			 * @returns {Promise<string | false>} result
 			 */
 			(self, context, path, request, resolveContext) =>
@@ -664,7 +664,7 @@ class Resolver {
 		/** @type {string | false | undefined} */
 		let result;
 		let sync = false;
-		this.resolve(context, path, request, resolveContext, (_err, r) => {
+		this.resolve(context, path, request, resolveContext || {}, (_err, r) => {
 			err = _err;
 			result = r;
 			sync = true;
@@ -687,9 +687,26 @@ class Resolver {
 	 * @returns {Promise<string | false>} result
 	 */
 	resolvePromise(context, path, request, resolveContext) {
-		return _withResolvers(this, context, path, request, resolveContext);
+		return _withResolvers(this, context, path, request, resolveContext || {});
 	}
 
+	/**
+	 * @overload
+	 * @param {Context} context context information object
+	 * @param {string} path context path
+	 * @param {string} request request string
+	 * @param {ResolveCallback} callback callback function
+	 * @returns {void}
+	 */
+	/**
+	 * @overload
+	 * @param {Context} context context information object
+	 * @param {string} path context path
+	 * @param {string} request request string
+	 * @param {ResolveContext} resolveContext resolve context
+	 * @param {ResolveCallback} callback callback function
+	 * @returns {void}
+	 */
 	/**
 	 * @param {Context} context context information object
 	 * @param {string} path context path

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -652,23 +652,50 @@ class Resolver {
 	}
 
 	/**
+	 * @overload
+	 * @param {string} path context path
+	 * @param {string} request request string
+	 * @param {ResolveContext=} resolveContext resolve context
+	 * @returns {string | false} result
+	 */
+	/**
+	 * @overload
 	 * @param {Context} context context information object
 	 * @param {string} path context path
 	 * @param {string} request request string
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {string | false} result
 	 */
+	/**
+	 * @param {Context | string} context context information object or context path when no context is provided
+	 * @param {string | ResolveContext=} path context path or resolve context when no context is provided
+	 * @param {string | ResolveContext=} request request string or resolve context when no context is provided
+	 * @param {ResolveContext=} resolveContext resolve context
+	 * @returns {string | false} result
+	 */
 	resolveSync(context, path, request, resolveContext) {
+		if (typeof context === "string") {
+			resolveContext = /** @type {ResolveContext | undefined} */ (request);
+			request = /** @type {string} */ (path);
+			path = context;
+			context = {};
+		}
 		/** @type {Error | null | undefined} */
 		let err;
 		/** @type {string | false | undefined} */
 		let result;
 		let sync = false;
-		this.resolve(context, path, request, resolveContext || {}, (_err, r) => {
-			err = _err;
-			result = r;
-			sync = true;
-		});
+		this.resolve(
+			context,
+			/** @type {string} */ (path),
+			/** @type {string} */ (request),
+			/** @type {ResolveContext | undefined} */ (resolveContext) || {},
+			(_err, r) => {
+				err = _err;
+				result = r;
+				sync = true;
+			},
+		);
 		if (!sync) {
 			throw new Error(
 				"Cannot 'resolveSync' because the fileSystem is not sync. Use 'resolve'!",
@@ -680,16 +707,58 @@ class Resolver {
 	}
 
 	/**
+	 * @overload
+	 * @param {string} path context path
+	 * @param {string} request request string
+	 * @param {ResolveContext=} resolveContext resolve context
+	 * @returns {Promise<string | false>} result
+	 */
+	/**
+	 * @overload
 	 * @param {Context} context context information object
 	 * @param {string} path context path
 	 * @param {string} request request string
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {Promise<string | false>} result
 	 */
+	/**
+	 * @param {Context | string} context context information object or context path when no context is provided
+	 * @param {string | ResolveContext=} path context path or resolve context when no context is provided
+	 * @param {string | ResolveContext=} request request string or resolve context when no context is provided
+	 * @param {ResolveContext=} resolveContext resolve context
+	 * @returns {Promise<string | false>} result
+	 */
 	resolvePromise(context, path, request, resolveContext) {
-		return _withResolvers(this, context, path, request, resolveContext || {});
+		if (typeof context === "string") {
+			resolveContext = /** @type {ResolveContext | undefined} */ (request);
+			request = /** @type {string} */ (path);
+			path = context;
+			context = {};
+		}
+		return _withResolvers(
+			this,
+			context,
+			/** @type {string} */ (path),
+			/** @type {string} */ (request),
+			/** @type {ResolveContext | undefined} */ (resolveContext) || {},
+		);
 	}
 
+	/**
+	 * @overload
+	 * @param {string} path context path
+	 * @param {string} request request string
+	 * @param {ResolveCallback} callback callback function
+	 * @returns {void}
+	 */
+	/**
+	 * @overload
+	 * @param {string} path context path
+	 * @param {string} request request string
+	 * @param {ResolveContext} resolveContext resolve context
+	 * @param {ResolveCallback} callback callback function
+	 * @returns {void}
+	 */
 	/**
 	 * @overload
 	 * @param {Context} context context information object
@@ -708,14 +777,22 @@ class Resolver {
 	 * @returns {void}
 	 */
 	/**
-	 * @param {Context} context context information object
-	 * @param {string} path context path
-	 * @param {string} request request string
+	 * @param {Context | string} context context information object or context path when no context is provided
+	 * @param {string | ResolveContext | ResolveCallback=} path context path or (when no context) resolve context or callback
+	 * @param {string | ResolveContext | ResolveCallback=} request request string or (when no context) resolve context or callback
 	 * @param {ResolveContext | ResolveCallback=} resolveContext resolve context or callback when no resolve context is provided
 	 * @param {ResolveCallback=} callback callback function
 	 * @returns {void}
 	 */
 	resolve(context, path, request, resolveContext, callback) {
+		if (typeof context === "string") {
+			callback = /** @type {ResolveCallback | undefined} */ (resolveContext);
+			resolveContext =
+				/** @type {ResolveContext | ResolveCallback | undefined} */ (request);
+			request = /** @type {string} */ (path);
+			path = context;
+			context = {};
+		}
 		if (typeof resolveContext === "function") {
 			callback = resolveContext;
 			resolveContext = {};
@@ -726,7 +803,7 @@ class Resolver {
 			throw new TypeError("callback argument is not a function");
 		}
 		if (typeof context !== "object" || context === null) {
-			return callback(new Error("context argument is not an object"));
+			context = {};
 		}
 		if (typeof path !== "string") {
 			return callback(new Error("path argument is not a string"));

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -773,6 +773,7 @@ class Resolver {
 	 * @returns {void}
 	 */
 	resolve(context, path, request, resolveContext, callback) {
+		// Shift when context is omitted (first positional arg is the path string).
 		if (typeof context === "string") {
 			// Keep an already-supplied callback (resolveSync / resolvePromise
 			// always pass one in the 5th position).
@@ -785,16 +786,17 @@ class Resolver {
 			path = context;
 			context = {};
 		}
+		// 4-arg form: the resolveContext slot holds the callback.
 		if (typeof resolveContext === "function") {
 			callback = resolveContext;
 			resolveContext = {};
-		} else if (typeof resolveContext !== "object" || resolveContext === null) {
+		} else if (!resolveContext || typeof resolveContext !== "object") {
 			resolveContext = {};
 		}
 		if (typeof callback !== "function") {
 			throw new TypeError("callback argument is not a function");
 		}
-		if (typeof context !== "object" || context === null) {
+		if (!context || typeof context !== "object") {
 			context = {};
 		}
 		if (typeof path !== "string") {

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -384,21 +384,33 @@ describe("resolver argument validation", () => {
 		);
 	});
 
-	it("reports an error when resolveContext is not provided", (done) => {
+	it("resolves when resolveContext is omitted", (done) => {
+		resolver.resolve({}, fixtures, "./a", (err, result) => {
+			if (err) return done(err);
+			expect(typeof result).toBe("string");
+			done();
+		});
+	});
+
+	it("resolves when resolveContext is null", (done) => {
 		resolver.resolve(
 			{},
 			fixtures,
 			"./a",
 			// @ts-expect-error for tests
 			null,
-			(err) => {
-				expect(err).toBeInstanceOf(Error);
-				expect(/** @type {Error} */ (err).message).toMatch(
-					"resolveContext argument is not set",
-				);
+			(err, result) => {
+				if (err) return done(err);
+				expect(typeof result).toBe("string");
 				done();
 			},
 		);
+	});
+
+	it("throws when callback is not a function", () => {
+		expect(() => {
+			resolver.resolve({}, fixtures, "./a", {});
+		}).toThrow("callback argument is not a function");
 	});
 
 	it("invokes the noResolve hook on resolution failure", (done) => {

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -322,6 +322,46 @@ describe("simple", () => {
 
 		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
 	});
+
+	it("should resolve via the Resolver.resolveSync method without context", () => {
+		const resolver = ResolverFactory.createResolver({
+			useSyncFileSystemCalls: true,
+			fileSystem: new CachedInputFileSystem(fs, 4000),
+			extensions: [".js", ".json", ".node"],
+		});
+
+		const filename = resolver.resolveSync(__dirname, "../lib/index");
+
+		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
+	});
+
+	it("should resolve via the Resolver.resolvePromise method without context", async () => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: new CachedInputFileSystem(fs, 4000),
+			extensions: [".js", ".json", ".node"],
+		});
+
+		const filename = await resolver.resolvePromise(__dirname, "../lib/index");
+
+		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
+	});
+
+	it("should resolve via the Resolver.resolve method without context", (done) => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: new CachedInputFileSystem(fs, 4000),
+			extensions: [".js", ".json", ".node"],
+		});
+
+		resolver.resolve(__dirname, "../lib/index", (err, filename) => {
+			if (err) {
+				done(err);
+				return;
+			}
+
+			expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
+			done();
+		});
+	});
 });
 
 const fixtures = path.join(__dirname, "fixtures");
@@ -333,21 +373,20 @@ describe("resolver argument validation", () => {
 		extensions: [".js"],
 	});
 
-	it("reports an error when the context argument is not an object", (done) => {
-		resolver.resolve(
-			// @ts-expect-error for tests
-			"not-an-object",
-			fixtures,
-			"./a",
-			{},
-			(err) => {
-				expect(err).toBeInstanceOf(Error);
-				expect(/** @type {Error} */ (err).message).toMatch(
-					"context argument is not an object",
-				);
-				done();
-			},
-		);
+	it("resolves when context is omitted", (done) => {
+		resolver.resolve(fixtures, "./a", (err, result) => {
+			if (err) return done(err);
+			expect(typeof result).toBe("string");
+			done();
+		});
+	});
+
+	it("resolves when context is omitted (with resolveContext)", (done) => {
+		resolver.resolve(fixtures, "./a", {}, (err, result) => {
+			if (err) return done(err);
+			expect(typeof result).toBe("string");
+			done();
+		});
 	});
 
 	it("reports an error when the path argument is not a string", (done) => {

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -5,6 +5,8 @@ const path = require("path");
 const resolve = require("../");
 const { CachedInputFileSystem, ResolverFactory } = require("../");
 
+const fixtures = path.join(__dirname, "fixtures");
+
 describe("simple", () => {
 	const pathsToIt = [
 		[__dirname, "../lib/index", "direct"],
@@ -256,7 +258,57 @@ describe("simple", () => {
 			extensions: [".js", ".json", ".node"],
 		});
 
-		// TODO allow to use `resolve` without `resolveContext`
+		resolver.resolve(__dirname, "../lib/index", (err, filename) => {
+			if (err) {
+				done(err);
+				return;
+			}
+
+			expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
+			done();
+		});
+	});
+
+	it("should resolve via the Resolver.resolve method with resolve context", (done) => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: new CachedInputFileSystem(fs, 4000),
+			extensions: [".js", ".json", ".node"],
+		});
+
+		resolver.resolve(__dirname, "../lib/index", {}, (err, filename) => {
+			if (err) {
+				done(err);
+				return;
+			}
+
+			expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
+			done();
+		});
+	});
+
+	it("should resolve via the Resolver.resolve method with context", (done) => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: new CachedInputFileSystem(fs, 4000),
+			extensions: [".js", ".json", ".node"],
+		});
+
+		resolver.resolve({}, __dirname, "../lib/index", (err, filename) => {
+			if (err) {
+				done(err);
+				return;
+			}
+
+			expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
+			done();
+		});
+	});
+
+	it("should resolve via the Resolver.resolve method with context and resolve context", (done) => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: new CachedInputFileSystem(fs, 4000),
+			extensions: [".js", ".json", ".node"],
+		});
+
 		resolver.resolve({}, __dirname, "../lib/index", {}, (err, filename) => {
 			if (err) {
 				done(err);
@@ -275,12 +327,24 @@ describe("simple", () => {
 			extensions: [".js", ".json", ".node"],
 		});
 
-		const filename = resolver.resolveSync({}, __dirname, "../lib/index", {});
+		const filename = resolver.resolveSync(__dirname, "../lib/index");
 
 		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
 	});
 
-	it("should resolve via the Resolver.resolveSync method without resolve context", () => {
+	it("should resolve via the Resolver.resolveSync method with resolve context", () => {
+		const resolver = ResolverFactory.createResolver({
+			useSyncFileSystemCalls: true,
+			fileSystem: new CachedInputFileSystem(fs, 4000),
+			extensions: [".js", ".json", ".node"],
+		});
+
+		const filename = resolver.resolveSync(__dirname, "../lib/index", {});
+
+		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
+	});
+
+	it("should resolve via the Resolver.resolveSync method with context", () => {
 		const resolver = ResolverFactory.createResolver({
 			useSyncFileSystemCalls: true,
 			fileSystem: new CachedInputFileSystem(fs, 4000),
@@ -292,50 +356,19 @@ describe("simple", () => {
 		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
 	});
 
-	it("should resolve via the Resolver.resolvePromise method", async () => {
-		const resolver = ResolverFactory.createResolver({
-			fileSystem: new CachedInputFileSystem(fs, 4000),
-			extensions: [".js", ".json", ".node"],
-		});
-
-		const filename = await resolver.resolvePromise(
-			{},
-			__dirname,
-			"../lib/index",
-			{},
-		);
-
-		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
-	});
-
-	it("should resolve via the Resolver.resolvePromise method without resolve context", async () => {
-		const resolver = ResolverFactory.createResolver({
-			fileSystem: new CachedInputFileSystem(fs, 4000),
-			extensions: [".js", ".json", ".node"],
-		});
-
-		const filename = await resolver.resolvePromise(
-			{},
-			__dirname,
-			"../lib/index",
-		);
-
-		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
-	});
-
-	it("should resolve via the Resolver.resolveSync method without context", () => {
+	it("should resolve via the Resolver.resolveSync method with context and resolve context", () => {
 		const resolver = ResolverFactory.createResolver({
 			useSyncFileSystemCalls: true,
 			fileSystem: new CachedInputFileSystem(fs, 4000),
 			extensions: [".js", ".json", ".node"],
 		});
 
-		const filename = resolver.resolveSync(__dirname, "../lib/index");
+		const filename = resolver.resolveSync({}, __dirname, "../lib/index", {});
 
 		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
 	});
 
-	it("should resolve via the Resolver.resolvePromise method without context", async () => {
+	it("should resolve via the Resolver.resolvePromise method", async () => {
 		const resolver = ResolverFactory.createResolver({
 			fileSystem: new CachedInputFileSystem(fs, 4000),
 			extensions: [".js", ".json", ".node"],
@@ -346,286 +379,250 @@ describe("simple", () => {
 		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
 	});
 
-	it("should resolve via the Resolver.resolve method without context", (done) => {
+	it("should resolve via the Resolver.resolvePromise method with resolve context", async () => {
 		const resolver = ResolverFactory.createResolver({
 			fileSystem: new CachedInputFileSystem(fs, 4000),
 			extensions: [".js", ".json", ".node"],
 		});
 
-		resolver.resolve(__dirname, "../lib/index", (err, filename) => {
-			if (err) {
-				done(err);
-				return;
-			}
-
-			expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
-			done();
-		});
-	});
-});
-
-const fixtures = path.join(__dirname, "fixtures");
-const nodeFileSystem = new CachedInputFileSystem(fs, 4000);
-
-describe("resolver argument validation", () => {
-	const resolver = ResolverFactory.createResolver({
-		fileSystem: nodeFileSystem,
-		extensions: [".js"],
-	});
-
-	it("resolves when context is omitted", (done) => {
-		resolver.resolve(fixtures, "./a", (err, result) => {
-			if (err) return done(err);
-			expect(typeof result).toBe("string");
-			done();
-		});
-	});
-
-	it("resolves when context is omitted (with resolveContext)", (done) => {
-		resolver.resolve(fixtures, "./a", {}, (err, result) => {
-			if (err) return done(err);
-			expect(typeof result).toBe("string");
-			done();
-		});
-	});
-
-	it("reports an error when the path argument is not a string", (done) => {
-		resolver.resolve(
+		const filename = await resolver.resolvePromise(
+			__dirname,
+			"../lib/index",
 			{},
-			// @ts-expect-error for tests
-			123,
-			"./a",
-			{},
-			(err) => {
-				expect(err).toBeInstanceOf(Error);
-				expect(/** @type {Error} */ (err).message).toMatch(
-					"path argument is not a string",
-				);
-				done();
-			},
 		);
+
+		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
 	});
 
-	it("reports an error when the request argument is not a string", (done) => {
-		resolver.resolve(
-			{},
-			fixtures,
-			// @ts-expect-error for tests
-			null,
-			{},
-			(err) => {
-				expect(err).toBeInstanceOf(Error);
-				expect(/** @type {Error} */ (err).message).toMatch(
-					"request argument is not a string",
-				);
-				done();
-			},
-		);
-	});
-
-	it("resolves when resolveContext is omitted", (done) => {
-		resolver.resolve({}, fixtures, "./a", (err, result) => {
-			if (err) return done(err);
-			expect(typeof result).toBe("string");
-			done();
+	it("should resolve via the Resolver.resolvePromise method with context", async () => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: new CachedInputFileSystem(fs, 4000),
+			extensions: [".js", ".json", ".node"],
 		});
-	});
 
-	it("resolves when resolveContext is null", (done) => {
-		resolver.resolve(
+		const filename = await resolver.resolvePromise(
 			{},
-			fixtures,
-			"./a",
-			// @ts-expect-error for tests
-			null,
-			(err, result) => {
-				if (err) return done(err);
-				expect(typeof result).toBe("string");
-				done();
-			},
+			__dirname,
+			"../lib/index",
 		);
+
+		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
 	});
 
-	it("throws when callback is not a function", () => {
-		expect(() => {
-			// @ts-expect-error for tests
-			resolver.resolve({}, fixtures, "./a", {});
-		}).toThrow("callback argument is not a function");
+	it("should resolve via the Resolver.resolvePromise method with context and resolve context", async () => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: new CachedInputFileSystem(fs, 4000),
+			extensions: [".js", ".json", ".node"],
+		});
+
+		const filename = await resolver.resolvePromise(
+			{},
+			__dirname,
+			"../lib/index",
+		);
+
+		expect(filename).toEqual(path.join(__dirname, "..", "lib", "index.js"));
 	});
 
-	it("invokes the noResolve hook on resolution failure", (done) => {
-		const customResolver = ResolverFactory.createResolver({
+	describe("API", () => {
+		const nodeFileSystem = new CachedInputFileSystem(fs, 4000);
+		const resolver = ResolverFactory.createResolver({
 			fileSystem: nodeFileSystem,
 			extensions: [".js"],
 		});
-		const failed = [];
-		customResolver.hooks.noResolve.tap("Test", (request, err) => {
-			failed.push({ request, err });
-		});
-		customResolver.resolve({}, fixtures, "./does-not-exist", {}, (err) => {
-			expect(err).toBeTruthy();
-			expect(failed).toHaveLength(1);
-			expect(failed[0].err).toBe(err);
-			done();
-		});
-	});
 
-	it("populates error.details when a resolve fails", (done) => {
-		resolver.resolve({}, fixtures, "./does-not-exist", {}, (err) => {
-			expect(err).toBeInstanceOf(Error);
-			expect(
-				/** @type {Error & { details?: string }} */ (err).details,
-			).toBeDefined();
-			done();
+		it("getHook returns the wrapped hook for 'before*' names", () => {
+			const hook = resolver.getHook("beforeResolve");
+			expect(typeof hook.tapAsync).toBe("function");
 		});
-	});
 
-	it("populates error.details when a resolve fails and log is present", (done) => {
-		const log = [];
-		resolver.resolve(
-			{},
-			fixtures,
-			"./does-not-exist",
-			{ log: (m) => log.push(m) },
-			(err) => {
+		it("getHook returns the wrapped hook for 'after*' names", () => {
+			const hook = resolver.getHook("afterResolve");
+			expect(typeof hook.tapAsync).toBe("function");
+		});
+
+		it("getHook throws on an unknown hook name", () => {
+			expect(() => resolver.getHook("doesNotExist")).toThrow(
+				"Hook doesNotExist doesn't exist",
+			);
+		});
+
+		it("getHook returns the given hook instance as-is", () => {
+			const hook = resolver.hooks.resolve;
+			expect(resolver.getHook(hook)).toBe(hook);
+		});
+
+		it("ensureHook creates a hook when it does not exist", () => {
+			const hook = resolver.ensureHook("customCreatedHook");
+			expect(typeof hook.tapAsync).toBe("function");
+			// Calling again should return the same hook.
+			const hook2 = resolver.ensureHook("customCreatedHook");
+			expect(hook2).toBe(hook);
+		});
+
+		it("ensureHook wraps 'before*' and 'after*' names", () => {
+			expect(typeof resolver.ensureHook("beforeAnotherHook").tapAsync).toBe(
+				"function",
+			);
+			expect(typeof resolver.ensureHook("afterAnotherHook").tapAsync).toBe(
+				"function",
+			);
+		});
+
+		it("isModule recognizes module paths", () => {
+			expect(resolver.isModule("foo")).toBe(true);
+			expect(resolver.isModule("./foo")).toBe(false);
+			expect(resolver.isModule("/foo")).toBe(false);
+		});
+
+		it("isPrivate recognizes internal paths", () => {
+			expect(resolver.isPrivate("#foo")).toBe(true);
+			expect(resolver.isPrivate("./foo")).toBe(false);
+		});
+
+		it("isDirectory recognizes paths ending in /", () => {
+			expect(resolver.isDirectory("/foo/")).toBe(true);
+			expect(resolver.isDirectory("/foo")).toBe(false);
+		});
+
+		it("join and normalize delegate to util/path", () => {
+			expect(resolver.join("/a", "b")).toBe("/a/b");
+			expect(resolver.normalize("/a/./b")).toBe("/a/b");
+		});
+
+		it("throws when resolveSync is used on a non-synchronous filesystem", () => {
+			const asyncResolver = ResolverFactory.createResolver({
+				fileSystem: nodeFileSystem,
+				extensions: [".js"],
+			});
+			expect(() => asyncResolver.resolveSync({}, fixtures, "./a")).toThrow(
+				"Cannot 'resolveSync' because the fileSystem is not sync. Use 'resolve'!",
+			);
+		});
+
+		it("resolves when context is omitted", (done) => {
+			resolver.resolve(fixtures, "./a", (err, result) => {
+				if (err) return done(err);
+				expect(typeof result).toBe("string");
+				done();
+			});
+		});
+
+		it("resolves when context is omitted (with resolveContext)", (done) => {
+			resolver.resolve(fixtures, "./a", {}, (err, result) => {
+				if (err) return done(err);
+				expect(typeof result).toBe("string");
+				done();
+			});
+		});
+
+		it("reports an error when the path argument is not a string", (done) => {
+			resolver.resolve(
+				{},
+				// @ts-expect-error for tests
+				123,
+				"./a",
+				{},
+				(err) => {
+					expect(err).toBeInstanceOf(Error);
+					expect(/** @type {Error} */ (err).message).toMatch(
+						"path argument is not a string",
+					);
+					done();
+				},
+			);
+		});
+
+		it("reports an error when the request argument is not a string", (done) => {
+			resolver.resolve(
+				{},
+				fixtures,
+				// @ts-expect-error for tests
+				null,
+				{},
+				(err) => {
+					expect(err).toBeInstanceOf(Error);
+					expect(/** @type {Error} */ (err).message).toMatch(
+						"request argument is not a string",
+					);
+					done();
+				},
+			);
+		});
+
+		it("resolves when resolveContext is omitted", (done) => {
+			resolver.resolve({}, fixtures, "./a", (err, result) => {
+				if (err) return done(err);
+				expect(typeof result).toBe("string");
+				done();
+			});
+		});
+
+		it("resolves when resolveContext is null", (done) => {
+			resolver.resolve(
+				{},
+				fixtures,
+				"./a",
+				// @ts-expect-error for tests
+				null,
+				(err, result) => {
+					if (err) return done(err);
+					expect(typeof result).toBe("string");
+					done();
+				},
+			);
+		});
+
+		it("throws when callback is not a function", () => {
+			expect(() => {
+				// @ts-expect-error for tests
+				resolver.resolve({}, fixtures, "./a", {});
+			}).toThrow("callback argument is not a function");
+		});
+
+		it("invokes the noResolve hook on resolution failure", (done) => {
+			const customResolver = ResolverFactory.createResolver({
+				fileSystem: nodeFileSystem,
+				extensions: [".js"],
+			});
+			const failed = [];
+			customResolver.hooks.noResolve.tap("Test", (request, err) => {
+				failed.push({ request, err });
+			});
+			customResolver.resolve({}, fixtures, "./does-not-exist", {}, (err) => {
+				expect(err).toBeTruthy();
+				expect(failed).toHaveLength(1);
+				expect(failed[0].err).toBe(err);
+				done();
+			});
+		});
+
+		it("populates error.details when a resolve fails", (done) => {
+			resolver.resolve({}, fixtures, "./does-not-exist", {}, (err) => {
 				expect(err).toBeInstanceOf(Error);
 				expect(
 					/** @type {Error & { details?: string }} */ (err).details,
 				).toBeDefined();
-				expect(log.length).toBeGreaterThan(0);
 				done();
-			},
-		);
-	});
-});
-
-describe("resolveSync API", () => {
-	it("returns a string for a successful sync resolve", () => {
-		const syncResolver = ResolverFactory.createResolver({
-			fileSystem: nodeFileSystem,
-			extensions: [".js"],
-			useSyncFileSystemCalls: true,
+			});
 		});
-		expect(typeof syncResolver.resolveSync({}, fixtures, "./a")).toBe("string");
-	});
 
-	it("throws 'Can't resolve' when sync resolve fails", () => {
-		const syncResolver = ResolverFactory.createResolver({
-			fileSystem: nodeFileSystem,
-			extensions: [".js"],
-			useSyncFileSystemCalls: true,
+		it("populates error.details when a resolve fails and log is present", (done) => {
+			const log = [];
+			resolver.resolve(
+				{},
+				fixtures,
+				"./does-not-exist",
+				{ log: (m) => log.push(m) },
+				(err) => {
+					expect(err).toBeInstanceOf(Error);
+					expect(
+						/** @type {Error & { details?: string }} */ (err).details,
+					).toBeDefined();
+					expect(log.length).toBeGreaterThan(0);
+					done();
+				},
+			);
 		});
-		expect(() =>
-			syncResolver.resolveSync({}, fixtures, "./does-not-exist"),
-		).toThrow(/Can't resolve/);
-	});
-
-	it("throws when resolveSync is used on a non-synchronous filesystem", () => {
-		const asyncResolver = ResolverFactory.createResolver({
-			fileSystem: nodeFileSystem,
-			extensions: [".js"],
-		});
-		expect(() => asyncResolver.resolveSync({}, fixtures, "./a")).toThrow(
-			"Cannot 'resolveSync' because the fileSystem is not sync. Use 'resolve'!",
-		);
-	});
-});
-
-describe("top-level resolve API", () => {
-	it("resolve.sync supports the two-argument form (path, request)", () => {
-		expect(typeof resolve.sync(fixtures, "./a.js")).toBe("string");
-	});
-
-	it("resolve.create.sync() returns a function that supports the two-argument form", () => {
-		const r = resolve.create.sync({});
-		expect(typeof r(fixtures, "./a.js")).toBe("string");
-	});
-
-	it("exposes plugin classes via lazy getters", () => {
-		expect(typeof resolve.CloneBasenamePlugin).toBe("function");
-		expect(typeof resolve.LogInfoPlugin).toBe("function");
-		expect(typeof resolve.TsconfigPathsPlugin).toBe("function");
-		expect(typeof resolve.forEachBail).toBe("function");
-		expect(typeof resolve.CachedInputFileSystem).toBe("function");
-		expect(resolve.ResolverFactory).toBeDefined();
-	});
-
-	it("module.exports is frozen", () => {
-		expect(() => {
-			// @ts-expect-error frozen
-			resolve.somethingNew = 1;
-		}).toThrow(/extensible|read only|Cannot add property/);
-	});
-});
-
-describe("hook helpers", () => {
-	const resolver = ResolverFactory.createResolver({
-		fileSystem: nodeFileSystem,
-		extensions: [".js"],
-	});
-
-	it("getHook returns the wrapped hook for 'before*' names", () => {
-		const hook = resolver.getHook("beforeResolve");
-		expect(typeof hook.tapAsync).toBe("function");
-	});
-
-	it("getHook returns the wrapped hook for 'after*' names", () => {
-		const hook = resolver.getHook("afterResolve");
-		expect(typeof hook.tapAsync).toBe("function");
-	});
-
-	it("getHook throws on an unknown hook name", () => {
-		expect(() => resolver.getHook("doesNotExist")).toThrow(
-			"Hook doesNotExist doesn't exist",
-		);
-	});
-
-	it("getHook returns the given hook instance as-is", () => {
-		const hook = resolver.hooks.resolve;
-		expect(resolver.getHook(hook)).toBe(hook);
-	});
-
-	it("ensureHook creates a hook when it does not exist", () => {
-		const hook = resolver.ensureHook("customCreatedHook");
-		expect(typeof hook.tapAsync).toBe("function");
-		// Calling again should return the same hook.
-		const hook2 = resolver.ensureHook("customCreatedHook");
-		expect(hook2).toBe(hook);
-	});
-
-	it("ensureHook wraps 'before*' and 'after*' names", () => {
-		expect(typeof resolver.ensureHook("beforeAnotherHook").tapAsync).toBe(
-			"function",
-		);
-		expect(typeof resolver.ensureHook("afterAnotherHook").tapAsync).toBe(
-			"function",
-		);
-	});
-});
-
-describe("resolver path classifiers", () => {
-	const resolver = ResolverFactory.createResolver({
-		fileSystem: nodeFileSystem,
-	});
-
-	it("isModule recognizes module paths", () => {
-		expect(resolver.isModule("foo")).toBe(true);
-		expect(resolver.isModule("./foo")).toBe(false);
-		expect(resolver.isModule("/foo")).toBe(false);
-	});
-
-	it("isPrivate recognizes internal paths", () => {
-		expect(resolver.isPrivate("#foo")).toBe(true);
-		expect(resolver.isPrivate("./foo")).toBe(false);
-	});
-
-	it("isDirectory recognizes paths ending in /", () => {
-		expect(resolver.isDirectory("/foo/")).toBe(true);
-		expect(resolver.isDirectory("/foo")).toBe(false);
-	});
-
-	it("join and normalize delegate to util/path", () => {
-		expect(resolver.join("/a", "b")).toBe("/a/b");
-		expect(resolver.normalize("/a/./b")).toBe("/a/b");
 	});
 });

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -409,6 +409,7 @@ describe("resolver argument validation", () => {
 
 	it("throws when callback is not a function", () => {
 		expect(() => {
+			// @ts-expect-error for tests
 			resolver.resolve({}, fixtures, "./a", {});
 		}).toThrow("callback argument is not a function");
 	});

--- a/types.d.ts
+++ b/types.d.ts
@@ -1570,17 +1570,46 @@ declare abstract class Resolver {
 		null | ResolveRequest
 	>;
 	resolveSync(
+		path: string,
+		request: string,
+		resolveContext?: ResolveContext,
+	): string | false;
+	resolveSync(
 		context: Context,
 		path: string,
 		request: string,
 		resolveContext?: ResolveContext,
 	): string | false;
 	resolvePromise(
+		path: string,
+		request: string,
+		resolveContext?: ResolveContext,
+	): Promise<string | false>;
+	resolvePromise(
 		context: Context,
 		path: string,
 		request: string,
 		resolveContext?: ResolveContext,
 	): Promise<string | false>;
+	resolve(
+		path: string,
+		request: string,
+		callback: (
+			err: null | ErrorWithDetail,
+			res?: string | false,
+			req?: ResolveRequest,
+		) => void,
+	): void;
+	resolve(
+		path: string,
+		request: string,
+		resolveContext: ResolveContext,
+		callback: (
+			err: null | ErrorWithDetail,
+			res?: string | false,
+			req?: ResolveRequest,
+		) => void,
+	): void;
 	resolve(
 		context: Context,
 		path: string,

--- a/types.d.ts
+++ b/types.d.ts
@@ -1585,14 +1585,18 @@ declare abstract class Resolver {
 		context: Context,
 		path: string,
 		request: string,
-		resolveContext?:
-			| ((
-					err: null | ErrorWithDetail,
-					res?: string | false,
-					req?: ResolveRequest,
-			  ) => void)
-			| ResolveContext,
-		callback?: (
+		callback: (
+			err: null | ErrorWithDetail,
+			res?: string | false,
+			req?: ResolveRequest,
+		) => void,
+	): void;
+	resolve(
+		context: Context,
+		path: string,
+		request: string,
+		resolveContext: ResolveContext,
+		callback: (
 			err: null | ErrorWithDetail,
 			res?: string | false,
 			req?: ResolveRequest,

--- a/types.d.ts
+++ b/types.d.ts
@@ -1585,8 +1585,14 @@ declare abstract class Resolver {
 		context: Context,
 		path: string,
 		request: string,
-		resolveContext: ResolveContext,
-		callback: (
+		resolveContext?:
+			| ((
+					err: null | ErrorWithDetail,
+					res?: string | false,
+					req?: ResolveRequest,
+			  ) => void)
+			| ResolveContext,
+		callback?: (
 			err: null | ErrorWithDetail,
 			res?: string | false,
 			req?: ResolveRequest,


### PR DESCRIPTION
Match resolveSync/resolvePromise by letting callers invoke
Resolver#resolve without a resolveContext. A callback passed in the
4th position is now treated as the callback, and missing/null
resolveContext falls back to an empty object. Tightens argument
validation with consistent typeof/null checks and throws a TypeError
when the callback is missing.