### PR TITLE
perf(benchmark): track memory usage via CodSpeed memory mode

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: ["simulation", "memory"]
+    name: benchmark (${{ matrix.mode }})
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,4 +42,4 @@ jobs:
         uses: CodSpeedHQ/action@db35df748deb45fdef0960669f57d627c1956c30 # v4.13.1
         with:
           run: npm run benchmark
-          mode: "simulation"
+          mode: ${{ matrix.mode }}

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -26,7 +26,8 @@ BENCH_FILTER=pathological npm run benchmark
 Locally the runner uses tinybench's wall-clock measurements and prints a
 table of ops/s, mean, p99, and relative margin of error per task. Under CI,
 the plugin detects the CodSpeed runner environment and switches to
-instruction-counting mode automatically.
+instruction-counting (`simulation`) or heap-allocation (`memory`) mode
+automatically, depending on which CI job invoked it.
 
 The V8 flags in `package.json` (`--no-opt --predictable --hash-seed=1` etc.)
 are required by CodSpeed's instrumentation mode for deterministic results —
@@ -147,8 +148,19 @@ A few rules of thumb:
 ## CI integration
 
 CI is driven by `.github/workflows/benchmarks.yml`, which uses
-`CodSpeedHQ/action@v4` in `mode: "simulation"` and authenticates via the
-`CODSPEED_TOKEN` repo secret.
+`CodSpeedHQ/action@v4` to run the same `npm run benchmark` entry point under
+two modes via a matrix:
 
-Both `CODSPEED_TOKEN` and CodSpeed repo enablement must be configured by a
-repo admin once — see the top-level PR description for the handoff.
+- `simulation` — CPU / instruction-count measurements (the standard CodSpeed
+  performance benchmark).
+- `memory` — heap-allocation measurements via the same instrumentation hooks
+  (`InstrumentHooks.startBenchmark` / `stopBenchmark`); the CodSpeed runner
+  collects allocation stats between those markers instead of instructions.
+
+Both jobs share the same bench cases — `benchmark/with-codspeed.mjs` routes
+both modes through the identical instrumented code path, so there is nothing
+per-case to add for memory tracking.
+
+Authentication is via the `CODSPEED_TOKEN` repo secret. Both `CODSPEED_TOKEN`
+and CodSpeed repo enablement must be configured by a repo admin once — see
+the top-level PR description for the handoff.

--- a/benchmark/with-codspeed.mjs
+++ b/benchmark/with-codspeed.mjs
@@ -15,6 +15,12 @@
  * Modes (via getCodspeedRunnerMode() from @codspeed/core):
  *   "disabled"   — returns the bench untouched (local runs)
  *   "simulation" — overrides bench.run/runSync for CodSpeed instrumentation
+ *                  (instruction-count measurement)
+ *   "memory"     — same instrumentation code path as "simulation"; CodSpeed's
+ *                  runner collects heap allocations via Massif instead of
+ *                  instruction counts. InstrumentHooks.startBenchmark /
+ *                  stopBenchmark are identical — the runner decides what to
+ *                  sample between them.
  *   "walltime"   — left untouched; tinybench's built-in timing is used
  */
 
@@ -92,7 +98,7 @@ export function withCodSpeed(bench) {
 	const mode = getCodspeedRunnerMode();
 	if (mode === "disabled" || mode === "walltime") return bench;
 
-	// --- simulation mode ---
+	// --- instrumented mode (simulation or memory) ---
 
 	const meta = getOrCreateMeta(bench);
 	const rawAdd = bench.add.bind(bench);
@@ -106,7 +112,7 @@ export function withCodSpeed(bench) {
 
 	const setup = () => {
 		setupCore();
-		console.log("[CodSpeed] running in simulation mode");
+		console.log(`[CodSpeed] running in ${mode} mode`);
 	};
 
 	const teardown = () => {


### PR DESCRIPTION
Enables CodSpeed's heap-allocation instrumentation alongside the existing
instruction-count ("simulation") benchmarks. Memory mode reuses the same
InstrumentHooks.startBenchmark/stopBenchmark code path, so no per-case
changes are required — only the wrapper's mode guard and the CI matrix.