### PR TITLE
feat: add hardlinks option to deduplicate hardlinked files by inode

### DIFF
--- a/.changeset/feat-hardlink-dedup.md
+++ b/.changeset/feat-hardlink-dedup.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": minor
+---
+
+Add `hardlinks` option to deduplicate hardlinked files by resolving them to the same canonical path based on filesystem inode. This is useful with pnpm, which hardlinks packages from a global content-addressable store — without this option, bundlers treat each path as a separate module and emit duplicate code. Set `hardlinks: true` to enable.

--- a/.cspell.json
+++ b/.cspell.json
@@ -50,7 +50,10 @@
     "readlink",
     "extensionless",
     "ENOENT",
-    "hardlinks"
+    "hardlinks",
+    "hardlink",
+    "hardlinks",
+    "hardlinked"
   ],
   "ignorePaths": [
     "package.json",

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ const filepath = myResolver.resolveSync(context, lookupStartPath, request);
 | preferAbsolute           | false                       | Prefer to resolve server-relative urls as absolute paths before falling back to resolve in roots                                                                                                                                                                                            |
 | restrictions             | []                          | A list of resolve restrictions                                                                                                                                                                                                                                                              |
 | roots                    | []                          | A list of root paths                                                                                                                                                                                                                                                                        |
+| hardlinks                | false                       | Deduplicate hardlinked files by resolving them to the same path based on filesystem inode. Useful with pnpm, which hardlinks packages from a global store                                                                                                                                   |
 | symlinks                 | true                        | Whether to resolve symlinks to their symlinked location                                                                                                                                                                                                                                     |
 | tsconfig                 | false                       | TypeScript config for paths mapping. Can be `false` (disabled), `true` (use default `tsconfig.json`), a string path to `tsconfig.json`, or an object with `configFile`, `references`, and `baseUrl` options. Supports JSONC format (comments and trailing commas) like TypeScript compiler. |
 | tsconfig.configFile      | tsconfig.json               | Path to the tsconfig.json file                                                                                                                                                                                                                                                              |
@@ -381,6 +382,12 @@ const options = {
 };
 ```
 
+**`hardlinks`** — deduplicate hardlinked files so that multiple paths pointing to the same physical file (same inode) resolve to a single canonical path. This is especially useful with pnpm, which hardlinks packages from a global content-addressable store — without this option, bundlers like webpack treat each path as a separate module and emit duplicate code:
+
+```js
+const options = { hardlinks: true };
+```
+
 **`symlinks`** — resolve to the real path by following symlinks. Set to `false` to keep the symlinked path (common for monorepo / pnpm layouts where you want module identity tied to the workspace location):
 
 ```js
@@ -454,37 +461,38 @@ Plugins are executed in a pipeline, and register which event they should be exec
 
 `enhanced-resolve` ships with the following plugins. Most of them are wired up automatically by `ResolverFactory` based on the [resolver options](#resolver-options); the ones exported from the package entry (`TsconfigPathsPlugin`, `CloneBasenamePlugin`, `LogInfoPlugin`) are the ones you're most likely to use explicitly.
 
-| Plugin                                   | Purpose                                                                                                                              |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `AliasPlugin`                            | Replaces a matching request with one or more alternative targets. Powers the `alias` and `fallback` options.                         |
-| `AliasFieldPlugin`                       | Applies aliasing based on a field in the description file (e.g. the `browser` field). Powers `aliasFields`.                          |
-| `AppendPlugin`                           | Appends a string (typically an extension) to the current path. Used for `extensions`.                                                |
-| `CloneBasenamePlugin`                    | Joins the current directory basename onto the path (e.g. `/foo/bar` → `/foo/bar/bar`). Useful for directory-named main-file schemes. |
-| `ConditionalPlugin`                      | Forwards the request only when it matches a given partial request shape.                                                             |
-| `DescriptionFilePlugin`                  | Finds and loads the nearest description file (e.g. `package.json`) so other plugins can read its fields. Powers `descriptionFiles`.  |
-| `DirectoryExistsPlugin`                  | Only continues the pipeline if the current path is an existing directory.                                                            |
-| `ExportsFieldPlugin`                     | Resolves requests through the `exports` field of a package's description file. Powers `exportsFields` and `conditionNames`.          |
-| `ExtensionAliasPlugin`                   | Maps one extension to a list of alternative extensions (e.g. `.js` → `.ts`, `.js`). Powers `extensionAlias`.                         |
-| `FileExistsPlugin`                       | Only continues the pipeline if the current path is an existing file, and records the file as a dependency.                           |
-| `ImportsFieldPlugin`                     | Resolves `#name` requests through the `imports` field of the enclosing package.                                                      |
-| `JoinRequestPlugin`                      | Joins the current path with the current request into a new path.                                                                     |
-| `JoinRequestPartPlugin`                  | Splits a module request into module name + inner request, joining the inner request onto the path.                                   |
-| `LogInfoPlugin`                          | Emits verbose log output at a given pipeline step. Handy for debugging resolves via `resolveContext.log`.                            |
-| `MainFieldPlugin`                        | Uses a field in the description file (e.g. `main`) to point to the entry file of a package. Powers `mainFields`.                     |
-| `ModulesInHierarchicalDirectoriesPlugin` | Searches for a module by walking up parent directories (the standard `node_modules` lookup). Powers `modules`.                       |
-| `ModulesInRootPlugin`                    | Searches for a module in a single absolute directory. Powers absolute-path entries in `modules`.                                     |
-| `NextPlugin`                             | Forwards the request from one hook to another without modification — glue between pipeline steps.                                    |
-| `ParsePlugin`                            | Parses a raw request string into its components (path, query, fragment, module flag, etc.).                                          |
-| `PnpPlugin`                              | Resolves module requests through a Yarn PnP API when one is available.                                                               |
-| `RestrictionsPlugin`                     | Rejects results that don't match a list of path restrictions (strings or regular expressions). Powers `restrictions`.                |
-| `ResultPlugin`                           | Terminal plugin that fires the `result` hook — signals a successful resolve.                                                         |
-| `RootsPlugin`                            | Resolves server-relative URL requests (starting with `/`) against one or more root directories. Powers `roots`.                      |
-| `SelfReferencePlugin`                    | Resolves a package self-reference (e.g. `my-pkg/foo` from within `my-pkg`).                                                          |
-| `SymlinkPlugin`                          | Real paths the resolved file by following symlinks. Can be disabled via the `symlinks` option.                                       |
-| `TryNextPlugin`                          | Forwards the request to the next hook with a log message. Useful for trying alternative resolutions.                                 |
-| `TsconfigPathsPlugin`                    | Rewrites requests using the `paths` and `baseUrl` from a `tsconfig.json`. Powers the `tsconfig` option.                              |
-| `UnsafeCachePlugin`                      | Caches successful resolves in an in-memory map to speed up repeated requests. Powers `unsafeCache`.                                  |
-| `UseFilePlugin`                          | Joins a fixed filename onto the current path (e.g. `index`). Powers `mainFiles`.                                                     |
+| Plugin                                   | Purpose                                                                                                                                                  |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AliasPlugin`                            | Replaces a matching request with one or more alternative targets. Powers the `alias` and `fallback` options.                                             |
+| `AliasFieldPlugin`                       | Applies aliasing based on a field in the description file (e.g. the `browser` field). Powers `aliasFields`.                                              |
+| `AppendPlugin`                           | Appends a string (typically an extension) to the current path. Used for `extensions`.                                                                    |
+| `CloneBasenamePlugin`                    | Joins the current directory basename onto the path (e.g. `/foo/bar` → `/foo/bar/bar`). Useful for directory-named main-file schemes.                     |
+| `ConditionalPlugin`                      | Forwards the request only when it matches a given partial request shape.                                                                                 |
+| `DescriptionFilePlugin`                  | Finds and loads the nearest description file (e.g. `package.json`) so other plugins can read its fields. Powers `descriptionFiles`.                      |
+| `DirectoryExistsPlugin`                  | Only continues the pipeline if the current path is an existing directory.                                                                                |
+| `ExportsFieldPlugin`                     | Resolves requests through the `exports` field of a package's description file. Powers `exportsFields` and `conditionNames`.                              |
+| `ExtensionAliasPlugin`                   | Maps one extension to a list of alternative extensions (e.g. `.js` → `.ts`, `.js`). Powers `extensionAlias`.                                             |
+| `FileExistsPlugin`                       | Only continues the pipeline if the current path is an existing file, and records the file as a dependency.                                               |
+| `HardlinkPlugin`                         | Deduplicates hardlinked files by mapping inode to a canonical path, so multiple paths to the same physical file resolve identically. Powers `hardlinks`. |
+| `ImportsFieldPlugin`                     | Resolves `#name` requests through the `imports` field of the enclosing package.                                                                          |
+| `JoinRequestPlugin`                      | Joins the current path with the current request into a new path.                                                                                         |
+| `JoinRequestPartPlugin`                  | Splits a module request into module name + inner request, joining the inner request onto the path.                                                       |
+| `LogInfoPlugin`                          | Emits verbose log output at a given pipeline step. Handy for debugging resolves via `resolveContext.log`.                                                |
+| `MainFieldPlugin`                        | Uses a field in the description file (e.g. `main`) to point to the entry file of a package. Powers `mainFields`.                                         |
+| `ModulesInHierarchicalDirectoriesPlugin` | Searches for a module by walking up parent directories (the standard `node_modules` lookup). Powers `modules`.                                           |
+| `ModulesInRootPlugin`                    | Searches for a module in a single absolute directory. Powers absolute-path entries in `modules`.                                                         |
+| `NextPlugin`                             | Forwards the request from one hook to another without modification — glue between pipeline steps.                                                        |
+| `ParsePlugin`                            | Parses a raw request string into its components (path, query, fragment, module flag, etc.).                                                              |
+| `PnpPlugin`                              | Resolves module requests through a Yarn PnP API when one is available.                                                                                   |
+| `RestrictionsPlugin`                     | Rejects results that don't match a list of path restrictions (strings or regular expressions). Powers `restrictions`.                                    |
+| `ResultPlugin`                           | Terminal plugin that fires the `result` hook — signals a successful resolve.                                                                             |
+| `RootsPlugin`                            | Resolves server-relative URL requests (starting with `/`) against one or more root directories. Powers `roots`.                                          |
+| `SelfReferencePlugin`                    | Resolves a package self-reference (e.g. `my-pkg/foo` from within `my-pkg`).                                                                              |
+| `SymlinkPlugin`                          | Real paths the resolved file by following symlinks. Can be disabled via the `symlinks` option.                                                           |
+| `TryNextPlugin`                          | Forwards the request to the next hook with a log message. Useful for trying alternative resolutions.                                                     |
+| `TsconfigPathsPlugin`                    | Rewrites requests using the `paths` and `baseUrl` from a `tsconfig.json`. Powers the `tsconfig` option.                                                  |
+| `UnsafeCachePlugin`                      | Caches successful resolves in an in-memory map to speed up repeated requests. Powers `unsafeCache`.                                                      |
+| `UseFilePlugin`                          | Joins a fixed filename onto the current path (e.g. `index`). Powers `mainFiles`.                                                                         |
 
 #### Plugin wiring and goals
 
@@ -500,6 +508,7 @@ One-line goal and default wiring (`source → target`) for each plugin. `*` mean
 - **`ExportsFieldPlugin`** — Goal: map a request through the `exports` field of a package's description file (with `conditionNames`). `resolve-in-package` → `relative`.
 - **`ExtensionAliasPlugin`** — Goal: rewrite a request's extension to a list of candidate extensions (e.g. `.js` → `.ts`, `.js`) for TypeScript ESM and similar. `raw-resolve` → `normal-resolve` for direct requests; also `imports-field-relative` → `relative` so extension substitution applies to `imports`-field targets.
 - **`FileExistsPlugin`** — Goal: confirm a candidate path exists as a file and record it as a file dependency. `final-file` → `existing-file`.
+- **`HardlinkPlugin`** — Goal: deduplicate hardlinked files by caching the first-seen path for each filesystem inode; subsequent files with the same inode resolve to the canonical path. Tapped on `resolved` (only when `hardlinks` is enabled).
 - **`ImportsFieldPlugin`** — Goal: resolve `#name` requests through the `imports` field of the enclosing package. `internal` → `imports-field-relative` (relative target) or `imports-resolve` (bare target).
 - **`JoinRequestPlugin`** — Goal: join the current path with the current request into a single concrete path. `after-normal-resolve` → `relative` (three stage-offset copies for `preferRelative`, `preferAbsolute`, and default), `resolve-in-existing-directory` → `relative`.
 - **`JoinRequestPartPlugin`** — Goal: split a module request into module name + inner request, joining the inner part onto the path. `module` → `resolve-as-module`.

--- a/lib/HardlinkPlugin.js
+++ b/lib/HardlinkPlugin.js
@@ -1,0 +1,73 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Natsu @xiaoxiaojx
+*/
+
+"use strict";
+
+/** @typedef {import("./Resolver")} Resolver */
+/** @typedef {import("./Resolver").FileSystem} FileSystem */
+/** @typedef {import("./Resolver").ResolveRequest} ResolveRequest */
+/** @typedef {import("./Resolver").ResolveStepHook} ResolveStepHook */
+
+/**
+ * Per-filesystem inode cache. The cache lifetime is tied to the filesystem
+ * object (same invariant as `_pathCacheByFs` in `Resolver.js`): when the
+ * user swaps filesystems the entries become unreachable and get collected.
+ * @type {WeakMap<FileSystem, Map<string, ResolveRequest>>}
+ */
+const _inodeCacheByFs = new WeakMap();
+
+module.exports = class HardlinkPlugin {
+	/**
+	 * @param {string | ResolveStepHook} source source
+	 */
+	constructor(source) {
+		this.source = source;
+	}
+
+	/**
+	 * @param {Resolver} resolver the resolver
+	 * @returns {void}
+	 */
+	apply(resolver) {
+		const fs = resolver.fileSystem;
+		let cache = _inodeCacheByFs.get(fs);
+		if (cache === undefined) {
+			cache = new Map();
+			_inodeCacheByFs.set(fs, cache);
+		}
+		const inodeCache = cache;
+
+		resolver
+			.getHook(this.source)
+			.tapAsync("HardlinkPlugin", (request, resolveContext, callback) => {
+				const filePath = request.path;
+				if (!filePath) return callback();
+
+				fs.stat(filePath, (err, stat) => {
+					if (err || !stat || !stat.isFile()) return callback();
+
+					const { ino } = stat;
+					if (ino === 0) return callback();
+
+					const key = `${stat.dev}:${ino}`;
+					const cached = inodeCache.get(key);
+
+					if (cached !== undefined) {
+						if (cached.path !== filePath) {
+							if (resolveContext.log) {
+								resolveContext.log(
+									`deduplicated hardlink ${filePath} to ${cached.path}`,
+								);
+							}
+							return callback(null, cached);
+						}
+					} else {
+						inodeCache.set(key, { ...request });
+					}
+					callback();
+				});
+			});
+	}
+};

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -17,6 +17,7 @@ const DirectoryExistsPlugin = require("./DirectoryExistsPlugin");
 const ExportsFieldPlugin = require("./ExportsFieldPlugin");
 const ExtensionAliasPlugin = require("./ExtensionAliasPlugin");
 const FileExistsPlugin = require("./FileExistsPlugin");
+const HardlinkPlugin = require("./HardlinkPlugin");
 const ImportsFieldPlugin = require("./ImportsFieldPlugin");
 const JoinRequestPartPlugin = require("./JoinRequestPartPlugin");
 const JoinRequestPlugin = require("./JoinRequestPlugin");
@@ -80,6 +81,7 @@ const { PathType, getType } = require("./util/path");
  * @property {FileSystem} fileSystem The file system which should be used
  * @property {(Cache | boolean)=} unsafeCache Use this cache object to unsafely cache the successful requests
  * @property {boolean=} symlinks Resolve symlinks to their symlinked location
+ * @property {boolean=} hardlinks Deduplicate hardlinked files by resolving them to the same path based on filesystem inode
  * @property {Resolver=} resolver A prepared Resolver to which the plugins are attached
  * @property {string[] | string=} modules A list of directories to resolve modules from, can be absolute path or folder name
  * @property {(string | string[] | { name: string | string[], forceRelative: boolean })[]=} mainFields A list of main fields in description files
@@ -114,6 +116,7 @@ const { PathType, getType } = require("./util/path");
  * @property {FileSystem} fileSystem fileSystem
  * @property {Cache | false} unsafeCache unsafe cache
  * @property {boolean} symlinks symlinks
+ * @property {boolean} hardlinks hardlinks
  * @property {Resolver=} resolver resolver
  * @property {(string | string[])[]} modules modules
  * @property {{ name: string[], forceRelative: boolean }[]} mainFields main fields
@@ -285,6 +288,7 @@ function createOptions(options) {
 				? /** @type {Cache} */ ({})
 				: options.unsafeCache || false,
 		symlinks: typeof options.symlinks !== "undefined" ? options.symlinks : true,
+		hardlinks: options.hardlinks || false,
 		resolver: options.resolver,
 		modules: mergeFilteredToArray(
 			Array.isArray(options.modules)
@@ -344,6 +348,7 @@ module.exports.createResolver = function createResolver(options) {
 		preferRelative,
 		preferAbsolute,
 		symlinks,
+		hardlinks,
 		unsafeCache,
 		resolver: customResolver,
 		restrictions,
@@ -769,6 +774,9 @@ module.exports.createResolver = function createResolver(options) {
 		(resolver.hooks);
 
 	// resolved
+	if (hardlinks) {
+		plugins.push(new HardlinkPlugin(resolved));
+	}
 	if (restrictions.size > 0) {
 		plugins.push(new RestrictionsPlugin(resolved, restrictions));
 	}

--- a/test/hardlink.test.js
+++ b/test/hardlink.test.js
@@ -1,0 +1,216 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { CachedInputFileSystem, ResolverFactory } = require("../");
+
+const tempPath = path.join(__dirname, "temp-hardlink");
+
+/**
+ * Create a resolver with a fresh CachedInputFileSystem to avoid
+ * stale stat caches across tests.
+ * @param {object} options resolver options
+ * @returns {{ resolve: (context: string, request: string, callback: (err: Error | null, result?: string) => void) => void, resolveSync: (context: string, request: string) => string | false }} resolver pair
+ */
+function createResolvers(options) {
+	const fileSystem = new CachedInputFileSystem(fs, 0);
+	const asyncResolver = ResolverFactory.createResolver({
+		fileSystem,
+		...options,
+	});
+	const syncResolver = ResolverFactory.createResolver({
+		fileSystem,
+		useSyncFileSystemCalls: true,
+		...options,
+	});
+	return {
+		resolve(context, request, callback) {
+			asyncResolver.resolve({}, context, request, {}, callback);
+		},
+		resolveSync(context, request) {
+			return syncResolver.resolveSync({}, context, request);
+		},
+	};
+}
+
+describe("hardlink", () => {
+	let canHardlink = true;
+
+	// Pre-check: verify we can create hardlinks on this filesystem
+	try {
+		fs.mkdirSync(tempPath, { recursive: true });
+		const testFile = path.join(tempPath, "_probe");
+		const testLink = path.join(tempPath, "_probe_link");
+		fs.writeFileSync(testFile, "probe");
+		fs.linkSync(testFile, testLink);
+		const origStat = fs.statSync(testFile);
+		const linkStat = fs.statSync(testLink);
+		canHardlink = origStat.ino === linkStat.ino && origStat.ino !== 0;
+		fs.unlinkSync(testLink);
+		fs.unlinkSync(testFile);
+		fs.rmSync(tempPath, { recursive: true, force: true });
+	} catch (_err) {
+		canHardlink = false;
+	}
+
+	if (canHardlink) {
+		// Simulate pnpm-like layout:
+		// store/pkg/{package.json,index.js}           — original files
+		// project-a/node_modules/pkg/{...}            — hardlinks to store
+		// project-b/node_modules/pkg/{...}            — hardlinks to store
+		// project-c/node_modules/pkg/{...}            — separate copies (different inode)
+		const storePkg = path.join(tempPath, "store", "pkg");
+		const projA = path.join(tempPath, "project-a");
+		const projB = path.join(tempPath, "project-b");
+		const projC = path.join(tempPath, "project-c");
+		const pkgA = path.join(projA, "node_modules", "pkg");
+		const pkgB = path.join(projB, "node_modules", "pkg");
+		const pkgC = path.join(projC, "node_modules", "pkg");
+
+		beforeEach(() => {
+			// Create store
+			fs.mkdirSync(storePkg, { recursive: true });
+			fs.writeFileSync(
+				path.join(storePkg, "package.json"),
+				JSON.stringify({ name: "pkg", version: "1.0.0", main: "index.js" }),
+			);
+			fs.writeFileSync(
+				path.join(storePkg, "index.js"),
+				"module.exports = 'pkg';",
+			);
+
+			// Create hardlinked copies for project-a and project-b
+			for (const pkgDir of [pkgA, pkgB]) {
+				fs.mkdirSync(pkgDir, { recursive: true });
+				fs.linkSync(
+					path.join(storePkg, "package.json"),
+					path.join(pkgDir, "package.json"),
+				);
+				fs.linkSync(
+					path.join(storePkg, "index.js"),
+					path.join(pkgDir, "index.js"),
+				);
+			}
+
+			// Create a separate (non-hardlinked) copy for project-c
+			fs.mkdirSync(pkgC, { recursive: true });
+			fs.writeFileSync(
+				path.join(pkgC, "package.json"),
+				JSON.stringify({ name: "pkg", version: "1.0.0", main: "index.js" }),
+			);
+			fs.writeFileSync(
+				path.join(pkgC, "index.js"),
+				"module.exports = 'pkg-different';",
+			);
+		});
+
+		afterEach(() => {
+			fs.rmSync(tempPath, { recursive: true, force: true });
+		});
+
+		it("should confirm hardlinked files share the same inode", () => {
+			const statA = fs.statSync(path.join(pkgA, "index.js"));
+			const statB = fs.statSync(path.join(pkgB, "index.js"));
+			expect(statA.ino).toBe(statB.ino);
+			expect(statA.dev).toBe(statB.dev);
+		});
+
+		it("should resolve hardlinked files to different paths by default", (done) => {
+			const { resolve } = createResolvers({
+				extensions: [".js"],
+				symlinks: false,
+			});
+
+			resolve(projA, "pkg", (err, resultA) => {
+				if (err) return done(err);
+				resolve(projB, "pkg", (err, resultB) => {
+					if (err) return done(err);
+					expect(resultA).toBe(path.join(pkgA, "index.js"));
+					expect(resultB).toBe(path.join(pkgB, "index.js"));
+					expect(resultA).not.toBe(resultB);
+					done();
+				});
+			});
+		});
+
+		it("should resolve hardlinked files to the same path with hardlinks option", (done) => {
+			const { resolve } = createResolvers({
+				extensions: [".js"],
+				symlinks: false,
+				hardlinks: true,
+			});
+
+			resolve(projA, "pkg", (err, resultA) => {
+				if (err) return done(err);
+				resolve(projB, "pkg", (err, resultB) => {
+					if (err) return done(err);
+					expect(resultA).toBe(resultB);
+					done();
+				});
+			});
+		});
+
+		it("should not deduplicate files with different inodes", (done) => {
+			const statA = fs.statSync(path.join(pkgA, "index.js"));
+			const statC = fs.statSync(path.join(pkgC, "index.js"));
+			expect(statA.ino).not.toBe(statC.ino);
+
+			const { resolve } = createResolvers({
+				extensions: [".js"],
+				symlinks: false,
+				hardlinks: true,
+			});
+
+			resolve(projA, "pkg", (err, resultA) => {
+				if (err) return done(err);
+				resolve(projC, "pkg", (err, resultC) => {
+					if (err) return done(err);
+					expect(resultA).not.toBe(resultC);
+					done();
+				});
+			});
+		});
+
+		it("should resolve hardlinked files to the same path (sync)", () => {
+			const { resolveSync } = createResolvers({
+				extensions: [".js"],
+				symlinks: false,
+				hardlinks: true,
+			});
+
+			const resultA = resolveSync(projA, "pkg");
+			const resultB = resolveSync(projB, "pkg");
+
+			expect(resultA).toBe(resultB);
+		});
+
+		it("should check restrictions against the canonical path", (done) => {
+			// restrictions allows project-a but not project-b.
+			// project-b's hardlink resolves to project-a's canonical path,
+			// so it passes restrictions even though project-b is not listed.
+			const { resolve } = createResolvers({
+				extensions: [".js"],
+				symlinks: false,
+				hardlinks: true,
+				restrictions: [pkgA],
+			});
+
+			resolve(projA, "pkg", (err, resultA) => {
+				if (err) return done(err);
+				expect(resultA).toBe(path.join(pkgA, "index.js"));
+
+				resolve(projB, "pkg", (err, resultB) => {
+					if (err) return done(err);
+					// project-b's path was rewritten to project-a's canonical path,
+					// which is inside the restriction — so it passes
+					expect(resultB).toBe(path.join(pkgA, "index.js"));
+					done();
+				});
+			});
+		});
+	} else {
+		it("cannot test hardlinks on this filesystem", () => {
+			expect(canHardlink).toBe(false);
+		});
+	}
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -1342,6 +1342,11 @@ declare interface ResolveOptionsResolverFactoryObject_1 {
 	symlinks: boolean;
 
 	/**
+	 * hardlinks
+	 */
+	hardlinks: boolean;
+
+	/**
 	 * resolver
 	 */
 	resolver?: Resolver;
@@ -1486,6 +1491,11 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	 * Resolve symlinks to their symlinked location
 	 */
 	symlinks?: boolean;
+
+	/**
+	 * Deduplicate hardlinked files by resolving them to the same path based on filesystem inode
+	 */
+	hardlinks?: boolean;
 
 	/**
 	 * A prepared Resolver to which the plugins are attached


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
feat https://github.com/webpack/enhanced-resolve/issues/410

When pnpm hardlinks packages from a global store, bundlers treat each path as a separate module despite them being the same physical file. Add a `hardlinks` option (default: false) that uses filesystem inode to detect hardlinked files and resolve them to a single canonical path.

- Add HardlinkPlugin with per-filesystem WeakMap inode cache
- Register on the `resolved` hook in ResolverFactory
- Add tests covering dedup, non-dedup, and sync resolver
- Update README with option docs and plugin description

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feat

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
Nothing