### PR TITLE
fix: correctly parse '#' in absolute path directory names (fixes webpack/webpack#16819)

### DIFF
--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -71,7 +71,26 @@ function parseIdentifier(identifier) {
 		identifier.charCodeAt(0) === 92 ? dosPrefixEnd(identifier) : 0;
 	const queryStart = identifier.indexOf("?", scanStart);
 	// Start at index 1 (or past a DOS prefix) to ignore a possible leading hash.
-	const fragmentStart = identifier.indexOf("#", scanStart || 1);
+	let fragmentStart = identifier.indexOf("#", scanStart || 1);
+
+	if (fragmentStart >= 0) {
+		if (identifier.startsWith("/") || /^[a-z]:[\\/]/i.test(identifier)) {
+			for (;;) {
+				const nextSlash = identifier.indexOf("/", fragmentStart + 1);
+				const nextBackslash = identifier.indexOf("\\", fragmentStart + 1);
+				if (
+					(nextSlash !== -1 && (queryStart === -1 || nextSlash < queryStart)) ||
+					(nextBackslash !== -1 &&
+						(queryStart === -1 || nextBackslash < queryStart))
+				) {
+					fragmentStart = identifier.indexOf("#", fragmentStart + 1);
+					if (fragmentStart === -1) break;
+				} else {
+					break;
+				}
+			}
+		}
+	}
 
 	if (fragmentStart < 0) {
 		if (queryStart < 0) {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -73,8 +73,10 @@ function parseIdentifier(identifier) {
 	// Start at index 1 (or past a DOS prefix) to ignore a possible leading hash.
 	let fragmentStart = identifier.indexOf("#", scanStart || 1);
 
-	if (fragmentStart >= 0) {
-		if (identifier.startsWith("/") || /^[a-z]:[\\/]/i.test(identifier)) {
+	if (
+		fragmentStart >= 0 &&
+		(identifier.startsWith("/") || /^[a-z]:[\\/]/i.test(identifier))
+	) {
 			for (;;) {
 				const nextSlash = identifier.indexOf("/", fragmentStart + 1);
 				const nextBackslash = identifier.indexOf("\\", fragmentStart + 1);

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -77,19 +77,18 @@ function parseIdentifier(identifier) {
 		fragmentStart >= 0 &&
 		(identifier.startsWith("/") || /^[a-z]:[\\/]/i.test(identifier))
 	) {
-			for (;;) {
-				const nextSlash = identifier.indexOf("/", fragmentStart + 1);
-				const nextBackslash = identifier.indexOf("\\", fragmentStart + 1);
-				if (
-					(nextSlash !== -1 && (queryStart === -1 || nextSlash < queryStart)) ||
-					(nextBackslash !== -1 &&
-						(queryStart === -1 || nextBackslash < queryStart))
-				) {
-					fragmentStart = identifier.indexOf("#", fragmentStart + 1);
-					if (fragmentStart === -1) break;
-				} else {
-					break;
-				}
+		for (;;) {
+			const nextSlash = identifier.indexOf("/", fragmentStart + 1);
+			const nextBackslash = identifier.indexOf("\\", fragmentStart + 1);
+			if (
+				(nextSlash !== -1 && (queryStart === -1 || nextSlash < queryStart)) ||
+				(nextBackslash !== -1 &&
+					(queryStart === -1 || nextBackslash < queryStart))
+			) {
+				fragmentStart = identifier.indexOf("#", fragmentStart + 1);
+				if (fragmentStart === -1) break;
+			} else {
+				break;
 			}
 		}
 	}

--- a/test/identifier.test.js
+++ b/test/identifier.test.js
@@ -96,7 +96,11 @@ describe("identifier", () => {
 			// (callers must escape '#' in paths via '\0#' — see webpack#16819)
 			{
 				input: "/home/user/projects/test#/webpack/src/file.js",
-				expected: ["/home/user/projects/test", "", "#/webpack/src/file.js"],
+				expected: ["/home/user/projects/test#/webpack/src/file.js", "", ""],
+			},
+			{
+				input: "/abs/path/file.js#fragment",
+				expected: ["/abs/path/file.js", "", "#fragment"],
 			},
 		];
 
@@ -136,10 +140,14 @@ describe("identifier", () => {
 				input: "C:\\Users\\test\0#proj\\webpack\\src\\file.js",
 				expected: ["C:\\Users\\test#proj\\webpack\\src\\file.js", "", ""],
 			},
+			{
+				input: "C:\\abs\\path\\file.js#fragment",
+				expected: ["C:\\abs\\path\\file.js", "", "#fragment"],
+			},
 			// Without escaping, '#' still starts a fragment (caller must escape)
 			{
 				input: "C:\\Users\\test#proj\\webpack\\src\\file.js",
-				expected: ["C:\\Users\\test", "", "#proj\\webpack\\src\\file.js"],
+				expected: ["C:\\Users\\test#proj\\webpack\\src\\file.js", "", ""],
 			},
 		];
 


### PR DESCRIPTION
This PR implements automatic detection for `#` in absolute paths in `parseIdentifier` to resolve webpack/webpack#16819.

Corresponding fix in webpack/webpack: https://github.com/webpack/webpack/pull/20877