### PR TITLE
fix(Resolver): propagate legacy Set<string> stack through the chain

### DIFF
--- a/.changeset/perf-stack-entry-linked-list.md
+++ b/.changeset/perf-stack-entry-linked-list.md
@@ -2,13 +2,6 @@
 "enhanced-resolve": patch
 ---
 
-Replace the `Set<string>`-based resolver stack with a singly-linked `StackEntry` class that exposes a Set-compatible API (`has`, iteration, `size`, `toString`).
+Replace the `Set<string>`-based resolver stack with a singly-linked `StackEntry` class that exposes a Set-compatible API.
 
 Each `doResolve` call now prepends a single linked-list node instead of cloning the entire Set, making stack push O(1) in time and memory. Recursion detection walks the linked list (O(n)), but because the stack is typically shallow this is much cheaper than cloning a Set per call.
-
-Because `StackEntry` implements the Set methods consumers use in practice, `resolveContext.stack` remains a drop-in replacement — existing callers that iterate or call `.has()` keep working.
-
-Benchmarks on the local suite:
-
-- `pathological-deep-stack` (50-level alias chain): +57%
-- `realistic-midsize` warm cache: +16%

--- a/.changeset/perf-stack-set-backcompat.md
+++ b/.changeset/perf-stack-set-backcompat.md
@@ -1,0 +1,7 @@
+---
+"enhanced-resolve": patch
+---
+
+Restore full back-compat with callers that pass `resolveContext.stack: new Set<string>()` (the pre-5505bb2 shape).
+
+The linked-list `StackEntry` change kept a partial fallback in `doResolve` but only matched pre-seeded Set entries at the first call and polluted the linked-list iteration. This change normalizes a legacy Set once — stores the strings on a `preSeeded` field that propagates through the chain — so pre-seeded entries are checked at every depth and error-message iteration stays clean. No extra work on the hot path when no Set is passed (`preSeeded` is `undefined` and the branch is skipped).

