### PR TITLE
perf: skip empty-query concat, bound star scan, flatten alias predicate

### DIFF
--- a/.changeset/perf-exists-tsconfig-pruning.md
+++ b/.changeset/perf-exists-tsconfig-pruning.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+perf: dedupe miss paths in `DirectoryExistsPlugin`/`FileExistsPlugin` and prune the per-resolve `TsconfigPathsPlugin` context scan.

--- a/.changeset/perf-findmatch-aliasfield.md
+++ b/.changeset/perf-findmatch-aliasfield.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+perf: drop a dead Map lookup in `findMatch` and flatten `AliasFieldPlugin`'s cache check.

--- a/.changeset/perf-imports-alias-entrypoints.md
+++ b/.changeset/perf-imports-alias-entrypoints.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+perf: hot-path tweaks in `ImportsFieldPlugin`, `AliasUtils`, and `util/entrypoints`.

--- a/.changeset/perf-parse-descfile-tsconfig.md
+++ b/.changeset/perf-parse-descfile-tsconfig.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+perf: cut per-resolve allocations in `Resolver.parse`, `loadDescriptionFile`, and `TsconfigPathsPlugin._selectPathsDataForContext`.

--- a/lib/AliasFieldPlugin.js
+++ b/lib/AliasFieldPlugin.js
@@ -55,18 +55,13 @@ module.exports = class AliasFieldPlugin {
 						descriptionFileData,
 						this.field,
 					);
-					if (raw === null || typeof raw !== "object") {
-						this._fieldDataCache.set(descriptionFileData, NO_FIELD_OBJECT);
-						if (resolveContext.log) {
-							resolveContext.log(
-								`Field '${this.field}' doesn't contain a valid alias configuration`,
-							);
-						}
-						return callback();
-					}
-					fieldData = /** @type {{ [k: string]: JsonPrimitive }} */ (raw);
+					fieldData =
+						raw === null || typeof raw !== "object"
+							? NO_FIELD_OBJECT
+							: /** @type {{ [k: string]: JsonPrimitive }} */ (raw);
 					this._fieldDataCache.set(descriptionFileData, fieldData);
