### PR TITLE
fix(path): classify DOS device paths as Windows-absolute

### DIFF
--- a/.changeset/fix-dos-device-paths.md
+++ b/.changeset/fix-dos-device-paths.md
@@ -1,0 +1,24 @@
+---
+"enhanced-resolve": patch
+---
+
+fix: properly handle DOS device paths (`\\?\…` and `\\.\…`) on Windows
+
+Requests and context paths using the Win32 file namespace (`\\?\C:\…`,
+`\\?\UNC\server\share\…`) or device namespace (`\\.\C:\…`) were not
+handled correctly:
+
+- `getType()` classified them as `Normal`, so `normalize`, `dirname`,
+  and `join` ran them through posix helpers and failed to collapse `..`
+  segments or compute parents correctly.
+- `parseIdentifier()` split on the literal `?` inside `\\?\`, turning a
+  valid absolute request into a bogus module lookup under
+  `node_modules`.
+- `cdUp()` returned `\` from `\` (via `slice(0, i || 1)`), so
+  `loadDescriptionFile` walked forever once it reached the UNC/device
+  root.
+
+These paths are now recognized as Windows-absolute, parsed without
+misinterpreting the prefix `?`, and the description-file walk
+terminates at a bare `\` root. Plain UNC (`\\server\share\…`) remains
+out of scope.

--- a/lib/DescriptionFileUtils.js
+++ b/lib/DescriptionFileUtils.js
@@ -45,6 +45,13 @@ const CHAR_BACKSLASH = 92;
  * separately and then picked the larger. For any non-trivial directory
  * string on POSIX, `lastIndexOf("\\")` scans the full string just to return
  * -1. A single reverse char-code scan does the same work in one pass.
+ *
+ * Both `"/"` and `"\\"` are treated as roots and short-circuit to `null`;
+ * otherwise `cdUp("\\")` (reached from a UNC root or a DOS device path like
+ * `\\?\…`) would return itself via `slice(0, i || 1)` and trap
+ * `loadDescriptionFile` in an infinite loop. Once those cases are guarded,
+ * the reverse scan always produces a strictly shorter string — no extra
+ * post-slice check is needed on the hot path.
  * @param {string} directory directory
  * @returns {string | null} parent directory or null
  */
@@ -53,11 +60,7 @@ function cdUp(directory) {
 	for (let i = directory.length - 1; i >= 0; i--) {
 		const code = directory.charCodeAt(i);
 		if (code === CHAR_SLASH || code === CHAR_BACKSLASH) {
-			const parent = directory.slice(0, i || 1);
-			// Walking up from "\\" or "/" would otherwise return the same
-			// string (via `i || 1`) and trap callers in an infinite loop.
-			// Happens with UNC roots and DOS device paths like `\\?\…`.
-			return parent === directory ? null : parent;
+			return directory.slice(0, i || 1);
 		}
 	}
 	return null;

--- a/lib/DescriptionFileUtils.js
+++ b/lib/DescriptionFileUtils.js
@@ -49,11 +49,15 @@ const CHAR_BACKSLASH = 92;
  * @returns {string | null} parent directory or null
  */
 function cdUp(directory) {
-	if (directory === "/") return null;
+	if (directory === "/" || directory === "\\") return null;
 	for (let i = directory.length - 1; i >= 0; i--) {
 		const code = directory.charCodeAt(i);
 		if (code === CHAR_SLASH || code === CHAR_BACKSLASH) {
-			return directory.slice(0, i || 1);
+			const parent = directory.slice(0, i || 1);
+			// Walking up from "\\" or "/" would otherwise return the same
+			// string (via `i || 1`) and trap callers in an infinite loop.
+			// Happens with UNC roots and DOS device paths like `\\?\…`.
+			return parent === directory ? null : parent;
 		}
 	}
 	return null;

--- a/lib/DescriptionFileUtils.js
+++ b/lib/DescriptionFileUtils.js
@@ -46,17 +46,18 @@ const CHAR_BACKSLASH = 92;
  * string on POSIX, `lastIndexOf("\\")` scans the full string just to return
  * -1. A single reverse char-code scan does the same work in one pass.
  *
- * Both `"/"` and `"\\"` are treated as roots and short-circuit to `null`;
- * otherwise `cdUp("\\")` (reached from a UNC root or a DOS device path like
- * `\\?\…`) would return itself via `slice(0, i || 1)` and trap
- * `loadDescriptionFile` in an infinite loop. Once those cases are guarded,
- * the reverse scan always produces a strictly shorter string — no extra
- * post-slice check is needed on the hot path.
+ * Any single-character directory is treated as a root — `directory.length
+ * <= 1` collapses the `"/"`, `"\\"` and `""` branches into one compare.
+ * Without the `"\\"` case, `cdUp("\\")` (reached from a UNC root or a DOS
+ * device path like `\\?\…`) would return itself via `slice(0, i || 1)`
+ * and trap `loadDescriptionFile` in an infinite loop. Once single-char
+ * roots are filtered up front, the reverse scan always produces a
+ * strictly shorter string.
  * @param {string} directory directory
  * @returns {string | null} parent directory or null
  */
 function cdUp(directory) {
-	if (directory === "/" || directory === "\\") return null;
+	if (directory.length <= 1) return null;
 	for (let i = directory.length - 1; i >= 0; i--) {
 		const code = directory.charCodeAt(i);
 		if (code === CHAR_SLASH || code === CHAR_BACKSLASH) {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -43,22 +43,36 @@ function parseIdentifier(identifier) {
 	}
 
 	// Fast path for inputs that don't use \0 escaping.
-	// Skip past a DOS device path prefix (`\\?\…` or `\\.\…`) so the literal
-	// `?` inside the prefix is not mistaken for a query separator.
-	const dosPrefixEnd =
-		identifier.length >= 4 &&
-		identifier.charCodeAt(0) === 92 &&
-		identifier.charCodeAt(1) === 92 &&
-		identifier.charCodeAt(3) === 92 &&
-		(identifier.charCodeAt(2) === 63 || identifier.charCodeAt(2) === 46)
-			? 4
-			: 0;
-	const queryStart = identifier.indexOf("?", dosPrefixEnd);
-	// Start at index 1 (or past a DOS prefix) to ignore a possible leading hash.
-	const fragmentStart = identifier.indexOf(
-		"#",
-		dosPrefixEnd > 0 ? dosPrefixEnd : 1,
-	);
+	// Common inputs (relative, absolute-posix, module names, `#imports`)
+	// never start with `\`, so gate the DOS-prefix check on a single
+	// char-code compare and fall straight through to the old two-line
+	// scan for everything else.
+	let queryStart;
+	let fragmentStart;
+	if (identifier.charCodeAt(0) === 92) {
+		// `\`-prefixed input: may be a DOS device path (`\\?\…` or
+		// `\\.\…`). The literal `?` / `.` inside the prefix must not be
+		// mistaken for a query separator, so skip past a recognised prefix
+		// before scanning.
+		let dosPrefixEnd = 0;
+		if (
+			identifier.length >= 4 &&
+			identifier.charCodeAt(1) === 92 &&
+			identifier.charCodeAt(3) === 92
+		) {
+			const c2 = identifier.charCodeAt(2);
+			if (c2 === 63 || c2 === 46) dosPrefixEnd = 4;
+		}
+		queryStart = identifier.indexOf("?", dosPrefixEnd);
+		fragmentStart = identifier.indexOf(
+			"#",
+			dosPrefixEnd > 0 ? dosPrefixEnd : 1,
+		);
+	} else {
+		queryStart = identifier.indexOf("?");
+		// Start at index 1 to ignore a possible leading hash.
+		fragmentStart = identifier.indexOf("#", 1);
+	}
 
 	if (fragmentStart < 0) {
 		if (queryStart < 0) {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -43,9 +43,22 @@ function parseIdentifier(identifier) {
 	}
 
 	// Fast path for inputs that don't use \0 escaping.
-	const queryStart = identifier.indexOf("?");
-	// Start at index 1 to ignore a possible leading hash.
-	const fragmentStart = identifier.indexOf("#", 1);
+	// Skip past a DOS device path prefix (`\\?\…` or `\\.\…`) so the literal
+	// `?` inside the prefix is not mistaken for a query separator.
+	const dosPrefixEnd =
+		identifier.length >= 4 &&
+		identifier.charCodeAt(0) === 92 &&
+		identifier.charCodeAt(1) === 92 &&
+		identifier.charCodeAt(3) === 92 &&
+		(identifier.charCodeAt(2) === 63 || identifier.charCodeAt(2) === 46)
+			? 4
+			: 0;
+	const queryStart = identifier.indexOf("?", dosPrefixEnd);
+	// Start at index 1 (or past a DOS prefix) to ignore a possible leading hash.
+	const fragmentStart = identifier.indexOf(
+		"#",
+		dosPrefixEnd > 0 ? dosPrefixEnd : 1,
+	);
 
 	if (fragmentStart < 0) {
 		if (queryStart < 0) {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -15,6 +15,26 @@ const ZERO_ESCAPE_REGEXP = /\0(.)/g;
 const FILE_REG_EXP = /file:/i;
 
 /**
+ * Index past a DOS device path prefix (`\\?\…` or `\\.\…`), or 0. Kept
+ * out of `parseIdentifier` on purpose: inlining it back bloats the caller
+ * beyond the size where V8's interpreter and JIT both handle it well
+ * (the cause of the description-files-multi CodSpeed regression).
+ * @param {string} identifier identifier known to start with `\`
+ * @returns {number} 4 if identifier starts with a DOS device prefix, else 0
+ */
+function dosPrefixEnd(identifier) {
+	if (
+		identifier.length >= 4 &&
+		identifier.charCodeAt(1) === 92 &&
+		identifier.charCodeAt(3) === 92
+	) {
+		const c2 = identifier.charCodeAt(2);
+		if (c2 === 63 || c2 === 46) return 4;
+	}
+	return 0;
+}
+
+/**
  * @param {string} identifier identifier
  * @returns {[string, string, string] | null} parsed identifier
  */
@@ -42,37 +62,16 @@ function parseIdentifier(identifier) {
 		];
 	}
 
-	// Fast path for inputs that don't use \0 escaping.
-	// Common inputs (relative, absolute-posix, module names, `#imports`)
-	// never start with `\`, so gate the DOS-prefix check on a single
-	// char-code compare and fall straight through to the old two-line
-	// scan for everything else.
-	let queryStart;
-	let fragmentStart;
-	if (identifier.charCodeAt(0) === 92) {
-		// `\`-prefixed input: may be a DOS device path (`\\?\…` or
-		// `\\.\…`). The literal `?` / `.` inside the prefix must not be
-		// mistaken for a query separator, so skip past a recognized prefix
-		// before scanning.
-		let dosPrefixEnd = 0;
-		if (
-			identifier.length >= 4 &&
-			identifier.charCodeAt(1) === 92 &&
-			identifier.charCodeAt(3) === 92
-		) {
-			const c2 = identifier.charCodeAt(2);
-			if (c2 === 63 || c2 === 46) dosPrefixEnd = 4;
-		}
-		queryStart = identifier.indexOf("?", dosPrefixEnd);
-		fragmentStart = identifier.indexOf(
-			"#",
-			dosPrefixEnd > 0 ? dosPrefixEnd : 1,
-		);
-	} else {
-		queryStart = identifier.indexOf("?");
-		// Start at index 1 to ignore a possible leading hash.
-		fragmentStart = identifier.indexOf("#", 1);
-	}
+	// Fast path for inputs that don't use \0 escaping. DOS device paths
+	// (`\\?\…`, `\\.\…`) embed a literal `?` / `.` that must not be read
+	// as a query separator; skip past the prefix when the input actually
+	// starts with `\`. Gate is a single char-code compare so this function
+	// stays inside V8's inline budget for its hot callers (resolver parse).
+	const scanStart =
+		identifier.charCodeAt(0) === 92 ? dosPrefixEnd(identifier) : 0;
+	const queryStart = identifier.indexOf("?", scanStart);
+	// Start at index 1 (or past a DOS prefix) to ignore a possible leading hash.
+	const fragmentStart = identifier.indexOf("#", scanStart || 1);
 
 	if (fragmentStart < 0) {
 		if (queryStart < 0) {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -52,7 +52,7 @@ function parseIdentifier(identifier) {
 	if (identifier.charCodeAt(0) === 92) {
 		// `\`-prefixed input: may be a DOS device path (`\\?\…` or
 		// `\\.\…`). The literal `?` / `.` inside the prefix must not be
-		// mistaken for a query separator, so skip past a recognised prefix
+		// mistaken for a query separator, so skip past a recognized prefix
 		// before scanning.
 		let dosPrefixEnd = 0;
 		if (

--- a/lib/util/path.js
+++ b/lib/util/path.js
@@ -106,23 +106,6 @@ const getType = (maybePath) => {
 			return PathType.AbsolutePosix;
 		case CHAR_HASH:
 			return PathType.Internal;
-		case CHAR_BACKSLASH: {
-			// DOS device paths: `\\?\...` (Win32 file namespace) or `\\.\...`
-			// (Win32 device namespace). Backslashes are required — Windows
-			// passes these paths to the filesystem without normalization, so
-			// forward-slash variants are not equivalent.
-			if (
-				maybePath.length >= 4 &&
-				maybePath.charCodeAt(1) === CHAR_BACKSLASH &&
-				maybePath.charCodeAt(3) === CHAR_BACKSLASH
-			) {
-				const c2 = maybePath.charCodeAt(2);
-				if (c2 === CHAR_QUESTION || c2 === CHAR_DOT) {
-					return PathType.AbsoluteWin;
-				}
-			}
-			return PathType.Normal;
-		}
 	}
 	const c1 = maybePath.charCodeAt(1);
 	if (c1 === CHAR_COLON) {
@@ -132,6 +115,22 @@ const getType = (maybePath) => {
 			((c0 >= CHAR_A && c0 <= CHAR_Z) ||
 				(c0 >= CHAR_LOWER_A && c0 <= CHAR_LOWER_Z))
 		) {
+			return PathType.AbsoluteWin;
+		}
+	}
+	// DOS device paths: `\\?\...` (Win32 file namespace) or `\\.\...`
+	// (Win32 device namespace). Backslashes are required — Windows passes
+	// these paths to the filesystem without normalization, so forward-slash
+	// variants are not equivalent. Checked last so POSIX/module inputs
+	// leave the main switch unchanged and V8 keeps its original dispatch.
+	if (
+		c0 === CHAR_BACKSLASH &&
+		c1 === CHAR_BACKSLASH &&
+		maybePath.length >= 4 &&
+		maybePath.charCodeAt(3) === CHAR_BACKSLASH
+	) {
+		const c2 = maybePath.charCodeAt(2);
+		if (c2 === CHAR_QUESTION || c2 === CHAR_DOT) {
 			return PathType.AbsoluteWin;
 		}
 	}

--- a/lib/util/path.js
+++ b/lib/util/path.js
@@ -16,6 +16,7 @@ const CHAR_LOWER_A = "a".charCodeAt(0);
 const CHAR_LOWER_Z = "z".charCodeAt(0);
 const CHAR_DOT = ".".charCodeAt(0);
 const CHAR_COLON = ":".charCodeAt(0);
+const CHAR_QUESTION = "?".charCodeAt(0);
 
 const posixNormalize = path.posix.normalize;
 const winNormalize = path.win32.normalize;
@@ -105,6 +106,23 @@ const getType = (maybePath) => {
 			return PathType.AbsolutePosix;
 		case CHAR_HASH:
 			return PathType.Internal;
+		case CHAR_BACKSLASH: {
+			// DOS device paths: `\\?\...` (Win32 file namespace) or `\\.\...`
+			// (Win32 device namespace). Backslashes are required — Windows
+			// passes these paths to the filesystem without normalization, so
+			// forward-slash variants are not equivalent.
+			if (
+				maybePath.length >= 4 &&
+				maybePath.charCodeAt(1) === CHAR_BACKSLASH &&
+				maybePath.charCodeAt(3) === CHAR_BACKSLASH
+			) {
+				const c2 = maybePath.charCodeAt(2);
+				if (c2 === CHAR_QUESTION || c2 === CHAR_DOT) {
+					return PathType.AbsoluteWin;
+				}
+			}
+			return PathType.Normal;
+		}
 	}
 	const c1 = maybePath.charCodeAt(1);
 	if (c1 === CHAR_COLON) {

--- a/lib/util/path.js
+++ b/lib/util/path.js
@@ -40,6 +40,20 @@ const invalidSegmentRegEx =
 	/(^|\\|\/)((\.|%2e)(\.|%2e)?|(n|%6e|%4e)(o|%6f|%4f)(d|%64|%44)(e|%65|%45)(_|%5f)(m|%6d|%4d)(o|%6f|%4f)(d|%64|%44)(u|%75|%55)(l|%6c|%4c)(e|%65|%45)(s|%73|%53))?(\\|\/|$)/i;
 
 /**
+ * @param {string} maybePath a path known to start with `\\`
+ * @returns {PathType} AbsoluteWin for `\\?\…` / `\\.\…`, otherwise Normal
+ */
+const getDosDeviceType = (maybePath) => {
+	if (maybePath.length >= 4 && maybePath.charCodeAt(3) === CHAR_BACKSLASH) {
+		const c2 = maybePath.charCodeAt(2);
+		if (c2 === CHAR_QUESTION || c2 === CHAR_DOT) {
+			return PathType.AbsoluteWin;
+		}
+	}
+	return PathType.Normal;
+};
+
+/**
  * @param {string} maybePath a path
  * @returns {PathType} type of path
  */
@@ -118,21 +132,12 @@ const getType = (maybePath) => {
 			return PathType.AbsoluteWin;
 		}
 	}
-	// DOS device paths: `\\?\...` (Win32 file namespace) or `\\.\...`
-	// (Win32 device namespace). Backslashes are required — Windows passes
-	// these paths to the filesystem without normalization, so forward-slash
-	// variants are not equivalent. Checked last so POSIX/module inputs
-	// leave the main switch unchanged and V8 keeps its original dispatch.
-	if (
-		c0 === CHAR_BACKSLASH &&
-		c1 === CHAR_BACKSLASH &&
-		maybePath.length >= 4 &&
-		maybePath.charCodeAt(3) === CHAR_BACKSLASH
-	) {
-		const c2 = maybePath.charCodeAt(2);
-		if (c2 === CHAR_QUESTION || c2 === CHAR_DOT) {
-			return PathType.AbsoluteWin;
-		}
+	// DOS device paths (`\\?\…`, `\\.\…`) are handled in a cold helper so
+	// this function stays small — inlining the full check here regressed
+	// `description-files-multi` under `--no-opt` interpretation. Here we
+	// only pay the two-byte gate for non-DOS inputs.
+	if (c0 === CHAR_BACKSLASH && c1 === CHAR_BACKSLASH) {
+		return getDosDeviceType(maybePath);
 	}
 	return PathType.Normal;
 };

--- a/test/dos-device-paths.test.js
+++ b/test/dos-device-paths.test.js
@@ -1,0 +1,219 @@
+"use strict";
+
+/* eslint-disable jsdoc/reject-any-type */
+
+const { ResolverFactory } = require("../");
+
+/**
+ * Build a minimal in-memory filesystem whose keys are backslash-separated
+ * Windows-style paths. memfs (used elsewhere in this suite) normalizes keys
+ * through a posix path module, so it cannot represent a DOS device path as
+ * an absolute root on a non-Windows test host — this helper can.
+ *
+ * Only the methods the resolver actually calls for a bare file/directory
+ * resolve are implemented.
+ * @param {Record<string, string>} files map from path to file content
+ * @returns {any} fake filesystem
+ */
+function createDosFs(files) {
+	const enoent = (p) => {
+		const e = /** @type {NodeJS.ErrnoException} */ (
+			new Error(`ENOENT: no such file or directory, '${p}'`)
+		);
+		e.code = "ENOENT";
+		return e;
+	};
+	const stats = (isFile) => ({
+		isFile: () => isFile,
+		isDirectory: () => !isFile,
+		isSymbolicLink: () => false,
+		isBlockDevice: () => false,
+		isCharacterDevice: () => false,
+		isFIFO: () => false,
+		isSocket: () => false,
+		size: 0,
+		mtimeMs: 0,
+		ctimeMs: 0,
+	});
+	const isDir = (p) => {
+		const prefix = p.endsWith("\\") || p.endsWith("/") ? p : `${p}\\`;
+		for (const k of Object.keys(files)) {
+			if (k !== p && k.startsWith(prefix)) return true;
+		}
+		return false;
+	};
+	const statSync = (p) => {
+		if (p in files) return stats(true);
+		if (isDir(p)) return stats(false);
+		throw enoent(p);
+	};
+	const readFileSync = (p) => {
+		if (!(p in files)) throw enoent(p);
+		return Buffer.from(files[p]);
+	};
+	const readdirSync = (p) => {
+		const prefix = p.endsWith("\\") || p.endsWith("/") ? p : `${p}\\`;
+		/** @type {Set<string>} */
+		const entries = new Set();
+		for (const k of Object.keys(files)) {
+			if (k.startsWith(prefix)) {
+				const [seg] = k.slice(prefix.length).split(/[\\/]/);
+				if (seg) entries.add(seg);
+			}
+		}
+		return [...entries];
+	};
+	return {
+		stat: (p, cb) => {
+			try {
+				cb(null, statSync(p));
+			} catch (err) {
+				cb(err);
+			}
+		},
+		statSync,
+		lstat: (p, cb) => {
+			try {
+				cb(null, statSync(p));
+			} catch (err) {
+				cb(err);
+			}
+		},
+		lstatSync: statSync,
+		readFile: (p, cb) => {
+			try {
+				cb(null, readFileSync(p));
+			} catch (err) {
+				cb(err);
+			}
+		},
+		readFileSync,
+		readdir: (p, cb) => {
+			try {
+				cb(null, readdirSync(p));
+			} catch (err) {
+				cb(err);
+			}
+		},
+		readdirSync,
+		// Resolver never follows symlinks here, but the interface requires these.
+		readlink: (p, cb) => cb(enoent(p)),
+		readlinkSync: (p) => {
+			throw enoent(p);
+		},
+		realpath: (p, cb) => cb(null, p),
+		realpathSync: (p) => p,
+	};
+}
+
+describe("DOS device path resolution", () => {
+	const files = {
+		"\\\\?\\C:\\project\\package.json": JSON.stringify({ name: "p" }),
+		"\\\\?\\C:\\project\\src\\index.js": "",
+		"\\\\?\\C:\\project\\src\\utils.js": "",
+		"\\\\?\\C:\\project\\src\\sub\\leaf.js": "",
+		"\\\\?\\UNC\\server\\share\\pkg\\index.js": "",
+		"\\\\.\\C:\\root\\device.js": "",
+	};
+	const fileSystem = createDosFs(files);
+	const resolver = ResolverFactory.createResolver({
+		useSyncFileSystemCalls: true,
+		fileSystem,
+		extensions: [".js"],
+	});
+
+	it("resolves a relative request against a \\\\?\\ context", () => {
+		expect(resolver.resolveSync({}, "\\\\?\\C:\\project\\src", "./utils")).toBe(
+			"\\\\?\\C:\\project\\src\\utils.js",
+		);
+	});
+
+	it("resolves a nested relative request against a \\\\?\\ context", () => {
+		expect(
+			resolver.resolveSync({}, "\\\\?\\C:\\project\\src", "./sub/leaf"),
+		).toBe("\\\\?\\C:\\project\\src\\sub\\leaf.js");
+	});
+
+	it("resolves '.' to the directory's index.js in a \\\\?\\ context", () => {
+		expect(resolver.resolveSync({}, "\\\\?\\C:\\project\\src", ".")).toBe(
+			"\\\\?\\C:\\project\\src\\index.js",
+		);
+	});
+
+	it("resolves an absolute \\\\?\\ request regardless of context", () => {
+		expect(
+			resolver.resolveSync(
+				{},
+				"/any/context",
+				"\\\\?\\C:\\project\\src\\utils",
+			),
+		).toBe("\\\\?\\C:\\project\\src\\utils.js");
+	});
+
+	it("resolves an absolute \\\\?\\UNC\\ request", () => {
+		expect(
+			resolver.resolveSync({}, "/any", "\\\\?\\UNC\\server\\share\\pkg\\index"),
+		).toBe("\\\\?\\UNC\\server\\share\\pkg\\index.js");
+	});
+
+	it("resolves relative requests against a \\\\.\\ device-namespace context", () => {
+		// The `\\.\` prefix is the Win32 device namespace. Walking up past it
+		// used to infinite-recurse in `cdUp` — this exercise proves the fix.
+		expect(resolver.resolveSync({}, "\\\\.\\C:\\root", "./device")).toBe(
+			"\\\\.\\C:\\root\\device.js",
+		);
+	});
+
+	it("preserves a query string on a \\\\?\\ request", () => {
+		// The literal `?` in `\\?\` must not be parsed as a query start; the
+		// real query is the one after the path.
+		const resolverWithQuery = ResolverFactory.createResolver({
+			useSyncFileSystemCalls: true,
+			fileSystem,
+			extensions: [".js"],
+		});
+		expect(
+			resolverWithQuery.resolveSync(
+				{},
+				"/any",
+				"\\\\?\\C:\\project\\src\\utils?foo=bar",
+			),
+		).toBe("\\\\?\\C:\\project\\src\\utils.js?foo=bar");
+	});
+
+	it("preserves a fragment on a \\\\?\\ request", () => {
+		expect(
+			resolver.resolveSync({}, "/any", "\\\\?\\C:\\project\\src\\utils#frag"),
+		).toBe("\\\\?\\C:\\project\\src\\utils.js#frag");
+	});
+
+	it("rejects a missing file under a DOS device context", () => {
+		expect(() =>
+			resolver.resolveSync({}, "\\\\?\\C:\\project\\src", "./does-not-exist"),
+		).toThrow(/Can't resolve/);
+	});
+
+	it("locates the package.json when resolving through a \\\\?\\ path", (done) => {
+		const asyncResolver = ResolverFactory.createResolver({
+			fileSystem,
+			extensions: [".js"],
+		});
+		asyncResolver.resolve(
+			{},
+			"\\\\?\\C:\\project\\src",
+			"./utils",
+			{},
+			(err, result, request) => {
+				if (err) return done(err);
+				expect(result).toBe("\\\\?\\C:\\project\\src\\utils.js");
+				// The description file walk must have terminated at the
+				// project root — not run past the `\\` root forever.
+				expect(request).toBeDefined();
+				expect(/** @type {any} */ (request).descriptionFilePath).toBe(
+					"\\\\?\\C:\\project\\package.json",
+				);
+				done();
+			},
+		);
+	});
+});

--- a/test/dos-device-paths.test.js
+++ b/test/dos-device-paths.test.js
@@ -1,216 +1,111 @@
 "use strict";
 
-/* eslint-disable jsdoc/reject-any-type */
+// eslint's jest plugin static-analyzes `describe` calls and doesn't recognize
+// `describeWin` below as one — disable `require-top-level-describe` for the
+// whole file rather than scatter per-test ignore comments.
+/* eslint-disable jest/require-top-level-describe, jsdoc/reject-any-type */
 
+const fs = require("fs");
+const path = require("path");
 const { ResolverFactory } = require("../");
 
-/**
- * Build a minimal in-memory filesystem whose keys are backslash-separated
- * Windows-style paths. memfs (used elsewhere in this suite) normalizes keys
- * through a posix path module, so it cannot represent a DOS device path as
- * an absolute root on a non-Windows test host — this helper can.
- *
- * Only the methods the resolver actually calls for a bare file/directory
- * resolve are implemented.
- * @param {Record<string, string>} files map from path to file content
- * @returns {any} fake filesystem
- */
-function createDosFs(files) {
-	const enoent = (p) => {
-		const e = /** @type {NodeJS.ErrnoException} */ (
-			new Error(`ENOENT: no such file or directory, '${p}'`)
-		);
-		e.code = "ENOENT";
-		return e;
-	};
-	const stats = (isFile) => ({
-		isFile: () => isFile,
-		isDirectory: () => !isFile,
-		isSymbolicLink: () => false,
-		isBlockDevice: () => false,
-		isCharacterDevice: () => false,
-		isFIFO: () => false,
-		isSocket: () => false,
-		size: 0,
-		mtimeMs: 0,
-		ctimeMs: 0,
-	});
-	const isDir = (p) => {
-		const prefix = p.endsWith("\\") || p.endsWith("/") ? p : `${p}\\`;
-		for (const k of Object.keys(files)) {
-			if (k !== p && k.startsWith(prefix)) return true;
-		}
-		return false;
-	};
-	const statSync = (p) => {
-		if (p in files) return stats(true);
-		if (isDir(p)) return stats(false);
-		throw enoent(p);
-	};
-	const readFileSync = (p) => {
-		if (!(p in files)) throw enoent(p);
-		return Buffer.from(files[p]);
-	};
-	const readdirSync = (p) => {
-		const prefix = p.endsWith("\\") || p.endsWith("/") ? p : `${p}\\`;
-		/** @type {Set<string>} */
-		const entries = new Set();
-		for (const k of Object.keys(files)) {
-			if (k.startsWith(prefix)) {
-				const [seg] = k.slice(prefix.length).split(/[\\/]/);
-				if (seg) entries.add(seg);
-			}
-		}
-		return [...entries];
-	};
-	return {
-		stat: (p, cb) => {
-			try {
-				cb(null, statSync(p));
-			} catch (err) {
-				cb(err);
-			}
-		},
-		statSync,
-		lstat: (p, cb) => {
-			try {
-				cb(null, statSync(p));
-			} catch (err) {
-				cb(err);
-			}
-		},
-		lstatSync: statSync,
-		readFile: (p, cb) => {
-			try {
-				cb(null, readFileSync(p));
-			} catch (err) {
-				cb(err);
-			}
-		},
-		readFileSync,
-		readdir: (p, cb) => {
-			try {
-				cb(null, readdirSync(p));
-			} catch (err) {
-				cb(err);
-			}
-		},
-		readdirSync,
-		// Resolver never follows symlinks here, but the interface requires these.
-		readlink: (p, cb) => cb(enoent(p)),
-		readlinkSync: (p) => {
-			throw enoent(p);
-		},
-		realpath: (p, cb) => cb(null, p),
-		realpathSync: (p) => p,
-	};
-}
+// DOS device paths (`\\?\…`, `\\.\…`) are Windows-only constructs. The real
+// resolver tests below hit the actual filesystem through those prefixes, so
+// they only make sense on a Windows host. `describe.skip` elsewhere keeps CI
+// on other platforms green while still validating the pure logic via
+// `path.test.js` and `identifier.test.js`.
+const describeWin = process.platform === "win32" ? describe : describe.skip;
 
-describe("DOS device path resolution", () => {
-	const files = {
-		"\\\\?\\C:\\project\\package.json": JSON.stringify({ name: "p" }),
-		"\\\\?\\C:\\project\\src\\index.js": "",
-		"\\\\?\\C:\\project\\src\\utils.js": "",
-		"\\\\?\\C:\\project\\src\\sub\\leaf.js": "",
-		"\\\\?\\UNC\\server\\share\\pkg\\index.js": "",
-		"\\\\.\\C:\\root\\device.js": "",
-	};
-	const fileSystem = createDosFs(files);
+describeWin("DOS device path resolution (Windows)", () => {
+	// `path.resolve` gives us the real Windows-absolute form of the fixtures
+	// directory (e.g. `C:\…\test\fixtures`), which we then re-address through
+	// the Win32 file (`\\?\`) and device (`\\.\`) namespaces.
+	const fixtures = path.resolve(__dirname, "fixtures");
+	const dosFixtures = `\\\\?\\${fixtures}`;
+	const dotFixtures = `\\\\.\\${fixtures}`;
+
+	// `symlinks: false` keeps the result verbatim — the realpath plugin would
+	// otherwise strip the DOS prefix on Windows, masking what we want to test.
 	const resolver = ResolverFactory.createResolver({
 		useSyncFileSystemCalls: true,
-		fileSystem,
+		fileSystem: fs,
 		extensions: [".js"],
+		symlinks: false,
 	});
 
-	it("resolves a relative request against a \\\\?\\ context", () => {
-		expect(resolver.resolveSync({}, "\\\\?\\C:\\project\\src", "./utils")).toBe(
-			"\\\\?\\C:\\project\\src\\utils.js",
+	test("resolves a relative request against a \\\\?\\ context", () => {
+		expect(resolver.resolveSync({}, dosFixtures, "./a")).toBe(
+			path.join(dosFixtures, "a.js"),
 		);
 	});
 
-	it("resolves a nested relative request against a \\\\?\\ context", () => {
-		expect(
-			resolver.resolveSync({}, "\\\\?\\C:\\project\\src", "./sub/leaf"),
-		).toBe("\\\\?\\C:\\project\\src\\sub\\leaf.js");
-	});
-
-	it("resolves '.' to the directory's index.js in a \\\\?\\ context", () => {
-		expect(resolver.resolveSync({}, "\\\\?\\C:\\project\\src", ".")).toBe(
-			"\\\\?\\C:\\project\\src\\index.js",
+	test("resolves a relative request to a subdirectory's index.js", () => {
+		expect(resolver.resolveSync({}, dosFixtures, "./foo")).toBe(
+			path.join(dosFixtures, "foo", "index.js"),
 		);
 	});
 
-	it("resolves an absolute \\\\?\\ request regardless of context", () => {
-		expect(
-			resolver.resolveSync(
-				{},
-				"/any/context",
-				"\\\\?\\C:\\project\\src\\utils",
-			),
-		).toBe("\\\\?\\C:\\project\\src\\utils.js");
-	});
-
-	it("resolves an absolute \\\\?\\UNC\\ request", () => {
-		expect(
-			resolver.resolveSync({}, "/any", "\\\\?\\UNC\\server\\share\\pkg\\index"),
-		).toBe("\\\\?\\UNC\\server\\share\\pkg\\index.js");
-	});
-
-	it("resolves relative requests against a \\\\.\\ device-namespace context", () => {
-		// The `\\.\` prefix is the Win32 device namespace. Walking up past it
-		// used to infinite-recurse in `cdUp` — this exercise proves the fix.
-		expect(resolver.resolveSync({}, "\\\\.\\C:\\root", "./device")).toBe(
-			"\\\\.\\C:\\root\\device.js",
+	test("resolves '.' to index.js in a \\\\?\\ context", () => {
+		expect(resolver.resolveSync({}, path.join(dosFixtures, "foo"), ".")).toBe(
+			path.join(dosFixtures, "foo", "index.js"),
 		);
 	});
 
-	it("preserves a query string on a \\\\?\\ request", () => {
-		// The literal `?` in `\\?\` must not be parsed as a query start; the
-		// real query is the one after the path.
-		const resolverWithQuery = ResolverFactory.createResolver({
-			useSyncFileSystemCalls: true,
-			fileSystem,
-			extensions: [".js"],
-		});
-		expect(
-			resolverWithQuery.resolveSync(
-				{},
-				"/any",
-				"\\\\?\\C:\\project\\src\\utils?foo=bar",
-			),
-		).toBe("\\\\?\\C:\\project\\src\\utils.js?foo=bar");
+	test("resolves an absolute \\\\?\\ request regardless of context", () => {
+		const request = path.join(dosFixtures, "a");
+		expect(resolver.resolveSync({}, fixtures, request)).toBe(
+			path.join(dosFixtures, "a.js"),
+		);
 	});
 
-	it("preserves a fragment on a \\\\?\\ request", () => {
-		expect(
-			resolver.resolveSync({}, "/any", "\\\\?\\C:\\project\\src\\utils#frag"),
-		).toBe("\\\\?\\C:\\project\\src\\utils.js#frag");
+	test("resolves through the \\\\.\\ device namespace", () => {
+		// The `\\.\` walk used to infinite-loop in `cdUp` once it reached
+		// the bare `\` root — this test proves it terminates.
+		expect(resolver.resolveSync({}, dotFixtures, "./a")).toBe(
+			path.join(dotFixtures, "a.js"),
+		);
 	});
 
-	it("rejects a missing file under a DOS device context", () => {
+	test("preserves a query string on a \\\\?\\ request", () => {
+		// The literal `?` inside `\\?\` must not be mistaken for a query
+		// separator — the real query is the one trailing the path.
+		const request = `${path.join(dosFixtures, "a")}?foo=bar`;
+		expect(resolver.resolveSync({}, fixtures, request)).toBe(
+			`${path.join(dosFixtures, "a.js")}?foo=bar`,
+		);
+	});
+
+	test("preserves a fragment on a \\\\?\\ request", () => {
+		const request = `${path.join(dosFixtures, "a")}#frag`;
+		expect(resolver.resolveSync({}, fixtures, request)).toBe(
+			`${path.join(dosFixtures, "a.js")}#frag`,
+		);
+	});
+
+	test("rejects a missing file under a DOS device context", () => {
 		expect(() =>
-			resolver.resolveSync({}, "\\\\?\\C:\\project\\src", "./does-not-exist"),
+			resolver.resolveSync({}, dosFixtures, "./does-not-exist"),
 		).toThrow(/Can't resolve/);
 	});
 
-	it("locates the package.json when resolving through a \\\\?\\ path", (done) => {
+	test("locates the nearest package.json when resolving through \\\\?\\", (done) => {
 		const asyncResolver = ResolverFactory.createResolver({
-			fileSystem,
+			fileSystem: fs,
 			extensions: [".js"],
+			symlinks: false,
 		});
 		asyncResolver.resolve(
 			{},
-			"\\\\?\\C:\\project\\src",
-			"./utils",
+			path.join(dosFixtures, "foo"),
+			".",
 			{},
 			(err, result, request) => {
 				if (err) return done(err);
-				expect(result).toBe("\\\\?\\C:\\project\\src\\utils.js");
-				// The description file walk must have terminated at the
-				// project root — not run past the `\\` root forever.
-				expect(request).toBeDefined();
+				expect(result).toBe(path.join(dosFixtures, "foo", "index.js"));
+				// The description-file walk must terminate — if `cdUp` didn't
+				// treat bare `\` as a root, this callback would never fire.
 				expect(/** @type {any} */ (request).descriptionFilePath).toBe(
-					"\\\\?\\C:\\project\\package.json",
+					path.join(dosFixtures, "foo", "package.json"),
 				);
 				done();
 			},

--- a/test/dos-device-paths.test.js
+++ b/test/dos-device-paths.test.js
@@ -26,75 +26,73 @@ describeWin("DOS device path resolution (Windows)", () => {
 
 	// `symlinks: false` keeps the result verbatim — the realpath plugin would
 	// otherwise strip the DOS prefix on Windows, masking what we want to test.
+	// Default (async) filesystem calls are used — sync fs is deliberately
+	// avoided so this exercises the same code paths as production resolves.
 	const resolver = ResolverFactory.createResolver({
-		useSyncFileSystemCalls: true,
 		fileSystem: fs,
 		extensions: [".js"],
 		symlinks: false,
 	});
 
-	test("resolves a relative request against a \\\\?\\ context", () => {
-		expect(resolver.resolveSync({}, dosFixtures, "./a")).toBe(
+	test("resolves a relative request against a \\\\?\\ context", async () => {
+		await expect(resolver.resolvePromise({}, dosFixtures, "./a")).resolves.toBe(
 			path.join(dosFixtures, "a.js"),
 		);
 	});
 
-	test("resolves a relative request to a subdirectory's index.js", () => {
-		expect(resolver.resolveSync({}, dosFixtures, "./foo")).toBe(
-			path.join(dosFixtures, "foo", "index.js"),
-		);
+	test("resolves a relative request to a subdirectory's index.js", async () => {
+		await expect(
+			resolver.resolvePromise({}, dosFixtures, "./foo"),
+		).resolves.toBe(path.join(dosFixtures, "foo", "index.js"));
 	});
 
-	test("resolves '.' to index.js in a \\\\?\\ context", () => {
-		expect(resolver.resolveSync({}, path.join(dosFixtures, "foo"), ".")).toBe(
-			path.join(dosFixtures, "foo", "index.js"),
-		);
+	test("resolves '.' to index.js in a \\\\?\\ context", async () => {
+		await expect(
+			resolver.resolvePromise({}, path.join(dosFixtures, "foo"), "."),
+		).resolves.toBe(path.join(dosFixtures, "foo", "index.js"));
 	});
 
-	test("resolves an absolute \\\\?\\ request regardless of context", () => {
+	test("resolves an absolute \\\\?\\ request regardless of context", async () => {
 		const request = path.join(dosFixtures, "a");
-		expect(resolver.resolveSync({}, fixtures, request)).toBe(
+		await expect(resolver.resolvePromise({}, fixtures, request)).resolves.toBe(
 			path.join(dosFixtures, "a.js"),
 		);
 	});
 
-	test("resolves through the \\\\.\\ device namespace", () => {
+	test("resolves through the \\\\.\\ device namespace", async () => {
 		// The `\\.\` walk used to infinite-loop in `cdUp` once it reached
 		// the bare `\` root — this test proves it terminates.
-		expect(resolver.resolveSync({}, dotFixtures, "./a")).toBe(
+		await expect(resolver.resolvePromise({}, dotFixtures, "./a")).resolves.toBe(
 			path.join(dotFixtures, "a.js"),
 		);
 	});
 
-	test("preserves a query string on a \\\\?\\ request", () => {
+	test("preserves a query string on a \\\\?\\ request", async () => {
 		// The literal `?` inside `\\?\` must not be mistaken for a query
 		// separator — the real query is the one trailing the path.
 		const request = `${path.join(dosFixtures, "a")}?foo=bar`;
-		expect(resolver.resolveSync({}, fixtures, request)).toBe(
+		await expect(resolver.resolvePromise({}, fixtures, request)).resolves.toBe(
 			`${path.join(dosFixtures, "a.js")}?foo=bar`,
 		);
 	});
 
-	test("preserves a fragment on a \\\\?\\ request", () => {
+	test("preserves a fragment on a \\\\?\\ request", async () => {
 		const request = `${path.join(dosFixtures, "a")}#frag`;
-		expect(resolver.resolveSync({}, fixtures, request)).toBe(
+		await expect(resolver.resolvePromise({}, fixtures, request)).resolves.toBe(
 			`${path.join(dosFixtures, "a.js")}#frag`,
 		);
 	});
 
-	test("rejects a missing file under a DOS device context", () => {
-		expect(() =>
-			resolver.resolveSync({}, dosFixtures, "./does-not-exist"),
-		).toThrow(/Can't resolve/);
+	test("rejects a missing file under a DOS device context", async () => {
+		await expect(
+			resolver.resolvePromise({}, dosFixtures, "./does-not-exist"),
+		).rejects.toThrow(/Can't resolve/);
 	});
 
 	test("locates the nearest package.json when resolving through \\\\?\\", (done) => {
-		const asyncResolver = ResolverFactory.createResolver({
-			fileSystem: fs,
-			extensions: [".js"],
-			symlinks: false,
-		});
-		asyncResolver.resolve(
+		// Uses the callback form because the `request` (third callback arg)
+		// carries `descriptionFilePath`, which the promise form drops.
+		resolver.resolve(
 			{},
 			path.join(dosFixtures, "foo"),
 			".",

--- a/test/identifier.test.js
+++ b/test/identifier.test.js
@@ -146,6 +146,48 @@ describe("identifier", () => {
 		run(tests);
 	});
 
+	describe("parse identifier. DOS device paths", () => {
+		/** @type {TestSuite[]} */
+		const tests = [
+			// The literal `?` inside `\\?\` is part of the prefix, not a query
+			// separator. Same for the `.` in `\\.\`.
+			{
+				input: "\\\\?\\C:\\foo",
+				expected: ["\\\\?\\C:\\foo", "", ""],
+			},
+			{
+				input: "\\\\.\\C:\\foo",
+				expected: ["\\\\.\\C:\\foo", "", ""],
+			},
+			{
+				input: "\\\\?\\UNC\\server\\share\\file.js",
+				expected: ["\\\\?\\UNC\\server\\share\\file.js", "", ""],
+			},
+			// Query/fragment past the prefix are still parsed normally.
+			{
+				input: "\\\\?\\C:\\foo?bar=1",
+				expected: ["\\\\?\\C:\\foo", "?bar=1", ""],
+			},
+			{
+				input: "\\\\?\\C:\\foo#frag",
+				expected: ["\\\\?\\C:\\foo", "", "#frag"],
+			},
+			{
+				input: "\\\\?\\C:\\foo?q=1#f",
+				expected: ["\\\\?\\C:\\foo", "?q=1", "#f"],
+			},
+			// `\\foo` (plain UNC-ish, not a DOS device path) should not trigger
+			// the prefix skip — its `?` would still be a query separator. We
+			// don't have one to test that the fallback still works unchanged.
+			{
+				input: "\\\\server\\share\\file.js",
+				expected: ["\\\\server\\share\\file.js", "", ""],
+			},
+		];
+
+		run(tests);
+	});
+
 	describe("parse identifier. malformed inputs", () => {
 		it("returns null for a single null-byte input (regex no-match)", () => {
 			expect(parseIdentifier("\0")).toBeNull();

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -53,6 +53,36 @@ describe("util/path getType", () => {
 		expect(getType("9:/foo")).toBe(PathType.Normal);
 		expect(getType("C:foo")).toBe(PathType.Normal);
 	});
+
+	it("classifies DOS device paths as Windows-absolute", () => {
+		// Win32 file namespace (\\?\)
+		expect(getType("\\\\?\\C:\\foo")).toBe(PathType.AbsoluteWin);
+		expect(getType("\\\\?\\C:\\foo\\bar")).toBe(PathType.AbsoluteWin);
+		expect(getType("\\\\?\\UNC\\server\\share")).toBe(PathType.AbsoluteWin);
+		expect(getType("\\\\?\\Volume{abc}\\f")).toBe(PathType.AbsoluteWin);
+		// Win32 device namespace (\\.\)
+		expect(getType("\\\\.\\C:\\foo")).toBe(PathType.AbsoluteWin);
+		expect(getType("\\\\.\\PhysicalDrive0")).toBe(PathType.AbsoluteWin);
+		// Bare prefix still counts — the filesystem will reject it, but
+		// classifying it as Windows-absolute keeps downstream calls on
+		// `path.win32` instead of silently falling back to posix.
+		expect(getType("\\\\?\\")).toBe(PathType.AbsoluteWin);
+		expect(getType("\\\\.\\")).toBe(PathType.AbsoluteWin);
+	});
+
+	it("does not classify non-DOS backslash paths as Windows-absolute", () => {
+		// Plain UNC (\\server\share) is not a DOS device path — don't
+		// misclassify it (its handling is out of scope of this change).
+		expect(getType("\\\\server\\share")).toBe(PathType.Normal);
+		// Too short to match a DOS device prefix.
+		expect(getType("\\\\?")).toBe(PathType.Normal);
+		expect(getType("\\\\.")).toBe(PathType.Normal);
+		// Second char must also be a backslash.
+		expect(getType("\\?\\C:\\foo")).toBe(PathType.Normal);
+		// Forward-slash variants aren't equivalent — Windows won't normalize
+		// a DOS device path expressed with `/`.
+		expect(getType("//?/C:/foo")).toBe(PathType.AbsolutePosix);
+	});
 });
 
 describe("util/path normalize", () => {
@@ -75,6 +105,14 @@ describe("util/path normalize", () => {
 
 	it("normalizes normal paths through posix normalize", () => {
 		expect(normalize("a/b/../c")).toBe("a/c");
+	});
+
+	it("normalizes DOS device paths via win32", () => {
+		expect(normalize("\\\\?\\C:\\foo\\..\\bar")).toBe("\\\\?\\C:\\bar");
+		expect(normalize("\\\\.\\C:\\foo\\..\\bar")).toBe("\\\\.\\C:\\bar");
+		expect(normalize("\\\\?\\UNC\\server\\share\\a\\..\\b")).toBe(
+			"\\\\?\\UNC\\server\\share\\b",
+		);
 	});
 });
 
@@ -101,6 +139,13 @@ describe("util/path join", () => {
 	it("joins rooted windows-style paths", () => {
 		expect(join("C:\\a", "b")).toBe("C:\\a\\b");
 	});
+
+	it("joins DOS device paths with win32 semantics", () => {
+		expect(join("\\\\?\\C:\\a", "b")).toBe("\\\\?\\C:\\a\\b");
+		expect(join("\\\\.\\C:\\a", "b")).toBe("\\\\.\\C:\\a\\b");
+		// Absolute DOS device request wins over any root.
+		expect(join("/posix/root", "\\\\?\\C:\\c")).toBe("\\\\?\\C:\\c");
+	});
 });
 
 describe("util/path dirname", () => {
@@ -111,6 +156,14 @@ describe("util/path dirname", () => {
 
 	it("computes windows dirname for windows absolute paths", () => {
 		expect(dirname("C:\\foo\\bar")).toBe("C:\\foo");
+	});
+
+	it("computes windows dirname for DOS device paths", () => {
+		expect(dirname("\\\\?\\C:\\foo\\bar")).toBe("\\\\?\\C:\\foo");
+		expect(dirname("\\\\.\\C:\\foo\\bar")).toBe("\\\\.\\C:\\foo");
+		expect(dirname("\\\\?\\UNC\\server\\share\\a\\b")).toBe(
+			"\\\\?\\UNC\\server\\share\\a",
+		);
 	});
 });
 


### PR DESCRIPTION
`getType()` previously missed paths starting with `\\?\` (Win32 file
namespace) or `\\.\` (Win32 device namespace), so they fell through to
`Normal` and downstream `normalize`/`dirname`/`join` ran them through
`path.posix` — `..` segments weren't collapsed and `dirname` returned
`"."` instead of the parent directory.

Recognize the two DOS device prefixes in the hot char-code switch and
return `AbsoluteWin` so normalization, dirname, and join use
`path.win32`, which handles these paths correctly.

Plain UNC (`\\server\share`) and forward-slash variants are left alone
— Windows treats DOS device paths as literal and forward slashes are
not equivalent inside them.