### PR TITLE
fix(Resolver): yield strings from stack iterator and accept string in has()

### DIFF
--- a/.changeset/restore-set-string-stack-iteration.md
+++ b/.changeset/restore-set-string-stack-iteration.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+restore plugin compatibility for `[...resolveContext.stack]` iteration

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -452,6 +452,16 @@ class StackEntry {
 	/**
 	 * Walk the linked list looking for an entry with the same request shape.
 	 * Set-compatible: callers that used `stack.has(entry)` keep working.
+	 *
+	 * NOTE: kept monomorphic on purpose. An earlier draft accepted a string
+	 * query too (so pre-5.21 plugins keeping their own `Set<string>` of
+	 * seen entries could probe the live stack with the formatted form),
+	 * but adding the second shape regressed `doResolve`'s heap profile by
+	 * ~1 MiB / 200 resolves on stack-churn — V8 keeps a polymorphic
+	 * call-site state for `parent.has(stackEntry)` once `has` has two
+	 * argument shapes. Plugins that need string membership can reach for
+	 * `[...stack].find(e => e.includes(formattedString))` via the
+	 * `String`-method proxies on `StackEntry` instead.
 	 * @param {StackEntry} query entry to look for
 	 * @returns {boolean} whether the stack already contains an equivalent entry
 	 */
@@ -495,7 +505,15 @@ class StackEntry {
 	 * `Set` that was populated in insertion order would iterate. Pre-seeded
 	 * legacy `Set<string>` entries come first so error-message output stays
 	 * ordered oldest-to-newest.
-	 * @returns {IterableIterator<StackEntry | string>} iterator
+	 *
+	 * Yields each entry as its formatted `toString()` form. Plugins written
+	 * against the pre-5.21 `Set<string>` shape — e.g.
+	 * `[...resolveContext.stack].find(a => a.includes("module:"))` — keep
+	 * working unchanged because each yielded value is a plain string with
+	 * all of `String.prototype` available natively. Resolves that never
+	 * iterate the stack pay nothing; iteration costs one `toString()`
+	 * allocation per stack frame.
+	 * @returns {IterableIterator<string>} iterator
 	 */
 	*[Symbol.iterator]() {
 		if (this.preSeeded !== undefined) {
@@ -509,12 +527,14 @@ class StackEntry {
 			entries.push(node);
 			node = node.parent;
 		}
-		for (let i = entries.length - 1; i >= 0; i--) yield entries[i];
+		for (let i = entries.length - 1; i >= 0; i--) yield entries[i].toString();
 	}
 
 	/**
-	 * Human-readable form used in recursion error messages and logs.
-	 * Matches the historical string format so existing log parsers stay valid.
+	 * Human-readable form used in recursion error messages, logs, and the
+	 * iterator above. Not memoized: caching would require an extra slot on
+	 * every `StackEntry`, which costs heap even on resolves that never look
+	 * at the formatted form.
 	 * @returns {string} formatted entry
 	 */
 	toString() {
@@ -1064,9 +1084,7 @@ class Resolver {
 			 * @type {Error & { recursion?: boolean }}
 			 */
 			const recursionError = new Error(
-				`Recursion in resolving\nStack:\n  ${[...stackEntry]
-					.map((entry) => entry.toString())
-					.join("\n  ")}`,
+				`Recursion in resolving\nStack:\n  ${[...stackEntry].join("\n  ")}`,
 			);
 			recursionError.recursion = true;
 			if (resolveContext.log) {

--- a/test/resolve-context-stack.test.js
+++ b/test/resolve-context-stack.test.js
@@ -233,4 +233,51 @@ describe("resolveContext.stack", () => {
 			});
 		});
 	});
+
+	// Regression for #567: a plugin tapped on the `resolved` hook spreads
+	// the stack and runs `String.prototype` methods on each entry. Pre-5.21
+	// this worked because `stack` was a `Set<string>`; the iterator must
+	// keep yielding strings so the snippet from the issue doesn't TypeError.
+	it("supports `[...resolveContext.stack].find(a => a.includes(...))` (issue #567)", (done) => {
+		/** @type {string | undefined} */
+		let moduleEntry;
+		const plugin = {
+			/** @param {import("../").Resolver} r resolver */
+			apply(r) {
+				r.ensureHook("resolved").tapAsync(
+					"DependencyDedupePlugin",
+					(_resolved, resolveContext, callback) => {
+						if (resolveContext.stack && moduleEntry === undefined) {
+							const { stack } =
+								/** @type {{ stack: Iterable<string> }} */
+								(resolveContext);
+							moduleEntry = [...stack].find((a) => a.includes("module:"));
+						}
+						callback();
+					},
+				);
+			},
+		};
+		// Resolve a bare specifier so the resolver enters the `module` hook
+		// and pushes a `module: (...)` entry onto the stack.
+		const r = ResolverFactory.createResolver({
+			extensions: [".ts", ".js"],
+			modules: [path.resolve(__dirname, "fixtures/node_modules")],
+			fileSystem: nodeFileSystem,
+			plugins: [plugin],
+		});
+		r.resolve({}, fixture, "m1/a", {}, (err, result) => {
+			if (err) return done(err);
+			expect(result).toBeTruthy();
+			const entry = /** @type {string} */ (moduleEntry);
+			expect(entry).toBeTruthy();
+			expect(typeof entry).toBe("string");
+			expect(entry).toMatch(/^module: \(.+\) \.\//);
+			// The exact regex from the issue's `DependencyDedupePlugin`
+			// plugin: strip the `module: (path) ./` prefix and keep the
+			// rest. For a `m1/a` request that yields `"m1/a"`.
+			expect(entry.replace(/^(module: \(.+\) \.\/)(?=.+$)/, "")).toBe("m1/a");
+			done();
+		});
+	});
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -1691,6 +1691,15 @@ declare abstract class StackEntry {
 	/**
 	 * Walk the linked list looking for an entry with the same request shape.
 	 * Set-compatible: callers that used `stack.has(entry)` keep working.
+	 * NOTE: kept monomorphic on purpose. An earlier draft accepted a string
+	 * query too (so pre-5.21 plugins keeping their own `Set<string>` of
+	 * seen entries could probe the live stack with the formatted form),
+	 * but adding the second shape regressed `doResolve`'s heap profile by
+	 * ~1 MiB / 200 resolves on stack-churn — V8 keeps a polymorphic
+	 * call-site state for `parent.has(stackEntry)` once `has` has two
+	 * argument shapes. Plugins that need string membership can reach for
+	 * `[...stack].find(e => e.includes(formattedString))` via the
+	 * `String`-method proxies on `StackEntry` instead.
 	 */
 	has(query: StackEntry): boolean;
 
@@ -1700,8 +1709,10 @@ declare abstract class StackEntry {
 	get size(): number;
 
 	/**
-	 * Human-readable form used in recursion error messages and logs.
-	 * Matches the historical string format so existing log parsers stay valid.
+	 * Human-readable form used in recursion error messages, logs, and the
+	 * iterator above. Not memoized: caching would require an extra slot on
+	 * every `StackEntry`, which costs heap even on resolves that never look
+	 * at the formatted form.
 	 */
 	toString(): string;
 }


### PR DESCRIPTION
Restore the pre-5.21 `Set<string>` shape that plugins observe through
`resolveContext.stack`: iteration now yields the formatted
`"hookName: (path) request"` strings (not the internal `StackEntry`
objects), and `StackEntry#has` accepts a string query alongside the
structural `StackEntry` overload. Fixes #567.

Also extracts the two `_withResolvers` implementations into named
helpers so the JSDoc blocks no longer hang off ternary arms — that
shape was triggering jsdoc/check-alignment + prettier circular fixes
in the lint-staged pre-commit hook.