### PR TITLE
test(imports/exports): cover query and fragment in field resolution

### DIFF
--- a/test/exportsField.test.js
+++ b/test/exportsField.test.js
@@ -2394,6 +2394,26 @@ describe("exportsFieldPlugin", () => {
 		});
 	});
 
+	it("resolver should respect query and fragment parameters together", (done) => {
+		resolver.resolve(
+			{},
+			fixture2,
+			"exports-field/dist/browser.js?foo=bar#frag",
+			{},
+			(err, result) => {
+				if (err) return done(err);
+				if (!result) return done(new Error("No result"));
+				expect(result).toEqual(
+					path.resolve(
+						fixture2,
+						"node_modules/exports-field/lib/browser.js?foo=bar#frag",
+					),
+				);
+				done();
+			},
+		);
+	});
+
 	it("relative path should work, if relative path as request is used", (done) => {
 		resolver.resolve(
 			{},

--- a/test/importsField.test.js
+++ b/test/importsField.test.js
@@ -1415,6 +1415,63 @@ describe("importsFieldPlugin", () => {
 		});
 	});
 
+	it("resolver should respect query parameters #1", (done) => {
+		resolver.resolve({}, fixture, "#a/dist/main.js?foo", {}, (err, result) => {
+			if (err) return done(err);
+			if (!result) return done(new Error("No result"));
+			expect(result).toEqual(
+				path.resolve(fixture, "node_modules/a/lib/main.js?foo"),
+			);
+			done();
+		});
+	});
+
+	it("resolver should respect query parameters #2. Direct matching", (done) => {
+		resolver.resolve({}, fixture, "#imports-field?foo", {}, (err, result) => {
+			if (!err) return done(new Error(`expect error, got ${result}`));
+			expect(err).toBeInstanceOf(Error);
+			expect(err.message).toMatch(/is not imported from package/);
+			done();
+		});
+	});
+
+	it("resolver should respect fragment parameters #1", (done) => {
+		resolver.resolve({}, fixture, "#a/dist/main.js#foo", {}, (err, result) => {
+			if (err) return done(err);
+			if (!result) return done(new Error("No result"));
+			expect(result).toEqual(
+				path.resolve(fixture, "node_modules/a/lib/main.js#foo"),
+			);
+			done();
+		});
+	});
+
+	it("resolver should respect fragment parameters #2. Direct matching", (done) => {
+		resolver.resolve({}, fixture, "#imports-field#foo", {}, (err, result) => {
+			if (!err) return done(new Error(`expect error, got ${result}`));
+			expect(err).toBeInstanceOf(Error);
+			expect(err.message).toMatch(/is not imported from package/);
+			done();
+		});
+	});
+
+	it("resolver should respect query and fragment parameters together", (done) => {
+		resolver.resolve(
+			{},
+			fixture,
+			"#a/dist/main.js?foo=bar#frag",
+			{},
+			(err, result) => {
+				if (err) return done(err);
+				if (!result) return done(new Error("No result"));
+				expect(result).toEqual(
+					path.resolve(fixture, "node_modules/a/lib/main.js?foo=bar#frag"),
+				);
+				done();
+			},
+		);
+	});
+
 	it("should work and throw an error on invalid imports #1", (done) => {
 		// Note: #/ patterns are now allowed per Node.js PR #60864
 		// #/dep will now try to resolve but fail because there's no mapping


### PR DESCRIPTION
Adds resolver-level tests that verify ?query and #fragment are preserved
when resolving through legacy subpath mappings, and that direct-match
keys reject requests carrying ?/# (matching Node's spec). Mirrors the
existing exportsField cases for the imports field, which previously had
no coverage for query/fragment, and adds a combined query+fragment case
to both suites.