-				} else if (fieldData === NO_FIELD_OBJECT) {
+				}
+				if (fieldData === NO_FIELD_OBJECT) {
 					if (resolveContext.log) {
 						resolveContext.log(
 							`Field '${this.field}' doesn't contain a valid alias configuration`,

--- a/lib/AliasUtils.js
+++ b/lib/AliasUtils.js
@@ -138,18 +138,15 @@ function aliasResolveHandler(
 			// windows request with native backslashes
 			// (e.g. `C:\\abs\\foo\\baz` against `name: "C:\\abs\\foo"`)
 			// otherwise fails `startsWith("C:\\abs\\foo/")` and is
-			// silently skipped. The `!hasRequestString` branch already
-			// uses `absolutePath`; mirroring it here closes the gap
-			// without changing any existing matches.
+			// silently skipped. Mirroring the `absolutePath` check in
+			// both branches closes the gap without changing any
+			// existing matches.
+			const { absolutePath } = item;
 			const matchRequest =
 				innerRequest === item.name ||
 				(!item.onlyModule &&
-					(hasRequestString
-						? innerRequest.startsWith(item.nameWithSlash) ||
-							(item.absolutePath !== null &&
-								innerRequest.startsWith(item.absolutePath))
-						: item.absolutePath !== null &&
-							innerRequest.startsWith(item.absolutePath)));
+					((hasRequestString && innerRequest.startsWith(item.nameWithSlash)) ||
+						(absolutePath !== null && innerRequest.startsWith(absolutePath))));
 
 			const matchWildcard = !item.onlyModule && item.wildcardPrefix !== null;
 

--- a/lib/DescriptionFileUtils.js
+++ b/lib/DescriptionFileUtils.js
@@ -83,112 +83,122 @@ function loadDescriptionFile(
 	resolveContext,
 	callback,
 ) {
-	(function findDescriptionFile() {
+	// Hoist the per-filename iterator and the per-level done callback out
+	// of `findDescriptionFile`. They both close over `directory`, which we
+	// reassign as we walk up the tree, so the same closures keep working
+	// across every level — the previous implementation re-allocated both
+	// arrows on every recursion step, which adds up on deep walks (multiple
+	// `DescriptionFilePlugin` taps per resolve, each climbing several
+	// directories looking for `package.json`).
+	/**
+	 * @param {string} filename filename
+	 * @param {(err?: null | Error, result?: null | Result) => void} iterCallback callback
+	 * @returns {void}
+	 */
+	const iterFilename = (filename, iterCallback) => {
+		const descriptionFilePath = resolver.join(directory, filename);
+
+		/**
+		 * @param {(null | Error)=} err error
+		 * @param {JsonObject=} resolvedContent content
+		 * @returns {void}
+		 */
+		function onJson(err, resolvedContent) {
+			if (err) {
+				if (resolveContext.log) {
+					resolveContext.log(
+						`${descriptionFilePath} (directory description file): ${err}`,
+					);
+				} else {
+					err.message = `${descriptionFilePath} (directory description file): ${err}`;
+				}
+				return iterCallback(err);
+			}
+			iterCallback(null, {
+				content: /** @type {JsonObject} */ (resolvedContent),
+				directory,
+				path: descriptionFilePath,
+			});
+		}
+
+		if (resolver.fileSystem.readJson) {
+			resolver.fileSystem.readJson(descriptionFilePath, (err, content) => {
+				if (err) {
+					if (
+						typeof (/** @type {NodeJS.ErrnoException} */ (err).code) !==
+						"undefined"
+					) {
+						if (resolveContext.missingDependencies) {
+							resolveContext.missingDependencies.add(descriptionFilePath);
+						}
+						return iterCallback();
+					}
+					if (resolveContext.fileDependencies) {
+						resolveContext.fileDependencies.add(descriptionFilePath);
+					}
+					return onJson(err);
+				}
+				if (resolveContext.fileDependencies) {
+					resolveContext.fileDependencies.add(descriptionFilePath);
+				}
+				onJson(null, content);
+			});
+		} else {
+			resolver.fileSystem.readFile(descriptionFilePath, (err, content) => {
+				if (err) {
+					if (resolveContext.missingDependencies) {
+						resolveContext.missingDependencies.add(descriptionFilePath);
+					}
+					return iterCallback();
+				}
+				if (resolveContext.fileDependencies) {
+					resolveContext.fileDependencies.add(descriptionFilePath);
+				}
+
+				/** @type {JsonObject | undefined} */
+				let json;
+
+				if (content) {
+					try {
+						json = JSON.parse(content.toString());
+					} catch (/** @type {unknown} */ err_) {
+						return onJson(/** @type {Error} */ (err_));
+					}
+				} else {
+					return onJson(new Error("No content in file"));
+				}
+
+				onJson(null, json);
+			});
+		}
+	};
+	// Forward-declared so the helpers below can reference each other
+	// without falling foul of `no-use-before-define`.
+	/** @type {() => void} */
+	let findDescriptionFile;
+	/**
+	 * @param {(null | Error)=} err error
+	 * @param {(null | Result)=} result result
+	 * @returns {void}
+	 */
+	const onLevelDone = (err, result) => {
+		if (err) return callback(err);
+		if (result) return callback(null, result);
+		const dir = cdUp(directory);
+		if (!dir) {
+			return callback();
+		}
+		directory = dir;
+		return findDescriptionFile();
+	};
+	findDescriptionFile = () => {
 		if (oldInfo && oldInfo.directory === directory) {
 			// We already have info for this directory and can reuse it
 			return callback(null, oldInfo);
 		}
-		forEachBail(
-			filenames,
-			/**
-			 * @param {string} filename filename
-			 * @param {(err?: null | Error, result?: null | Result) => void} callback callback
-			 * @returns {void}
-			 */
-			(filename, callback) => {
-				const descriptionFilePath = resolver.join(directory, filename);
-
-				/**
-				 * @param {(null | Error)=} err error
-				 * @param {JsonObject=} resolvedContent content
-				 * @returns {void}
-				 */
-				function onJson(err, resolvedContent) {
-					if (err) {
-						if (resolveContext.log) {
-							resolveContext.log(
-								`${descriptionFilePath} (directory description file): ${err}`,
-							);
-						} else {
-							err.message = `${descriptionFilePath} (directory description file): ${err}`;
-						}
-						return callback(err);
-					}
-					callback(null, {
-						content: /** @type {JsonObject} */ (resolvedContent),
-						directory,
-						path: descriptionFilePath,
-					});
-				}
-
-				if (resolver.fileSystem.readJson) {
-					resolver.fileSystem.readJson(descriptionFilePath, (err, content) => {
-						if (err) {
-							if (
-								typeof (/** @type {NodeJS.ErrnoException} */ (err).code) !==
-								"undefined"
-							) {
-								if (resolveContext.missingDependencies) {
-									resolveContext.missingDependencies.add(descriptionFilePath);
-								}
-								return callback();
-							}
-							if (resolveContext.fileDependencies) {
-								resolveContext.fileDependencies.add(descriptionFilePath);
-							}
-							return onJson(err);
-						}
-						if (resolveContext.fileDependencies) {
-							resolveContext.fileDependencies.add(descriptionFilePath);
-						}
-						onJson(null, content);
-					});
-				} else {
-					resolver.fileSystem.readFile(descriptionFilePath, (err, content) => {
-						if (err) {
-							if (resolveContext.missingDependencies) {
-								resolveContext.missingDependencies.add(descriptionFilePath);
-							}
-							return callback();
-						}
-						if (resolveContext.fileDependencies) {
-							resolveContext.fileDependencies.add(descriptionFilePath);
-						}
-
-						/** @type {JsonObject | undefined} */
-						let json;
-
-						if (content) {
-							try {
-								json = JSON.parse(content.toString());
-							} catch (/** @type {unknown} */ err_) {
-								return onJson(/** @type {Error} */ (err_));
-							}
-						} else {
-							return onJson(new Error("No content in file"));
-						}
-
-						onJson(null, json);
-					});
-				}
-			},
-			/**
-			 * @param {(null | Error)=} err error
-			 * @param {(null | Result)=} result result
-			 * @returns {void}
-			 */
-			(err, result) => {
-				if (err) return callback(err);
-				if (result) return callback(null, result);
-				const dir = cdUp(directory);
-				if (!dir) {
-					return callback();
-				}
-				directory = dir;
-				return findDescriptionFile();
-			},
-		);
-	})();
+		forEachBail(filenames, iterFilename, onLevelDone);
+	};
+	findDescriptionFile();
 }
 
 /**

--- a/lib/DirectoryExistsPlugin.js
+++ b/lib/DirectoryExistsPlugin.js
@@ -33,21 +33,21 @@ module.exports = class DirectoryExistsPlugin {
 					const directory = request.path;
 					if (!directory) return callback();
 					fs.stat(directory, (err, stat) => {
-						if (err || !stat) {
+						// Combine the two miss branches: a stat failure and a
+						// "not a directory" result share the same handling — record
+						// the path on `missingDependencies`, log the right reason,
+						// then bail. The error-message ternary picks the wording
+						// that matched the failing condition.
+						if (err || !stat || !stat.isDirectory()) {
 							if (resolveContext.missingDependencies) {
 								resolveContext.missingDependencies.add(directory);
 							}
 							if (resolveContext.log) {
-								resolveContext.log(`${directory} doesn't exist`);
-							}
-							return callback();
-						}
-						if (!stat.isDirectory()) {
-							if (resolveContext.missingDependencies) {
-								resolveContext.missingDependencies.add(directory);
-							}
-							if (resolveContext.log) {
-								resolveContext.log(`${directory} is not a directory`);
+								resolveContext.log(
+									err || !stat
+										? `${directory} doesn't exist`
+										: `${directory} is not a directory`,
+								);
 							}
 							return callback();
 						}

--- a/lib/FileExistsPlugin.js
+++ b/lib/FileExistsPlugin.js
@@ -31,18 +31,22 @@ module.exports = class FileExistsPlugin {
 				const file = request.path;
 				if (!file) return callback();
 				fs.stat(file, (err, stat) => {
-					if (err || !stat) {
+					// Combine the two miss branches: a stat failure and a
+					// "not a file" result share the same handling — record the
+					// path on `missingDependencies`, log the right reason, then
+					// bail. The error-message ternary picks the wording that
+					// matched the failing condition.
+					if (err || !stat || !stat.isFile()) {
 						if (resolveContext.missingDependencies) {
 							resolveContext.missingDependencies.add(file);
 						}
-						if (resolveContext.log) resolveContext.log(`${file} doesn't exist`);
-						return callback();
-					}
-					if (!stat.isFile()) {
-						if (resolveContext.missingDependencies) {
-							resolveContext.missingDependencies.add(file);
+						if (resolveContext.log) {
+							resolveContext.log(
+								err || !stat
+									? `${file} doesn't exist`
+									: `${file} is not a file`,
+							);
 						}
-						if (resolveContext.log) resolveContext.log(`${file} is not a file`);
 						return callback();
 					}
 					if (resolveContext.fileDependencies) {

--- a/lib/ImportsFieldPlugin.js
+++ b/lib/ImportsFieldPlugin.js
@@ -64,8 +64,13 @@ module.exports = class ImportsFieldPlugin {
 				}
 
 				const { descriptionFileData } = request;
+				// Skip the concat when there's nothing to append — the common
+				// case has empty query/fragment, so this avoids an allocation
+				// per resolve. Mirrors the pattern in ExportsFieldPlugin.
 				const remainingRequest =
-					request.request + request.query + request.fragment;
+					request.query || request.fragment
+						? request.request + request.query + request.fragment
+						: request.request;
 
 				/** @type {string[]} */
 				let paths;

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -1137,9 +1137,25 @@ class Resolver {
 		[part.request, part.query, part.fragment] = parsedIdentifier;
 
 		if (part.request.length > 0) {
-			part.internal = this.isPrivate(identifier);
-			part.module = this.isModule(part.request);
-			part.directory = this.isDirectory(part.request);
+			// `getType` looks at the prefix of its input and the prefix is
+			// identical between `identifier` and `part.request` in every
+			// non-`\0`-escape case (slicing off `?query` / `#fragment` doesn't
+			// touch the head). `parseIdentifier`'s common fast path returns
+			// the same `identifier` reference as `parsedIdentifier[0]`, so a
+			// pointer-equality check detects the case where we can compute
+			// `getType` once and use it for both `module` and `internal`. The
+			// `\0#…` escape path produces a fresh `part.request` and falls
+			// through to the second `getType(identifier)` call to preserve
+			// the original `internal` flag.
+			const requestType = getType(part.request);
+			part.module = requestType === PathType.Normal;
+			part.internal =
+				identifier === part.request
+					? requestType === PathType.Internal
+					: getType(identifier) === PathType.Internal;
+			// `isDirectory` is just `endsWith("/")` — inline so `parse()`
+			// doesn't pay for the extra method dispatch on every resolve.
+			part.directory = part.request.endsWith("/");
 			if (part.directory) {
 				part.request = part.request.slice(0, -1);
 			}

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -42,6 +42,12 @@ const DEFAULT_CONFIG_FILE = "tsconfig.json";
 
 const READ_JSON_OPTIONS = { stripComments: true };
 
+// Trailing `/*` or `\*` segment of a tsconfig `paths` mapping (e.g.
+// `./src/*` → `./src`). Hoisted so we don't allocate a fresh regex per
+// path entry on every tsconfig load — and so the same regex object can be
+// reused for the matching `test` + `replace` pair below.
+const WILDCARD_TAIL_RE = /[/\\]\*$/;
+
 /**
  * @param {string} pattern Path pattern
  * @returns {number} Length of the prefix
@@ -125,16 +131,16 @@ function tsconfigPathsToResolveOptions(configDir, paths, resolver, baseUrl) {
 
 		if (absolutePaths.length > 0) {
 			if (pattern === "*") {
-				modules.push(
-					...absolutePaths
-						.map((dir) => {
-							if (/[/\\]\*$/.test(dir)) {
-								return dir.replace(/[/\\]\*$/, "");
-							}
-							return "";
-						})
-						.filter(Boolean),
-				);
+				// Pull `dir/*` entries directly into `modules` with their
+				// trailing wildcard stripped, skipping anything else. The
+				// previous `.map(...).filter(Boolean)` form allocated two
+				// throwaway arrays plus a spread iterator per `*` mapping.
+				for (let j = 0; j < absolutePaths.length; j++) {
+					const dir = absolutePaths[j];
+					if (WILDCARD_TAIL_RE.test(dir)) {
+						modules.push(dir.replace(WILDCARD_TAIL_RE, ""));
+					}
+				}
 			} else {
 				alias.push({ name: pattern, alias: absolutePaths });
 			}
@@ -439,9 +445,14 @@ module.exports = class TsconfigPathsPlugin {
 			if (context === requestPath) {
 				return data;
 			}
+			// Cheap integer-compare gate first: a context can only beat the
+			// current longest match if its own length is strictly greater.
+			// Skipping `isSubPath` (a `startsWith` + char-code probe) when the
+			// length already disqualifies the candidate avoids the per-resolve
+			// scan over every shorter context.
 			if (
-				isSubPath(context, requestPath) &&
-				context.length > longestMatchLength
+				context.length > longestMatchLength &&
+				isSubPath(context, requestPath)
 			) {
 				longestMatch = data;
 				longestMatchLength = context.length;

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -434,16 +434,17 @@ module.exports = class TsconfigPathsPlugin {
 		if (!requestPath) {
 			return main;
 		}
-		let longestMatch = null;
+		let longestMatchContext = null;
 		let longestMatchLength = 0;
-		// Iterate over the pre-computed key list + indexed access into
-		// `allContexts` — the previous `Object.entries(allContexts)` form
-		// allocated a fresh `[key, value][]` array on every resolve.
+		// Iterate the pre-computed key list (the previous
+		// `Object.entries(allContexts)` form allocated a fresh
+		// `[key, value][]` per resolve). Defer the `allContexts[context]`
+		// lookup to after we know the context actually matches — non-matches
+		// are the common case and don't need the property access.
 		for (let i = 0; i < contextList.length; i++) {
 			const context = contextList[i];
-			const data = allContexts[context];
 			if (context === requestPath) {
-				return data;
+				return allContexts[context];
 			}
 			// Cheap integer-compare gate first: a context can only beat the
 			// current longest match if its own length is strictly greater.
@@ -454,14 +455,13 @@ module.exports = class TsconfigPathsPlugin {
 				context.length > longestMatchLength &&
 				isSubPath(context, requestPath)
 			) {
-				longestMatch = data;
+				longestMatchContext = context;
 				longestMatchLength = context.length;
 			}
 		}
-		if (longestMatch) {
-			return longestMatch;
-		}
-		return null;
+		return longestMatchContext === null
+			? null
+			: allContexts[longestMatchContext];
 	}
 
 	/**

--- a/lib/util/entrypoints.js
+++ b/lib/util/entrypoints.js
@@ -140,7 +140,12 @@ function getFieldKeyInfos(field) {
 	for (let i = 0; i < keys.length; i++) {
 		const key = keys[i];
 		const patternIndex = key.indexOf("*");
-		const lastStar = patternIndex === -1 ? -1 : key.lastIndexOf("*");
+		// `isValidPattern` is true when the key has at most one `*`. Searching
+		// from `patternIndex + 1` stops as soon as a second `*` is found, so
+		// we avoid the full-string scan that `lastIndexOf` would do — and the
+		// single-star common case finishes in one pass.
+		const isValidPattern =
+			patternIndex === -1 || !key.includes("*", patternIndex + 1);
 		const keyLen = key.length;
 		const endsWithSlash =
 			keyLen > 0 && key.charCodeAt(keyLen - 1) === slashCode;
@@ -152,7 +157,7 @@ function getFieldKeyInfos(field) {
 			isLegacySubpath: patternIndex === -1 && endsWithSlash,
 			isPattern: patternIndex !== -1,
 			isSubpathMapping: endsWithSlash,
-			isValidPattern: patternIndex === -1 || lastStar === patternIndex,
+			isValidPattern,
 		};
 	}
 	_fieldKeyInfoCache.set(fieldKey, infos);

--- a/lib/util/entrypoints.js
+++ b/lib/util/entrypoints.js
@@ -292,16 +292,17 @@ function computeFindMatch(request, field) {
 function findMatch(request, field) {
 	const fieldKey = /** @type {RecordMapping} */ (field);
 	let perRequest = _findMatchCache.get(fieldKey);
-	if (perRequest !== undefined) {
-		const cached = perRequest.get(request);
-		if (cached !== undefined) return cached;
-		// `null` is a valid cached value (= "no match"), so a `get(...)`
-		// that returns undefined could either mean "not cached yet" or
-		// "cached null". Do the explicit `has` only in the undefined case.
-		if (perRequest.has(request)) return null;
-	} else {
+	if (perRequest === undefined) {
 		perRequest = new Map();
 		_findMatchCache.set(fieldKey, perRequest);
+	} else {
+		// `computeFindMatch` only ever returns `MatchTuple | null` — never
+		// `undefined` — and `Map.set(k, null)` then `Map.get(k)` returns
+		// `null`, not `undefined`. So `get(...) === undefined` already
+		// unambiguously means "not cached yet"; one Map lookup is enough,
+		// no follow-up `has` needed to disambiguate "cached null".
+		const cached = perRequest.get(request);
+		if (cached !== undefined) return cached;
 	}
 
 	const result = computeFindMatch(request, field);


### PR DESCRIPTION
* `ImportsFieldPlugin`: skip `request + query + fragment` when both
  `query` and `fragment` are empty (the common case), matching
  `ExportsFieldPlugin`.
* `util/entrypoints`: replace per-key `lastIndexOf("*")` (which scans
  the full string) with a bounded `includes("*", patternIndex + 1)` so
  single-star keys finish in one pass.
* `AliasUtils`: factor the duplicated `absolutePath !== null &&
  startsWith(absolutePath)` clause out of both ternary branches and
  destructure `absolutePath` once per option.

https://claude.ai/code/session_015jvA8SSpQbK7E2FeCEECdr