--- a/.changeset/perf-stack-set-backcompat.md
+++ b/.changeset/perf-stack-set-backcompat.md
@@ -1,7 +1,0 @@
----
-"enhanced-resolve": patch
----
-
-Restore full back-compat with callers that pass `resolveContext.stack: new Set<string>()` (the pre-5505bb2 shape).
-
-The linked-list `StackEntry` change kept a partial fallback in `doResolve` but only matched pre-seeded Set entries at the first call and polluted the linked-list iteration. This change normalizes a legacy Set once — stores the strings on a `preSeeded` field that propagates through the chain — so pre-seeded entries are checked at every depth and error-message iteration stays clean. No extra work on the hot path when no Set is passed (`preSeeded` is `undefined` and the branch is skipped).

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -425,8 +425,9 @@ class StackEntry {
 	 * @param {ResolveStepHook} hook hook
 	 * @param {ResolveRequest} request request
 	 * @param {StackEntry=} parent previous tip
+	 * @param {Set<string>=} preSeeded entries pre-seeded via the legacy `Set<string>` API
 	 */
-	constructor(hook, request, parent) {
+	constructor(hook, request, parent, preSeeded) {
 		this.name = hook.name;
 		this.path = request.path;
 		this.request = request.request || "";
@@ -436,6 +437,14 @@ class StackEntry {
 		this.module = Boolean(request.module);
 		/** @type {StackEntry | undefined} */
 		this.parent = parent;
+		/**
+		 * Strings seeded by callers that still pass `stack: new Set([...])`.
+		 * Propagated through the chain so deeper `doResolve` calls still see
+		 * them during recursion checks. `undefined` in the common case so
+		 * there is no extra work on the hot path.
+		 * @type {Set<string> | undefined}
+		 */
+		this.preSeeded = preSeeded;
 	}
 
 	/**
@@ -461,7 +470,7 @@ class StackEntry {
 			}
 			node = node.parent;
 		}
-		return false;
+		return this.preSeeded !== undefined && this.preSeeded.has(query.toString());
 	}
 
 	/**
@@ -469,7 +478,7 @@ class StackEntry {
 	 * @returns {number} size
 	 */
 	get size() {
-		let count = 0;
+		let count = this.preSeeded ? this.preSeeded.size : 0;
 		/** @type {StackEntry | undefined} */
 		let node = this;
 		while (node) {
@@ -481,10 +490,15 @@ class StackEntry {
 
 	/**
 	 * Iterate entries from oldest (root) to newest (tip), matching how a
-	 * `Set` that was populated in insertion order would iterate.
-	 * @returns {IterableIterator<StackEntry>} iterator
+	 * `Set` that was populated in insertion order would iterate. Pre-seeded
+	 * legacy `Set<string>` entries come first so error-message output stays
+	 * ordered oldest-to-newest.
+	 * @returns {IterableIterator<StackEntry | string>} iterator
 	 */
 	*[Symbol.iterator]() {
+		if (this.preSeeded !== undefined) {
+			for (const entry of this.preSeeded) yield entry;
+		}
 		/** @type {StackEntry[]} */
 		const entries = [];
 		/** @type {StackEntry | undefined} */
@@ -514,7 +528,7 @@ class StackEntry {
  * @property {WriteOnlySet<string>=} contextDependencies directories that was found on file system
  * @property {WriteOnlySet<string>=} fileDependencies files that was found on file system
  * @property {WriteOnlySet<string>=} missingDependencies dependencies that was not found on file system
- * @property {StackEntry=} stack tip of the resolver call stack (a singly-linked list with Set-like API). For instance, `resolve → parsedResolve → describedResolve`,
+ * @property {StackEntry | Set<string>=} stack tip of the resolver call stack (a singly-linked list with Set-like API). For instance, `resolve → parsedResolve → describedResolve`. Accepts a legacy `Set<string>` for back-compat with older callers; it is normalized internally without a hot-path branch.
  * @property {((str: string) => void)=} log log function
  * @property {ResolveContextYield=} yield yield result, if provided plugins can return several results
  */
@@ -546,10 +560,11 @@ class Resolver {
 	 * @param {ResolveStepHook} hook hook
 	 * @param {ResolveRequest} request request
 	 * @param {StackEntry=} parent previous tip of the stack
+	 * @param {Set<string>=} preSeeded entries pre-seeded via the legacy `Set<string>` API
 	 * @returns {StackEntry} stack entry
 	 */
-	static createStackEntry(hook, request, parent) {
-		return new StackEntry(hook, request, parent);
+	static createStackEntry(hook, request, parent, preSeeded) {
+		return new StackEntry(hook, request, parent, preSeeded);
 	}
 
 	/**
@@ -999,16 +1014,36 @@ class Resolver {
 	 * @returns {void}
 	 */
 	doResolve(hook, request, message, resolveContext, callback) {
-		const parent = resolveContext.stack;
+		const rawStack = resolveContext.stack;
+		/** @type {StackEntry | undefined} */
+		let parent;
+		/** @type {Set<string> | undefined} */
+		let preSeeded;
+		if (rawStack instanceof StackEntry) {
+			parent = rawStack;
+			preSeeded = rawStack.preSeeded;
+		} else if (rawStack) {
+			// Legacy `stack: new Set<string>()` API: don't link the Set into
+			// the parent chain (it would pollute iteration and field-compare
+			// walks). Carry the strings on the StackEntry itself instead so
+			// deeper `doResolve` calls keep seeing pre-seeded entries.
+			preSeeded = /** @type {Set<string>} */ (rawStack);
+		}
 		// Prepend a new linked-list node. O(1) allocation, no Set clone.
-		const stackEntry = Resolver.createStackEntry(hook, request, parent);
+		const stackEntry = Resolver.createStackEntry(
+			hook,
+			request,
+			parent,
+			preSeeded,
+		);
 
+		// When `parent` exists, its `has()` already consults `preSeeded`
+		// (inherited from the same chain), so we only need the direct Set
+		// lookup on the very first `doResolve` call (no parent yet).
 		if (
-			parent &&
-			(parent instanceof StackEntry
+			parent !== undefined
 				? parent.has(stackEntry)
-				: // @ts-expect-error for old Set based API
-					parent.has(stackEntry.toString()))
+				: preSeeded !== undefined && preSeeded.has(stackEntry.toString())
 		) {
 			/**
 			 * Prevent recursion

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -1023,6 +1023,7 @@ class Resolver {
 			parent = rawStack;
 			preSeeded = rawStack.preSeeded;
 		} else if (rawStack) {
+			// TODO in the next major remove `Set<string>` support in favor of `StackEntry`
 			// Legacy `stack: new Set<string>()` API: don't link the Set into
 			// the parent chain (it would pollute iteration and field-compare
 			// walks). Carry the strings on the StackEntry itself instead so

--- a/test/resolve-context-stack.test.js
+++ b/test/resolve-context-stack.test.js
@@ -142,4 +142,95 @@ describe("resolveContext.stack", () => {
 			});
 		});
 	});
+
+	// Plugin pattern: a cache plugin (e.g. webpack's ResolverCachePlugin)
+	// taps into a hook and, on a cache miss, re-issues a fresh
+	// `resolver.resolve()` to populate the cache. The inner call needs to
+	// preserve the parent context (log, deps, yield) but start with an
+	// empty recursion-tracking stack — otherwise it inherits the outer
+	// chain and the guard fires on the first inner step (the same
+	// `resolve: (path) request` it just pushed).
+	//
+	// Old API: `{ ...resolveContext, stack: new Set() }`.
+	// New API (works today, future-proof once Set support is dropped):
+	// `{ ...resolveContext, stack: undefined }`.
+	describe("re-issuing resolves from inside a hook (cache-plugin pattern)", () => {
+		/**
+		 * @param {boolean} resetStack whether the plugin clears `stack`
+		 * @returns {import("../").Resolver} resolver
+		 */
+		const buildReplayResolver = (resetStack) => {
+			let didReplay = false;
+			return ResolverFactory.createResolver({
+				extensions: [".ts", ".js"],
+				fileSystem: nodeFileSystem,
+				plugins: [
+					{
+						/** @param {import("../").Resolver} r resolver */
+						apply(r) {
+							const target = r.ensureHook("parsed-resolve");
+							r.getHook("resolve").tapAsync(
+								"ReplayPlugin",
+								(request, resolveContext, callback) => {
+									if (didReplay) {
+										// Inner pass: continue normally so the test
+										// actually finishes its resolve.
+										return r.doResolve(
+											target,
+											request,
+											null,
+											resolveContext,
+											callback,
+										);
+									}
+									didReplay = true;
+									r.resolve(
+										/** @type {import("../").Context} */
+										(request.context || {}),
+										/** @type {string} */ (request.path),
+										/** @type {string} */ (request.request),
+										resetStack
+											? { ...resolveContext, stack: undefined }
+											: resolveContext,
+										(err, _result, fullResult) => {
+											if (err) return callback(err);
+											callback(null, fullResult);
+										},
+									);
+								},
+							);
+						},
+					},
+				],
+			});
+		};
+
+		it("succeeds when the plugin resets `stack` to undefined before re-issuing", (done) => {
+			buildReplayResolver(true).resolve(
+				{},
+				fixture,
+				"./foo",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					expect(result).toBeTruthy();
+					done();
+				},
+			);
+		});
+
+		it("trips the recursion guard if the plugin forgets to reset `stack`", (done) => {
+			// Negative control: confirms the reset above isn't a no-op.
+			// Without it, the inner `resolver.resolve()` inherits the outer
+			// chain, sees its own `resolve: (...)` entry already on the stack,
+			// and aborts.
+			buildReplayResolver(false).resolve({}, fixture, "./foo", {}, (err) => {
+				expect(err).toBeTruthy();
+				expect(
+					/** @type {Error & { recursion?: boolean }} */ (err).recursion,
+				).toBe(true);
+				done();
+			});
+		});
+	});
 });

--- a/test/resolve-context-stack.test.js
+++ b/test/resolve-context-stack.test.js
@@ -27,7 +27,6 @@ describe("resolveContext.stack", () => {
 			{},
 			fixture,
 			"./foo",
-			// @ts-expect-error for test cases old Set API
 			{ stack: new Set() },
 			(err, result) => {
 				if (err) return done(err);
@@ -45,7 +44,6 @@ describe("resolveContext.stack", () => {
 			{},
 			fixture,
 			"./foo",
-			// @ts-expect-error for test cases old Set API
 			{ stack: new Set(["custom-entry-1", "custom-entry-2"]) },
 			(err, result) => {
 				if (err) return done(err);
@@ -64,8 +62,29 @@ describe("resolveContext.stack", () => {
 			{},
 			fixture,
 			"./foo",
-			// @ts-expect-error for test cases old Set API
 			{ stack: new Set([preSeededEntry]) },
+			(err) => {
+				expect(err).toBeTruthy();
+				expect(
+					/** @type {Error & { recursion?: boolean }} */ (err).recursion,
+				).toBe(true);
+				done();
+			},
+		);
+	});
+
+	it("should detect recursion against Set entries at deeper resolve steps", (done) => {
+		// `parsedResolve` runs after the top-level `resolve` hook, so
+		// pre-seeding its entry only triggers recursion at a deeper
+		// `doResolve` call. This exercises the path where the legacy Set
+		// needs to be propagated through the StackEntry chain, not just
+		// checked on the first call.
+		const deeperEntry = `parsedResolve: (${fixture}) ./foo`;
+		resolver.resolve(
+			{},
+			fixture,
+			"./foo",
+			{ stack: new Set([deeperEntry]) },
 			(err) => {
 				expect(err).toBeTruthy();
 				expect(

--- a/test/resolve-context-stack.test.js
+++ b/test/resolve-context-stack.test.js
@@ -94,4 +94,52 @@ describe("resolveContext.stack", () => {
 			},
 		);
 	});
+
+	// Reset patterns for the StackEntry API. With the legacy Set the canonical
+	// reset between resolve calls was assigning `stack = new Set()` on a reused
+	// context. StackEntry isn't user-constructible, so the equivalent reset is
+	// either omitting `stack` or assigning `undefined`. Both forms must clear
+	// any prior pre-seeded entries so a follow-up resolve no longer recurses.
+
+	it("should reset the stack by assigning `undefined` (StackEntry equivalent of `new Set()`)", (done) => {
+		// First call: pre-seed an entry that triggers recursion immediately.
+		// Reuse the same `ctx` object on the second call after clearing the
+		// field — the resolve must succeed because the seeded entry is gone.
+		/** @type {import("../").ResolveContext} */
+		const ctx = { stack: new Set([`resolve: (${fixture}) ./foo`]) };
+		resolver.resolve({}, fixture, "./foo", ctx, (err) => {
+			expect(err).toBeTruthy();
+			expect(
+				/** @type {Error & { recursion?: boolean }} */ (err).recursion,
+			).toBe(true);
+
+			ctx.stack = undefined;
+			resolver.resolve({}, fixture, "./foo", ctx, (err2, result) => {
+				if (err2) return done(err2);
+				expect(result).toBeTruthy();
+				done();
+			});
+		});
+	});
+
+	it("should reset the stack by assigning a fresh `new Set()` on a reused context", (done) => {
+		// Same pattern, but using the legacy Set form for the reset to confirm
+		// back-compat: a fresh empty Set clears the recursion guard just like
+		// `undefined` does.
+		/** @type {import("../").ResolveContext} */
+		const ctx = { stack: new Set([`resolve: (${fixture}) ./foo`]) };
+		resolver.resolve({}, fixture, "./foo", ctx, (err) => {
+			expect(err).toBeTruthy();
+			expect(
+				/** @type {Error & { recursion?: boolean }} */ (err).recursion,
+			).toBe(true);
+
+			ctx.stack = new Set();
+			resolver.resolve({}, fixture, "./foo", ctx, (err2, result) => {
+				if (err2) return done(err2);
+				expect(result).toBeTruthy();
+				done();
+			});
+		});
+	});
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -1163,9 +1163,9 @@ declare interface ResolveContext {
 	missingDependencies?: WriteOnlySet<string>;
 
 	/**
-	 * tip of the resolver call stack (a singly-linked list with Set-like API). For instance, `resolve → parsedResolve → describedResolve`,
+	 * tip of the resolver call stack (a singly-linked list with Set-like API). For instance, `resolve → parsedResolve → describedResolve`. Accepts a legacy `Set<string>` for back-compat with older callers; it is normalized internally without a hot-path branch.
 	 */
-	stack?: StackEntry;
+	stack?: StackEntry | Set<string>;
 
 	/**
 	 * log function
@@ -1659,6 +1659,14 @@ declare abstract class StackEntry {
 	directory: boolean;
 	module: boolean;
 	parent?: StackEntry;
+
+	/**
+	 * Strings seeded by callers that still pass `stack: new Set([...])`.
+	 * Propagated through the chain so deeper `doResolve` calls still see
+	 * them during recursion checks. `undefined` in the common case so
+	 * there is no extra work on the hot path.
+	 */
+	preSeeded?: Set<string>;
 
 	/**
 	 * Walk the linked list looking for an entry with the same request shape.


### PR DESCRIPTION
Normalizes `resolveContext.stack: new Set<string>()` once at the
`doResolve` boundary into a `preSeeded` field carried on the StackEntry
chain. Pre-seeded entries are now matched at every depth (not just the
first call) and no longer pollute linked-list iteration used for error
messages. Common path (no Set ever passed) adds a single
`preSeeded !== undefined` check on `has()`, preserving the perf wins
from #526.