### PR TITLE
docs: add resolvePromise examples for Resolver and ResolverFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,16 @@ const resolver = ResolverFactory.createResolver({
 	extensions: [".js", ".json"],
 });
 
+// callback
 resolver.resolve({}, __dirname, "./utils", {}, (err, file) => {
 	// ...
 });
+
+// sync (requires a sync fileSystem)
+const fileSync = resolver.resolveSync({}, __dirname, "./utils");
+
+// promise
+const filePromise = await resolver.resolvePromise({}, __dirname, "./utils", {});
 ```
 
 #### `CachedInputFileSystem(fileSystem, duration)`
@@ -199,6 +206,8 @@ const context = {};
 const lookupStartPath = "/Users/webpack/some/root/dir";
 const request = "./path/to-look-up.js";
 const resolveContext = {};
+
+// callback
 myResolver.resolve(
 	context,
 	lookupStartPath,
@@ -208,6 +217,22 @@ myResolver.resolve(
 		// Do something with the path
 	},
 );
+
+// promise
+try {
+	const filepath = await myResolver.resolvePromise(
+		context,
+		lookupStartPath,
+		request,
+		resolveContext,
+	);
+	// Do something with the path
+} catch (err) {
+	// handle resolve failure
+}
+
+// sync (requires a sync fileSystem, e.g. the default Node.js one)
+const filepath = myResolver.resolveSync(context, lookupStartPath, request);
 ```
 
 #### Resolver Options


### PR DESCRIPTION
The README's `ResolverFactory.createResolver` and "Creating a Resolver"
sections only showed the callback API, even though the prose mentions
all three methods. Add `resolvePromise` (and `resolveSync` where it
made sense) examples so users can see how to consume the promise API
on a resolver instance.