### PR TITLE
fix: make TsconfigPathsPlugin work with sync file systems (#571)

### DIFF
--- a/.changeset/tsconfig-paths-plugin-sync.md
+++ b/.changeset/tsconfig-paths-plugin-sync.md
@@ -2,4 +2,4 @@
 "enhanced-resolve": patch
 ---
 
-Fix `TsconfigPathsPlugin` to support synchronous resolution. The plugin was implemented with `async`/`await` and `Promise`-wrapped file system calls, so its `tapAsync` handlers always invoked their callback after a Promise tick. That made `resolveSync` throw `Cannot 'resolveSync' because the fileSystem is not sync. Use 'resolve'!` whenever `tsconfig` was enabled, even with `useSyncFileSystemCalls: true` (issue #571). The plugin and `util/fs#readJson` are now callback-based, so when the underlying file system is synchronous the entire chain stays synchronous and `resolveSync` works as expected.
+fix `TsconfigPathsPlugin` to support `resolveSync` with `useSyncFileSystemCalls`

--- a/.changeset/tsconfig-paths-plugin-sync.md
+++ b/.changeset/tsconfig-paths-plugin-sync.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Fix `TsconfigPathsPlugin` to support synchronous resolution. The plugin was implemented with `async`/`await` and `Promise`-wrapped file system calls, so its `tapAsync` handlers always invoked their callback after a Promise tick. That made `resolveSync` throw `Cannot 'resolveSync' because the fileSystem is not sync. Use 'resolve'!` whenever `tsconfig` was enabled, even with `useSyncFileSystemCalls: true` (issue #571). The plugin and `util/fs#readJson` are now callback-based, so when the underlying file system is synchronous the entire chain stays synchronous and `resolveSync` works as expected.

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -212,65 +212,56 @@ module.exports = class TsconfigPathsPlugin {
 		const aliasTarget = resolver.ensureHook("internal-resolve");
 		const moduleTarget = resolver.ensureHook("module");
 
-		resolver
-			.getHook("raw-resolve")
-			.tapAsync("TsconfigPathsPlugin", (request, resolveContext, callback) => {
-				this._getTsconfigPathsMap(
-					resolver,
-					request,
-					resolveContext,
-					(err, tsconfigPathsMap) => {
-						if (err) return callback(err);
-						if (!tsconfigPathsMap) return callback();
-
-						const selectedData = this._selectPathsDataForContext(
-							request.path,
-							tsconfigPathsMap,
-						);
-
-						if (!selectedData) return callback();
-
-						aliasResolveHandler(
+		/**
+		 * @template T
+		 * @param {string} hookName hook name
+		 * @param {ResolveStepHook} target target hook
+		 * @param {(data: TsconfigPathsData) => T} pickField pick alias/modules field
+		 * @param {(resolver: Resolver, value: T, target: ResolveStepHook, request: ResolveRequest, resolveContext: ResolveContext, callback: (err?: null | Error, result?: null | ResolveRequest) => void) => void} handler handler
+		 * @returns {void}
+		 */
+		const tap = (hookName, target, pickField, handler) => {
+			resolver
+				.getHook(hookName)
+				.tapAsync(
+					"TsconfigPathsPlugin",
+					(request, resolveContext, callback) => {
+						this._getTsconfigPathsMap(
 							resolver,
-							selectedData.alias,
-							aliasTarget,
 							request,
 							resolveContext,
-							callback,
+							(err, tsconfigPathsMap) => {
+								if (err) return callback(err);
+								if (!tsconfigPathsMap) return callback();
+
+								const selectedData = this._selectPathsDataForContext(
+									request.path,
+									tsconfigPathsMap,
+								);
+
+								if (!selectedData) return callback();
+
+								handler(
+									resolver,
+									pickField(selectedData),
+									target,
+									request,
+									resolveContext,
+									callback,
+								);
+							},
 						);
 					},
 				);
-			});
+		};
 
-		resolver
-			.getHook("raw-module")
-			.tapAsync("TsconfigPathsPlugin", (request, resolveContext, callback) => {
-				this._getTsconfigPathsMap(
-					resolver,
-					request,
-					resolveContext,
-					(err, tsconfigPathsMap) => {
-						if (err) return callback(err);
-						if (!tsconfigPathsMap) return callback();
-
-						const selectedData = this._selectPathsDataForContext(
-							request.path,
-							tsconfigPathsMap,
-						);
-
-						if (!selectedData) return callback();
-
-						modulesResolveHandler(
-							resolver,
-							selectedData.modules,
-							moduleTarget,
-							request,
-							resolveContext,
-							callback,
-						);
-					},
-				);
-			});
+		tap("raw-resolve", aliasTarget, (data) => data.alias, aliasResolveHandler);
+		tap(
+			"raw-module",
+			moduleTarget,
+			(data) => data.modules,
+			modulesResolveHandler,
+		);
 	}
 
 	/**
@@ -562,14 +553,8 @@ module.exports = class TsconfigPathsPlugin {
 		if (references.length === 0) return callback(null);
 
 		let pending = references.length;
-		let done = false;
 		const finishOne = () => {
-			if (done) return;
-			pending--;
-			if (pending === 0) {
-				done = true;
-				callback(null);
-			}
+			if (--pending === 0) callback(null);
 		};
 
 		for (const ref of references) {
@@ -585,10 +570,9 @@ module.exports = class TsconfigPathsPlugin {
 				fileDependencies,
 				undefined,
 				(err, refConfig) => {
-					if (err) {
-						// continue
-						return finishOne();
-					}
+					// Failures are swallowed to match tsconfig-paths-webpack-plugin:
+					// a broken reference must not abort the main project's resolution.
+					if (err) return finishOne();
 
 					const cfg = /** @type {Tsconfig} */ (refConfig);
 					if (cfg.compilerOptions && cfg.compilerOptions.paths) {
@@ -609,7 +593,7 @@ module.exports = class TsconfigPathsPlugin {
 							cfg.references,
 							fileDependencies,
 							referenceMatchMap,
-							() => finishOne(),
+							finishOne,
 						);
 					} else {
 						finishOne();
@@ -624,8 +608,8 @@ module.exports = class TsconfigPathsPlugin {
 	 * @param {Resolver} resolver the resolver
 	 * @param {string} configFilePath absolute path to tsconfig.json
 	 * @param {Set<string>} fileDependencies the file dependencies
-	 * @param {Set<string>=} visitedConfigPaths config paths being loaded (for circular extends detection)
-	 * @param {(err: Error | null, result?: Tsconfig) => void=} callback callback
+	 * @param {Set<string> | undefined} visitedConfigPaths config paths being loaded (for circular extends detection)
+	 * @param {(err: Error | null, result?: Tsconfig) => void} callback callback
 	 * @returns {void}
 	 */
 	_loadTsconfig(
@@ -635,13 +619,10 @@ module.exports = class TsconfigPathsPlugin {
 		visitedConfigPaths,
 		callback,
 	) {
-		const cb = /** @type {(err: Error | null, result?: Tsconfig) => void} */ (
-			callback
-		);
 		const visited = visitedConfigPaths || new Set();
 
 		if (visited.has(configFilePath)) {
-			return cb(null, /** @type {Tsconfig} */ ({}));
+			return callback(null, /** @type {Tsconfig} */ ({}));
 		}
 		visited.add(configFilePath);
 
@@ -650,61 +631,41 @@ module.exports = class TsconfigPathsPlugin {
 			configFilePath,
 			{ stripComments: true },
 			(err, parsed) => {
-				if (err) return cb(/** @type {Error} */ (err));
+				if (err) return callback(/** @type {Error} */ (err));
 
 				const config = /** @type {Tsconfig} */ (parsed);
 				fileDependencies.add(configFilePath);
 
 				const extendedConfig = config.extends;
-				if (!extendedConfig) {
-					return cb(null, config);
-				}
+				if (!extendedConfig) return callback(null, config);
 
-				if (Array.isArray(extendedConfig)) {
-					/** @type {Tsconfig} */
-					let base = {};
-					let i = 0;
-					const next = () => {
-						if (i >= extendedConfig.length) {
-							const merged = /** @type {Tsconfig} */ (
-								mergeTsconfigs(base, config)
-							);
-							return cb(null, merged);
-						}
-						const element = extendedConfig[i++];
-						this._loadTsconfigFromExtends(
-							resolver,
-							configFilePath,
-							element,
-							fileDependencies,
-							visited,
-							(extErr, extendedTsconfig) => {
-								if (extErr) return cb(extErr);
-								base = mergeTsconfigs(
-									base,
-									/** @type {Tsconfig} */ (extendedTsconfig),
-								);
-								next();
-							},
-						);
-					};
-					next();
-				} else {
+				const extendsList = Array.isArray(extendedConfig)
+					? extendedConfig
+					: [extendedConfig];
+				/** @type {Tsconfig} */
+				let base = {};
+				let i = 0;
+				const next = () => {
+					if (i >= extendsList.length) {
+						return callback(null, mergeTsconfigs(base, config));
+					}
 					this._loadTsconfigFromExtends(
 						resolver,
 						configFilePath,
-						extendedConfig,
+						extendsList[i++],
 						fileDependencies,
 						visited,
-						(extErr, base) => {
-							if (extErr) return cb(extErr);
-							const merged = /** @type {Tsconfig} */ (
-								mergeTsconfigs(/** @type {Tsconfig} */ (base), config)
+						(extErr, extendedTsconfig) => {
+							if (extErr) return callback(extErr);
+							base = mergeTsconfigs(
+								base,
+								/** @type {Tsconfig} */ (extendedTsconfig),
 							);
-							cb(null, merged);
+							next();
 						},
 					);
-				}
+				};
+				next();
 			},
 		);
 	}

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -40,6 +40,8 @@ const { PathType: _PathType, isSubPath, normalize } = require("./util/path");
 
 const DEFAULT_CONFIG_FILE = "tsconfig.json";
 
+const READ_JSON_OPTIONS = { stripComments: true };
+
 /**
  * @param {string} pattern Path pattern
  * @returns {number} Length of the prefix
@@ -158,6 +160,32 @@ function tsconfigPathsToResolveOptions(configDir, paths, resolver, baseUrl) {
  */
 function getAbsoluteBaseUrl(context, resolver, baseUrl) {
 	return !baseUrl ? context : resolver.join(context, baseUrl);
+}
+
+/**
+ * @param {TsconfigPathsData} main main paths data
+ * @param {string} mainContext main context
+ * @param {{ [baseUrl: string]: TsconfigPathsData }} refs references map
+ * @param {Set<string>} fileDependencies file dependencies
+ * @returns {TsconfigPathsMap} the tsconfig paths map
+ */
+function buildTsconfigPathsMap(main, mainContext, refs, fileDependencies) {
+	const allContexts = /** @type {{ [context: string]: TsconfigPathsData }} */ ({
+		[mainContext]: main,
+		...refs,
+	});
+	// Precompute the key list once per tsconfig load. `_selectPathsDataForContext`
+	// runs per resolve and otherwise would call `Object.entries(allContexts)`
+	// each time, allocating a fresh [key, value][] array.
+	const contextList = Object.keys(allContexts);
+	return {
+		main,
+		mainContext,
+		refs,
+		allContexts,
+		contextList,
+		fileDependencies,
+	};
 }
 
 module.exports = class TsconfigPathsPlugin {
@@ -363,41 +391,27 @@ module.exports = class TsconfigPathsPlugin {
 					referencesToUse = this.references;
 				}
 
-				const finish = () => {
-					const allContexts =
-						/** @type {{ [context: string]: TsconfigPathsData }} */ ({
-							[mainContext]: main,
-							...refs,
-						});
-					// Precompute the key list once per tsconfig load. `_selectPathsDataForContext`
-					// runs per resolve and otherwise would call `Object.entries(allContexts)`
-					// each time, allocating a fresh [key, value][] array.
-					const contextList = Object.keys(allContexts);
-					callback(null, {
-						main,
-						mainContext,
-						refs,
-						allContexts,
-						contextList,
-						fileDependencies,
-					});
-				};
-
-				if (Array.isArray(referencesToUse)) {
-					this._loadTsconfigReferences(
-						resolver,
-						mainContext,
-						referencesToUse,
-						fileDependencies,
-						refs,
-						(refErr) => {
-							if (refErr) return callback(refErr);
-							finish();
-						},
+				if (!Array.isArray(referencesToUse)) {
+					return callback(
+						null,
+						buildTsconfigPathsMap(main, mainContext, refs, fileDependencies),
 					);
-				} else {
-					finish();
 				}
+
+				this._loadTsconfigReferences(
+					resolver,
+					mainContext,
+					referencesToUse,
+					fileDependencies,
+					refs,
+					(refErr) => {
+						if (refErr) return callback(refErr);
+						callback(
+							null,
+							buildTsconfigPathsMap(main, mainContext, refs, fileDependencies),
+						);
+					},
+				);
 			},
 		);
 	}
@@ -636,7 +650,7 @@ module.exports = class TsconfigPathsPlugin {
 		readJson(
 			resolver.fileSystem,
 			configFilePath,
-			{ stripComments: true },
+			READ_JSON_OPTIONS,
 			(err, parsed) => {
 				if (err) return callback(/** @type {Error} */ (err));
 
@@ -646,20 +660,38 @@ module.exports = class TsconfigPathsPlugin {
 				const extendedConfig = config.extends;
 				if (!extendedConfig) return callback(null, config);
 
-				const extendsList = Array.isArray(extendedConfig)
-					? extendedConfig
-					: [extendedConfig];
+				if (!Array.isArray(extendedConfig)) {
+					this._loadTsconfigFromExtends(
+						resolver,
+						configFilePath,
+						extendedConfig,
+						fileDependencies,
+						visited,
+						(extErr, extendedTsconfig) => {
+							if (extErr) return callback(extErr);
+							callback(
+								null,
+								mergeTsconfigs(
+									/** @type {Tsconfig} */ (extendedTsconfig),
+									config,
+								),
+							);
+						},
+					);
+					return;
+				}
+
 				/** @type {Tsconfig} */
 				let base = {};
 				let i = 0;
 				const next = () => {
-					if (i >= extendsList.length) {
+					if (i >= extendedConfig.length) {
 						return callback(null, mergeTsconfigs(base, config));
 					}
 					this._loadTsconfigFromExtends(
 						resolver,
 						configFilePath,
-						extendsList[i++],
+						extendedConfig[i++],
 						fileDependencies,
 						visited,
 						(extErr, extendedTsconfig) => {

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -212,68 +212,65 @@ module.exports = class TsconfigPathsPlugin {
 		const aliasTarget = resolver.ensureHook("internal-resolve");
 		const moduleTarget = resolver.ensureHook("module");
 
-		/**
-		 * @template T
-		 * @param {string} hookName hook name
-		 * @param {ResolveStepHook} target target hook
-		 * @param {(data: TsconfigPathsData) => T} pickField pick alias/modules field
-		 * @param {(resolver: Resolver, value: T, target: ResolveStepHook, request: ResolveRequest, resolveContext: ResolveContext, callback: (err?: null | Error, result?: null | ResolveRequest) => void) => void} handler handler
-		 * @returns {void}
-		 */
-		const tap = (hookName, target, pickField, handler) => {
-			resolver
-				.getHook(hookName)
-				.tapAsync(
-					"TsconfigPathsPlugin",
-					(request, resolveContext, callback) => {
-						this._getTsconfigPathsMap(
+		resolver
+			.getHook("raw-resolve")
+			.tapAsync("TsconfigPathsPlugin", (request, resolveContext, callback) => {
+				this._getTsconfigPathsMap(
+					resolver,
+					request,
+					resolveContext,
+					(err, tsconfigPathsMap) => {
+						if (err) return callback(err);
+						if (!tsconfigPathsMap) return callback();
+
+						const selectedData = this._selectPathsDataForContext(
+							request.path,
+							tsconfigPathsMap,
+						);
+
+						if (!selectedData) return callback();
+
+						aliasResolveHandler(
 							resolver,
+							selectedData.alias,
+							aliasTarget,
 							request,
 							resolveContext,
-							(err, tsconfigPathsMap) => {
-								if (err) return callback(err);
-								if (!tsconfigPathsMap) return callback();
-
-								const selectedData = this._selectPathsDataForContext(
-									request.path,
-									tsconfigPathsMap,
-								);
-
-								if (!selectedData) return callback();
-
-								handler(
-									resolver,
-									pickField(selectedData),
-									target,
-									request,
-									resolveContext,
-									callback,
-								);
-							},
+							callback,
 						);
 					},
 				);
-		};
+			});
 
-		tap("raw-resolve", aliasTarget, (data) => data.alias, aliasResolveHandler);
-		tap(
-			"raw-module",
-			moduleTarget,
-			(data) => data.modules,
-			modulesResolveHandler,
-		);
-	}
+		resolver
+			.getHook("raw-module")
+			.tapAsync("TsconfigPathsPlugin", (request, resolveContext, callback) => {
+				this._getTsconfigPathsMap(
+					resolver,
+					request,
+					resolveContext,
+					(err, tsconfigPathsMap) => {
+						if (err) return callback(err);
+						if (!tsconfigPathsMap) return callback();
 
-	/**
-	 * @param {TsconfigPathsMap} tsconfigPathsMap the tsconfig paths map
-	 * @param {ResolveContext} resolveContext the resolve context
-	 * @returns {void}
-	 */
-	_addFileDependencies(tsconfigPathsMap, resolveContext) {
-		if (!resolveContext.fileDependencies) return;
-		for (const fileDependency of tsconfigPathsMap.fileDependencies) {
-			resolveContext.fileDependencies.add(fileDependency);
-		}
+						const selectedData = this._selectPathsDataForContext(
+							request.path,
+							tsconfigPathsMap,
+						);
+
+						if (!selectedData) return callback();
+
+						modulesResolveHandler(
+							resolver,
+							selectedData.modules,
+							moduleTarget,
+							request,
+							resolveContext,
+							callback,
+						);
+					},
+				);
+			});
 	}
 
 	/**
@@ -286,9 +283,14 @@ module.exports = class TsconfigPathsPlugin {
 	 */
 	_getTsconfigPathsMap(resolver, request, resolveContext, callback) {
 		if (typeof request.tsconfigPathsMap !== "undefined") {
-			if (!request.tsconfigPathsMap) return callback(null, null);
-			this._addFileDependencies(request.tsconfigPathsMap, resolveContext);
-			return callback(null, request.tsconfigPathsMap);
+			const cached = request.tsconfigPathsMap;
+			if (!cached) return callback(null, null);
+			if (resolveContext.fileDependencies) {
+				for (const fileDependency of cached.fileDependencies) {
+					resolveContext.fileDependencies.add(fileDependency);
+				}
+			}
+			return callback(null, cached);
 		}
 
 		const absTsconfigPath = resolver.join(
@@ -307,9 +309,14 @@ module.exports = class TsconfigPathsPlugin {
 				return callback(err);
 			}
 
-			request.tsconfigPathsMap = /** @type {TsconfigPathsMap} */ (result);
-			this._addFileDependencies(request.tsconfigPathsMap, resolveContext);
-			callback(null, request.tsconfigPathsMap);
+			const map = /** @type {TsconfigPathsMap} */ (result);
+			request.tsconfigPathsMap = map;
+			if (resolveContext.fileDependencies) {
+				for (const fileDependency of map.fileDependencies) {
+					resolveContext.fileDependencies.add(fileDependency);
+				}
+			}
+			callback(null, map);
 		});
 	}
 

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -214,16 +214,13 @@ module.exports = class TsconfigPathsPlugin {
 
 		resolver
 			.getHook("raw-resolve")
-			.tapAsync(
-				"TsconfigPathsPlugin",
-				async (request, resolveContext, callback) => {
-					try {
-						const tsconfigPathsMap = await this._getTsconfigPathsMap(
-							resolver,
-							request,
-							resolveContext,
-						);
-
+			.tapAsync("TsconfigPathsPlugin", (request, resolveContext, callback) => {
+				this._getTsconfigPathsMap(
+					resolver,
+					request,
+					resolveContext,
+					(err, tsconfigPathsMap) => {
+						if (err) return callback(err);
 						if (!tsconfigPathsMap) return callback();
 
 						const selectedData = this._selectPathsDataForContext(
@@ -241,24 +238,19 @@ module.exports = class TsconfigPathsPlugin {
 							resolveContext,
 							callback,
 						);
-					} catch (err) {
-						callback(/** @type {Error} */ (err));
-					}
-				},
-			);
+					},
+				);
+			});
 
 		resolver
 			.getHook("raw-module")
-			.tapAsync(
-				"TsconfigPathsPlugin",
-				async (request, resolveContext, callback) => {
-					try {
-						const tsconfigPathsMap = await this._getTsconfigPathsMap(
-							resolver,
-							request,
-							resolveContext,
-						);
-
+			.tapAsync("TsconfigPathsPlugin", (request, resolveContext, callback) => {
+				this._getTsconfigPathsMap(
+					resolver,
+					request,
+					resolveContext,
+					(err, tsconfigPathsMap) => {
+						if (err) return callback(err);
 						if (!tsconfigPathsMap) return callback();
 
 						const selectedData = this._selectPathsDataForContext(
@@ -276,11 +268,21 @@ module.exports = class TsconfigPathsPlugin {
 							resolveContext,
 							callback,
 						);
-					} catch (err) {
-						callback(/** @type {Error} */ (err));
-					}
-				},
-			);
+					},
+				);
+			});
+	}
+
+	/**
+	 * @param {TsconfigPathsMap} tsconfigPathsMap the tsconfig paths map
+	 * @param {ResolveContext} resolveContext the resolve context
+	 * @returns {void}
+	 */
+	_addFileDependencies(tsconfigPathsMap, resolveContext) {
+		if (!resolveContext.fileDependencies) return;
+		for (const fileDependency of tsconfigPathsMap.fileDependencies) {
+			resolveContext.fileDependencies.add(fileDependency);
+		}
 	}
 
 	/**
@@ -288,43 +290,36 @@ module.exports = class TsconfigPathsPlugin {
 	 * @param {Resolver} resolver the resolver
 	 * @param {ResolveRequest} request the request
 	 * @param {ResolveContext} resolveContext the resolve context
-	 * @returns {Promise<TsconfigPathsMap | null>} the tsconfig paths map or null
+	 * @param {(err: Error | null, result?: TsconfigPathsMap | null) => void} callback the callback
+	 * @returns {void}
 	 */
-	async _getTsconfigPathsMap(resolver, request, resolveContext) {
-		if (typeof request.tsconfigPathsMap === "undefined") {
-			try {
-				const absTsconfigPath = resolver.join(
-					request.path || process.cwd(),
-					this.configFile,
-				);
-				const result = await this._loadTsconfigPathsMap(
-					resolver,
-					absTsconfigPath,
-				);
+	_getTsconfigPathsMap(resolver, request, resolveContext, callback) {
+		if (typeof request.tsconfigPathsMap !== "undefined") {
+			if (!request.tsconfigPathsMap) return callback(null, null);
+			this._addFileDependencies(request.tsconfigPathsMap, resolveContext);
+			return callback(null, request.tsconfigPathsMap);
+		}
 
-				request.tsconfigPathsMap = result;
-			} catch (err) {
+		const absTsconfigPath = resolver.join(
+			request.path || process.cwd(),
+			this.configFile,
+		);
+		this._loadTsconfigPathsMap(resolver, absTsconfigPath, (err, result) => {
+			if (err) {
 				request.tsconfigPathsMap = null;
 				if (
 					this.isAutoConfigFile &&
 					/** @type {NodeJS.ErrnoException} */ (err).code === "ENOENT"
 				) {
-					return null;
+					return callback(null, null);
 				}
-				throw err;
+				return callback(err);
 			}
-		}
 
-		if (!request.tsconfigPathsMap) {
-			return null;
-		}
-
-		for (const fileDependency of request.tsconfigPathsMap.fileDependencies) {
-			if (resolveContext.fileDependencies) {
-				resolveContext.fileDependencies.add(fileDependency);
-			}
-		}
-		return request.tsconfigPathsMap;
+			request.tsconfigPathsMap = /** @type {TsconfigPathsMap} */ (result);
+			this._addFileDependencies(request.tsconfigPathsMap, resolveContext);
+			callback(null, request.tsconfigPathsMap);
+		});
 	}
 
 	/**
@@ -332,66 +327,81 @@ module.exports = class TsconfigPathsPlugin {
 	 * Includes main project paths and all referenced projects
 	 * @param {Resolver} resolver the resolver
 	 * @param {string} absTsconfigPath absolute path to tsconfig.json
-	 * @returns {Promise<TsconfigPathsMap>} the complete tsconfig paths map
+	 * @param {(err: Error | null, result?: TsconfigPathsMap) => void} callback the callback
+	 * @returns {void}
 	 */
-	async _loadTsconfigPathsMap(resolver, absTsconfigPath) {
+	_loadTsconfigPathsMap(resolver, absTsconfigPath, callback) {
 		/** @type {Set<string>} */
 		const fileDependencies = new Set();
-		const config = await this._loadTsconfig(
+
+		this._loadTsconfig(
 			resolver,
 			absTsconfigPath,
 			fileDependencies,
+			undefined,
+			(err, config) => {
+				if (err) return callback(err);
+
+				const cfg = /** @type {Tsconfig} */ (config);
+				const compilerOptions = cfg.compilerOptions || {};
+				const mainContext = resolver.dirname(absTsconfigPath);
+
+				const baseUrl =
+					this.baseUrl !== undefined ? this.baseUrl : compilerOptions.baseUrl;
+
+				const main = tsconfigPathsToResolveOptions(
+					mainContext,
+					compilerOptions.paths || {},
+					resolver,
+					baseUrl,
+				);
+				/** @type {{ [baseUrl: string]: TsconfigPathsData }} */
+				const refs = {};
+
+				let referencesToUse = null;
+				if (this.references === "auto") {
+					referencesToUse = cfg.references;
+				} else if (Array.isArray(this.references)) {
+					referencesToUse = this.references;
+				}
+
+				const finish = () => {
+					const allContexts =
+						/** @type {{ [context: string]: TsconfigPathsData }} */ ({
+							[mainContext]: main,
+							...refs,
+						});
+					// Precompute the key list once per tsconfig load. `_selectPathsDataForContext`
+					// runs per resolve and otherwise would call `Object.entries(allContexts)`
+					// each time, allocating a fresh [key, value][] array.
+					const contextList = Object.keys(allContexts);
+					callback(null, {
+						main,
+						mainContext,
+						refs,
+						allContexts,
+						contextList,
+						fileDependencies,
+					});
+				};
+
+				if (Array.isArray(referencesToUse)) {
+					this._loadTsconfigReferences(
+						resolver,
+						mainContext,
+						referencesToUse,
+						fileDependencies,
+						refs,
+						(refErr) => {
+							if (refErr) return callback(refErr);
+							finish();
+						},
+					);
+				} else {
+					finish();
+				}
+			},
 		);
-
-		const compilerOptions = config.compilerOptions || {};
-		const mainContext = resolver.dirname(absTsconfigPath);
-
-		const baseUrl =
-			this.baseUrl !== undefined ? this.baseUrl : compilerOptions.baseUrl;
-
-		const main = tsconfigPathsToResolveOptions(
-			mainContext,
-			compilerOptions.paths || {},
-			resolver,
-			baseUrl,
-		);
-		/** @type {{ [baseUrl: string]: TsconfigPathsData }} */
-		const refs = {};
-
-		let referencesToUse = null;
-		if (this.references === "auto") {
-			referencesToUse = config.references;
-		} else if (Array.isArray(this.references)) {
-			referencesToUse = this.references;
-		}
-
-		if (Array.isArray(referencesToUse)) {
-			await this._loadTsconfigReferences(
-				resolver,
-				mainContext,
-				referencesToUse,
-				fileDependencies,
-				refs,
-			);
-		}
-
-		const allContexts =
-			/** @type {{ [context: string]: TsconfigPathsData }} */ ({
-				[mainContext]: main,
-				...refs,
-			});
-		// Precompute the key list once per tsconfig load. `_selectPathsDataForContext`
-		// runs per resolve and otherwise would call `Object.entries(allContexts)`
-		// each time, allocating a fresh [key, value][] array.
-		const contextList = Object.keys(allContexts);
-		return {
-			main,
-			mainContext,
-			refs,
-			allContexts,
-			contextList,
-			fileDependencies,
-		};
 	}
 
 	/**
@@ -438,14 +448,16 @@ module.exports = class TsconfigPathsPlugin {
 	 * @param {string} extendedConfigValue extends value
 	 * @param {Set<string>} fileDependencies the file dependencies
 	 * @param {Set<string>} visitedConfigPaths config paths being loaded (for circular extends detection)
-	 * @returns {Promise<Tsconfig>} the extended tsconfig
+	 * @param {(err: Error | null, result?: Tsconfig) => void} callback callback
+	 * @returns {void}
 	 */
-	async _loadTsconfigFromExtends(
+	_loadTsconfigFromExtends(
 		resolver,
 		configFilePath,
 		extendedConfigValue,
 		fileDependencies,
 		visitedConfigPaths,
+		callback,
 	) {
 		const { fileSystem } = resolver;
 		const currentDir = resolver.dirname(configFilePath);
@@ -463,60 +475,68 @@ module.exports = class TsconfigPathsPlugin {
 			extendedConfigValue += ".json";
 		}
 
-		let extendedConfigPath = resolver.join(currentDir, extendedConfigValue);
-
-		const exists = await new Promise((resolve) => {
-			fileSystem.readFile(extendedConfigPath, (err) => {
-				resolve(!err);
-			});
-		});
-		if (!exists) {
-			// Handle scoped package extends like "@scope/name" (no sub-path):
-			// "@scope/name" should resolve to node_modules/@scope/name/tsconfig.json,
-			// not node_modules/@scope/name.json
-			// See: test/fixtures/tsconfig-paths/extends-pkg-entry/
-			if (
-				typeof originalExtendedConfigValue === "string" &&
-				originalExtendedConfigValue.startsWith("@") &&
-				originalExtendedConfigValue.split("/").length === 2
-			) {
-				extendedConfigPath = resolver.join(
-					currentDir,
-					normalize(
-						`node_modules/${originalExtendedConfigValue}/${DEFAULT_CONFIG_FILE}`,
-					),
-				);
-			} else if (extendedConfigValue.includes("/")) {
-				// Handle package sub-path extends like "react/tsconfig":
-				// "react/tsconfig" resolves to node_modules/react/tsconfig.json
-				// See: test/fixtures/tsconfig-paths/extends-npm/
-				extendedConfigPath = resolver.join(
-					currentDir,
-					normalize(`node_modules/${extendedConfigValue}`),
-				);
-			}
-		}
-
-		const config = await this._loadTsconfig(
-			resolver,
-			extendedConfigPath,
-			fileDependencies,
-			visitedConfigPaths,
+		const initialExtendedConfigPath = resolver.join(
+			currentDir,
+			extendedConfigValue,
 		);
-		const compilerOptions = config.compilerOptions || { baseUrl: undefined };
 
-		if (compilerOptions.baseUrl) {
-			const extendedConfigDir = resolver.dirname(extendedConfigPath);
-			compilerOptions.baseUrl = getAbsoluteBaseUrl(
-				extendedConfigDir,
+		fileSystem.readFile(initialExtendedConfigPath, (existsErr) => {
+			let extendedConfigPath = initialExtendedConfigPath;
+			if (existsErr) {
+				// Handle scoped package extends like "@scope/name" (no sub-path):
+				// "@scope/name" should resolve to node_modules/@scope/name/tsconfig.json,
+				// not node_modules/@scope/name.json
+				// See: test/fixtures/tsconfig-paths/extends-pkg-entry/
+				if (
+					typeof originalExtendedConfigValue === "string" &&
+					originalExtendedConfigValue.startsWith("@") &&
+					originalExtendedConfigValue.split("/").length === 2
+				) {
+					extendedConfigPath = resolver.join(
+						currentDir,
+						normalize(
+							`node_modules/${originalExtendedConfigValue}/${DEFAULT_CONFIG_FILE}`,
+						),
+					);
+				} else if (extendedConfigValue.includes("/")) {
+					// Handle package sub-path extends like "react/tsconfig":
+					// "react/tsconfig" resolves to node_modules/react/tsconfig.json
+					// See: test/fixtures/tsconfig-paths/extends-npm/
+					extendedConfigPath = resolver.join(
+						currentDir,
+						normalize(`node_modules/${extendedConfigValue}`),
+					);
+				}
+			}
+
+			this._loadTsconfig(
 				resolver,
-				compilerOptions.baseUrl,
+				extendedConfigPath,
+				fileDependencies,
+				visitedConfigPaths,
+				(err, config) => {
+					if (err) return callback(err);
+
+					const cfg = /** @type {Tsconfig} */ (config);
+					const compilerOptions = cfg.compilerOptions || {
+						baseUrl: undefined,
+					};
+
+					if (compilerOptions.baseUrl) {
+						const extendedConfigDir = resolver.dirname(extendedConfigPath);
+						compilerOptions.baseUrl = getAbsoluteBaseUrl(
+							extendedConfigDir,
+							resolver,
+							compilerOptions.baseUrl,
+						);
+					}
+
+					delete cfg.references;
+
+					callback(null, cfg);
+				},
 			);
-		}
-
-		delete config.references;
-
-		return /** @type {Tsconfig} */ (config);
+		});
 	}
 
 	/**
@@ -528,58 +548,75 @@ module.exports = class TsconfigPathsPlugin {
 	 * @param {TsconfigReference[]} references array of references
 	 * @param {Set<string>} fileDependencies the file dependencies
 	 * @param {{ [baseUrl: string]: TsconfigPathsData }} referenceMatchMap the map to populate
-	 * @returns {Promise<void>}
+	 * @param {(err: Error | null) => void} callback callback
+	 * @returns {void}
 	 */
-	async _loadTsconfigReferences(
+	_loadTsconfigReferences(
 		resolver,
 		context,
 		references,
 		fileDependencies,
 		referenceMatchMap,
+		callback,
 	) {
-		await Promise.all(
-			references.map(async (ref) => {
-				const refPath = substituteConfigDir(ref.path, context);
-				const refConfigPath = resolver.join(
-					resolver.join(context, refPath),
-					DEFAULT_CONFIG_FILE,
-				);
+		if (references.length === 0) return callback(null);
 
-				try {
-					const refConfig = await this._loadTsconfig(
-						resolver,
-						refConfigPath,
-						fileDependencies,
-					);
+		let pending = references.length;
+		let done = false;
+		const finishOne = () => {
+			if (done) return;
+			pending--;
+			if (pending === 0) {
+				done = true;
+				callback(null);
+			}
+		};
 
-					if (refConfig.compilerOptions && refConfig.compilerOptions.paths) {
+		for (const ref of references) {
+			const refPath = substituteConfigDir(ref.path, context);
+			const refConfigPath = resolver.join(
+				resolver.join(context, refPath),
+				DEFAULT_CONFIG_FILE,
+			);
+
+			this._loadTsconfig(
+				resolver,
+				refConfigPath,
+				fileDependencies,
+				undefined,
+				(err, refConfig) => {
+					if (err) {
+						// continue
+						return finishOne();
+					}
+
+					const cfg = /** @type {Tsconfig} */ (refConfig);
+					if (cfg.compilerOptions && cfg.compilerOptions.paths) {
 						const refContext = resolver.dirname(refConfigPath);
 
 						referenceMatchMap[refContext] = tsconfigPathsToResolveOptions(
 							refContext,
-							refConfig.compilerOptions.paths || {},
+							cfg.compilerOptions.paths || {},
 							resolver,
-							refConfig.compilerOptions.baseUrl,
+							cfg.compilerOptions.baseUrl,
 						);
 					}
 
-					if (
-						this.references === "auto" &&
-						Array.isArray(refConfig.references)
-					) {
-						await this._loadTsconfigReferences(
+					if (this.references === "auto" && Array.isArray(cfg.references)) {
+						this._loadTsconfigReferences(
 							resolver,
 							resolver.dirname(refConfigPath),
-							refConfig.references,
+							cfg.references,
 							fileDependencies,
 							referenceMatchMap,
+							() => finishOne(),
 						);
+					} else {
+						finishOne();
 					}
-				} catch (_err) {
-					// continue
-				}
-			}),
-		);
+				},
+			);
+		}
 	}
 
 	/**
@@ -588,54 +625,87 @@ module.exports = class TsconfigPathsPlugin {
 	 * @param {string} configFilePath absolute path to tsconfig.json
 	 * @param {Set<string>} fileDependencies the file dependencies
 	 * @param {Set<string>=} visitedConfigPaths config paths being loaded (for circular extends detection)
-	 * @returns {Promise<Tsconfig>} the merged tsconfig
+	 * @param {(err: Error | null, result?: Tsconfig) => void=} callback callback
+	 * @returns {void}
 	 */
-	async _loadTsconfig(
+	_loadTsconfig(
 		resolver,
 		configFilePath,
 		fileDependencies,
-		visitedConfigPaths = new Set(),
+		visitedConfigPaths,
+		callback,
 	) {
-		if (visitedConfigPaths.has(configFilePath)) {
-			return /** @type {Tsconfig} */ ({});
+		const cb = /** @type {(err: Error | null, result?: Tsconfig) => void} */ (
+			callback
+		);
+		const visited = visitedConfigPaths || new Set();
+
+		if (visited.has(configFilePath)) {
+			return cb(null, /** @type {Tsconfig} */ ({}));
 		}
-		visitedConfigPaths.add(configFilePath);
-		const config = await readJson(resolver.fileSystem, configFilePath, {
-			stripComments: true,
-		});
-		fileDependencies.add(configFilePath);
+		visited.add(configFilePath);
 
-		let result = config;
+		readJson(
+			resolver.fileSystem,
+			configFilePath,
+			{ stripComments: true },
+			(err, parsed) => {
+				if (err) return cb(/** @type {Error} */ (err));
 
-		const extendedConfig = config.extends;
-		if (extendedConfig) {
-			let base;
+				const config = /** @type {Tsconfig} */ (parsed);
+				fileDependencies.add(configFilePath);
 
-			if (Array.isArray(extendedConfig)) {
-				base = {};
-				for (const extendedConfigElement of extendedConfig) {
-					const extendedTsconfig = await this._loadTsconfigFromExtends(
+				const extendedConfig = config.extends;
+				if (!extendedConfig) {
+					return cb(null, config);
+				}
+
+				if (Array.isArray(extendedConfig)) {
+					/** @type {Tsconfig} */
+					let base = {};
+					let i = 0;
+					const next = () => {
+						if (i >= extendedConfig.length) {
+							const merged = /** @type {Tsconfig} */ (
+								mergeTsconfigs(base, config)
+							);
+							return cb(null, merged);
+						}
+						const element = extendedConfig[i++];
+						this._loadTsconfigFromExtends(
+							resolver,
+							configFilePath,
+							element,
+							fileDependencies,
+							visited,
+							(extErr, extendedTsconfig) => {
+								if (extErr) return cb(extErr);
+								base = mergeTsconfigs(
+									base,
+									/** @type {Tsconfig} */ (extendedTsconfig),
+								);
+								next();
+							},
+						);
+					};
+					next();
+				} else {
+					this._loadTsconfigFromExtends(
 						resolver,
 						configFilePath,
-						extendedConfigElement,
+						extendedConfig,
 						fileDependencies,
-						visitedConfigPaths,
+						visited,
+						(extErr, base) => {
+							if (extErr) return cb(extErr);
+							const merged = /** @type {Tsconfig} */ (
+								mergeTsconfigs(/** @type {Tsconfig} */ (base), config)
+							);
+							cb(null, merged);
+						},
 					);
-					base = mergeTsconfigs(base, extendedTsconfig);
 				}
-			} else {
-				base = await this._loadTsconfigFromExtends(
-					resolver,
-					configFilePath,
-					extendedConfig,
-					fileDependencies,
-					visitedConfigPaths,
-				);
-			}
-
-			result = /** @type {Tsconfig} */ (mergeTsconfigs(base, config));
-		}
-
-		return result;
+			},
+		);
 	}
 };

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -20,10 +20,10 @@ const _stripCommentsCache = new WeakMap();
 
 /**
  * Read and parse JSON file (supports JSONC with comments).
- * Callback-based so that synchronous file systems remain synchronous —
- * wrapping `fileSystem.readFile` in a Promise would always defer resolution
- * to a microtask, which breaks `resolveSync` for callers using
- * `useSyncFileSystemCalls: true` together with `tsconfig`.
+ * Callback-based so a synchronous `fileSystem` stays synchronous all the
+ * way through — Promise wrapping would defer resolution by a Promise tick
+ * and break `resolveSync` when `tsconfig` is used together with
+ * `useSyncFileSystemCalls: true`.
  * @param {FileSystem} fileSystem the file system
  * @param {string} jsonFilePath absolute path to JSON file
  * @param {ReadJsonOptions} options Options

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -19,49 +19,57 @@ const stripJsonComments = require("./strip-json-comments");
 const _stripCommentsCache = new WeakMap();
 
 /**
- * Read and parse JSON file (supports JSONC with comments)
- * @template T
+ * Read and parse JSON file (supports JSONC with comments).
+ * Callback-based so that synchronous file systems remain synchronous —
+ * wrapping `fileSystem.readFile` in a Promise would always defer resolution
+ * to a microtask, which breaks `resolveSync` for callers using
+ * `useSyncFileSystemCalls: true` together with `tsconfig`.
  * @param {FileSystem} fileSystem the file system
  * @param {string} jsonFilePath absolute path to JSON file
  * @param {ReadJsonOptions} options Options
- * @returns {Promise<T>} parsed JSON content
+ * @param {(err: NodeJS.ErrnoException | Error | null, content?: JsonObject) => void} callback callback
+ * @returns {void}
  */
-async function readJson(fileSystem, jsonFilePath, options = {}) {
+function readJson(fileSystem, jsonFilePath, options, callback) {
 	const { stripComments = false } = options;
-	const { readJson } = fileSystem;
-	if (readJson && !stripComments) {
-		return new Promise((resolve, reject) => {
-			readJson(jsonFilePath, (err, content) => {
-				if (err) return reject(err);
-				resolve(/** @type {T} */ (content));
-			});
+	const { readJson: fsReadJson } = fileSystem;
+	if (fsReadJson && !stripComments) {
+		fsReadJson(jsonFilePath, (err, content) => {
+			if (err) return callback(err);
+			callback(null, /** @type {JsonObject} */ (content));
 		});
+		return;
 	}
 
-	const buf = await new Promise((resolve, reject) => {
-		fileSystem.readFile(jsonFilePath, (err, data) => {
-			if (err) return reject(err);
-			resolve(data);
-		});
+	fileSystem.readFile(jsonFilePath, (err, data) => {
+		if (err) return callback(err);
+		const buf = /** @type {Buffer} */ (data);
+
+		if (stripComments) {
+			const cached = _stripCommentsCache.get(buf);
+			if (cached !== undefined) return callback(null, cached);
+		}
+
+		let result;
+		try {
+			const jsonText = buf.toString();
+			const jsonWithoutComments = stripComments
+				? stripJsonComments(jsonText, {
+						trailingCommas: true,
+						whitespace: true,
+					})
+				: jsonText;
+			result = JSON.parse(jsonWithoutComments);
+		} catch (parseErr) {
+			return callback(/** @type {Error} */ (parseErr));
+		}
+
+		if (stripComments) {
+			_stripCommentsCache.set(buf, result);
+		}
+
+		callback(null, result);
 	});
-
-	if (stripComments) {
-		const cached = _stripCommentsCache.get(buf);
-		if (cached !== undefined) return /** @type {T} */ (cached);
-	}
-
-	const jsonText = /** @type {string} */ (buf.toString());
-	// Strip comments to support JSONC (e.g., tsconfig.json with comments)
-	const jsonWithoutComments = stripComments
-		? stripJsonComments(jsonText, { trailingCommas: true, whitespace: true })
-		: jsonText;
-	const result = JSON.parse(jsonWithoutComments);
-
-	if (stripComments) {
-		_stripCommentsCache.set(buf, result);
-	}
-
-	return result;
 }
 
 module.exports.readJson = readJson;

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -181,7 +181,7 @@ describe("TsconfigPathsPlugin", () => {
 		);
 	});
 
-	it("resolves synchronously via resolveSync when useSyncFileSystemCalls is set (issue #571)", () => {
+	it("resolves synchronously via resolveSync when useSyncFileSystemCalls is set", () => {
 		const resolver = ResolverFactory.createResolver({
 			fileSystem,
 			extensions: [".ts", ".tsx"],
@@ -202,7 +202,7 @@ describe("TsconfigPathsPlugin", () => {
 		}).toThrow(/Can't resolve 'does-not-exist'/);
 	});
 
-	it("resolveSync surfaces missing-tsconfig errors instead of fileSystem-not-sync (issue #571)", () => {
+	it("resolveSync surfaces missing-tsconfig errors instead of fileSystem-not-sync", () => {
 		const resolver = ResolverFactory.createResolver({
 			fileSystem,
 			tsconfig: true,

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -181,6 +181,39 @@ describe("TsconfigPathsPlugin", () => {
 		);
 	});
 
+	it("resolves synchronously via resolveSync when useSyncFileSystemCalls is set (issue #571)", () => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem,
+			extensions: [".ts", ".tsx"],
+			mainFields: ["browser", "main"],
+			mainFiles: ["index"],
+			tsconfig: path.join(baseExampleDir, "tsconfig.json"),
+			useSyncFileSystemCalls: true,
+		});
+
+		expect(resolver.resolveSync({}, baseExampleDir, "@components/button")).toBe(
+			path.join(baseExampleDir, "src", "components", "button.ts"),
+		);
+		expect(resolver.resolveSync({}, baseExampleDir, "bar/file1")).toBe(
+			path.join(baseExampleDir, "src", "mapped", "bar", "file1.ts"),
+		);
+		expect(() => {
+			resolver.resolveSync({}, baseExampleDir, "does-not-exist");
+		}).toThrow(/Can't resolve 'does-not-exist'/);
+	});
+
+	it("resolveSync surfaces missing-tsconfig errors instead of fileSystem-not-sync (issue #571)", () => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem,
+			tsconfig: true,
+			useSyncFileSystemCalls: true,
+		});
+
+		expect(() => {
+			resolver.resolveSync(process.cwd(), "test");
+		}).toThrow(/Can't resolve 'test'/);
+	});
+
 	it("resolves '@components/*' using extends from extendsExampleDir project", (done) => {
 		const resolver = ResolverFactory.createResolver({
 			fileSystem,

--- a/test/util-fs.test.js
+++ b/test/util-fs.test.js
@@ -2,17 +2,9 @@
 
 /* eslint-disable jsdoc/reject-any-type */
 
-// readJson is a utility used internally by TsconfigPathsPlugin to load JSONC
-// files (tsconfig.json with comments). Because that plugin always passes
-// stripComments:true, the `readJson`-fast path and other options in this
-// utility have no integration callers — they are tested here directly
-// (matching the style of test/identifier.test.js, test/getPaths.test.js
-// and test/forEachBail.test.js).
-//
-// The API is callback-based (rather than Promise-based) so that synchronous
-// file systems remain synchronous all the way through `TsconfigPathsPlugin`,
-// which is what makes `resolveSync` work when `tsconfig` is enabled (see
-// issue #571).
+// `readJson` is the JSONC loader used internally by TsconfigPathsPlugin.
+// The plugin always passes stripComments:true, so the readJson-fast path
+// and other branches have no integration callers and are tested directly.
 const { readJson } = require("../lib/util/fs");
 
 /**
@@ -98,7 +90,7 @@ describe("util/fs readJson", () => {
 		).rejects.toThrow("read-fail");
 	});
 
-	it("invokes the callback synchronously when the file system is synchronous (issue #571)", () => {
+	it("invokes the callback synchronously when the file system is synchronous", () => {
 		const fileSystem = /** @type {any} */ ({
 			readFile(_p, callback) {
 				callback(null, Buffer.from('{"sync": true}'));

--- a/test/util-fs.test.js
+++ b/test/util-fs.test.js
@@ -8,7 +8,27 @@
 // utility have no integration callers — they are tested here directly
 // (matching the style of test/identifier.test.js, test/getPaths.test.js
 // and test/forEachBail.test.js).
+//
+// The API is callback-based (rather than Promise-based) so that synchronous
+// file systems remain synchronous all the way through `TsconfigPathsPlugin`,
+// which is what makes `resolveSync` work when `tsconfig` is enabled (see
+// issue #571).
 const { readJson } = require("../lib/util/fs");
+
+/**
+ * @param {any} fileSystem file system
+ * @param {string} jsonFilePath path
+ * @param {{ stripComments?: boolean }=} options options
+ * @returns {Promise<any>} parsed JSON
+ */
+function readJsonPromise(fileSystem, jsonFilePath, options = {}) {
+	return new Promise((resolve, reject) => {
+		readJson(fileSystem, jsonFilePath, options, (err, content) => {
+			if (err) return reject(err);
+			resolve(content);
+		});
+	});
+}
 
 describe("util/fs readJson", () => {
 	it("uses fileSystem.readJson when available and stripComments is false", async () => {
@@ -21,7 +41,7 @@ describe("util/fs readJson", () => {
 				callback(new Error("should not be called"));
 			},
 		});
-		const result = await readJson(fileSystem, "/a/package.json");
+		const result = await readJsonPromise(fileSystem, "/a/package.json");
 		expect(result).toEqual(content);
 	});
 
@@ -34,9 +54,9 @@ describe("util/fs readJson", () => {
 				callback(null, Buffer.from("{}"));
 			},
 		});
-		await expect(readJson(fileSystem, "/a/package.json")).rejects.toThrow(
-			"boom",
-		);
+		await expect(
+			readJsonPromise(fileSystem, "/a/package.json"),
+		).rejects.toThrow("boom");
 	});
 
 	it("falls back to readFile when stripComments is true", async () => {
@@ -51,7 +71,7 @@ describe("util/fs readJson", () => {
 				);
 			},
 		});
-		const result = await readJson(fileSystem, "/a/tsconfig.json", {
+		const result = await readJsonPromise(fileSystem, "/a/tsconfig.json", {
 			stripComments: true,
 		});
 		expect(result).toEqual({ a: 1, b: [1, 2] });
@@ -63,7 +83,7 @@ describe("util/fs readJson", () => {
 				callback(null, Buffer.from('{"hello": "world"}'));
 			},
 		});
-		const result = await readJson(fileSystem, "/a/package.json");
+		const result = await readJsonPromise(fileSystem, "/a/package.json");
 		expect(result).toEqual({ hello: "world" });
 	});
 
@@ -73,8 +93,30 @@ describe("util/fs readJson", () => {
 				callback(new Error("read-fail"));
 			},
 		});
-		await expect(readJson(fileSystem, "/a/package.json")).rejects.toThrow(
-			"read-fail",
+		await expect(
+			readJsonPromise(fileSystem, "/a/package.json"),
+		).rejects.toThrow("read-fail");
+	});
+
+	it("invokes the callback synchronously when the file system is synchronous (issue #571)", () => {
+		const fileSystem = /** @type {any} */ ({
+			readFile(_p, callback) {
+				callback(null, Buffer.from('{"sync": true}'));
+			},
+		});
+		let sync = false;
+		let result;
+		readJson(
+			fileSystem,
+			"/a/tsconfig.json",
+			{ stripComments: true },
+			(err, content) => {
+				if (err) throw err;
+				result = content;
+				sync = true;
+			},
 		);
+		expect(sync).toBe(true);
+		expect(result).toEqual({ sync: true });
 	});
 });


### PR DESCRIPTION
The plugin used async/await and Promise-wrapped file system calls, so its
tapAsync handlers always deferred callback invocation by a Promise tick.
That caused resolveSync to throw "fileSystem is not sync" whenever
tsconfig was enabled, even with useSyncFileSystemCalls: true. Convert the
plugin and util/fs#readJson to callback-based code so a synchronous file
system stays synchronous all the way through, and resolveSync works as
expected.