### PR TITLE
fix: TsconfigPathsPlugin circular references, unscoped pkg extends, and perf

### DIFF
--- a/.changeset/fix-tsconfig-paths-plugin.md
+++ b/.changeset/fix-tsconfig-paths-plugin.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Fix TsconfigPathsPlugin circular project references causing stack overflow, add support for extending from unscoped npm packages, and use `stat` instead of `readFile` for existence checks in extends resolution.

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -91,6 +91,8 @@ function mergeTsconfigs(base, config) {
  * @returns {string} the path with substituted template
  */
 function substituteConfigDir(pathValue, configDir) {
+	// eslint-disable-next-line no-template-curly-in-string
+	if (!pathValue.includes("${configDir}")) return pathValue;
 	return pathValue.replace(/\$\{configDir\}/g, configDir);
 }
 
@@ -492,7 +494,7 @@ module.exports = class TsconfigPathsPlugin {
 			extendedConfigValue,
 		);
 
-		fileSystem.readFile(initialExtendedConfigPath, (existsErr) => {
+		fileSystem.stat(initialExtendedConfigPath, (existsErr) => {
 			let extendedConfigPath = initialExtendedConfigPath;
 			if (existsErr) {
 				// Handle scoped package extends like "@scope/name" (no sub-path):
@@ -517,6 +519,18 @@ module.exports = class TsconfigPathsPlugin {
 					extendedConfigPath = resolver.join(
 						currentDir,
 						normalize(`node_modules/${extendedConfigValue}`),
+					);
+				} else if (
+					!originalExtendedConfigValue.startsWith(".") &&
+					!originalExtendedConfigValue.startsWith("/")
+				) {
+					// Handle unscoped package extends like "my-base-config" (no sub-path):
+					// "my-base-config" should resolve to node_modules/my-base-config/tsconfig.json
+					extendedConfigPath = resolver.join(
+						currentDir,
+						normalize(
+							`node_modules/${originalExtendedConfigValue}/${DEFAULT_CONFIG_FILE}`,
+						),
 					);
 				}
 			}
@@ -561,6 +575,7 @@ module.exports = class TsconfigPathsPlugin {
 	 * @param {Set<string>} fileDependencies the file dependencies
 	 * @param {{ [baseUrl: string]: TsconfigPathsData }} referenceMatchMap the map to populate
 	 * @param {(err: Error | null) => void} callback callback
+	 * @param {Set<string>=} visitedRefPaths visited reference config paths (for circular reference detection)
 	 * @returns {void}
 	 */
 	_loadTsconfigReferences(
@@ -570,9 +585,11 @@ module.exports = class TsconfigPathsPlugin {
 		fileDependencies,
 		referenceMatchMap,
 		callback,
+		visitedRefPaths,
 	) {
 		if (references.length === 0) return callback(null);
 
+		const visited = visitedRefPaths || new Set();
 		let pending = references.length;
 		const finishOne = () => {
 			if (--pending === 0) callback(null);
@@ -584,6 +601,12 @@ module.exports = class TsconfigPathsPlugin {
 				resolver.join(context, refPath),
 				DEFAULT_CONFIG_FILE,
 			);
+
+			if (visited.has(refConfigPath)) {
+				finishOne();
+				continue;
+			}
+			visited.add(refConfigPath);
 
 			this._loadTsconfig(
 				resolver,
@@ -615,6 +638,7 @@ module.exports = class TsconfigPathsPlugin {
 							fileDependencies,
 							referenceMatchMap,
 							finishOne,
+							visited,
 						);
 					} else {
 						finishOne();

--- a/test/fixtures/tsconfig-paths/extends-unscoped-pkg/node_modules/my-base-config/src/util.ts
+++ b/test/fixtures/tsconfig-paths/extends-unscoped-pkg/node_modules/my-base-config/src/util.ts
@@ -1,0 +1,1 @@
+export const util = "util";

--- a/test/fixtures/tsconfig-paths/extends-unscoped-pkg/node_modules/my-base-config/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/extends-unscoped-pkg/node_modules/my-base-config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@pkg/*": ["./src/*"]
+		}
+	}
+}

--- a/test/fixtures/tsconfig-paths/extends-unscoped-pkg/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/extends-unscoped-pkg/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "my-base-config"
+}

--- a/test/fixtures/tsconfig-paths/references-circular/a/src/index.ts
+++ b/test/fixtures/tsconfig-paths/references-circular/a/src/index.ts
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/test/fixtures/tsconfig-paths/references-circular/a/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/references-circular/a/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@a/*": ["./src/*"]
+		},
+		"composite": true
+	},
+	"references": [{ "path": "../b" }]
+}

--- a/test/fixtures/tsconfig-paths/references-circular/b/src/index.ts
+++ b/test/fixtures/tsconfig-paths/references-circular/b/src/index.ts
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/test/fixtures/tsconfig-paths/references-circular/b/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/references-circular/b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@b/*": ["./src/*"]
+		},
+		"composite": true
+	},
+	"references": [{ "path": "../a" }]
+}

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -38,6 +38,18 @@ const referencesProjectDir = path.resolve(
 	"tsconfig-paths",
 	"references-project",
 );
+const referencesCircularDir = path.resolve(
+	__dirname,
+	"fixtures",
+	"tsconfig-paths",
+	"references-circular",
+);
+const extendsUnscopedPkgDir = path.resolve(
+	__dirname,
+	"fixtures",
+	"tsconfig-paths",
+	"extends-unscoped-pkg",
+);
 
 describe("TsconfigPathsPlugin", () => {
 	it("resolves exact mapped path '@components/*' via tsconfig option (example)", (done) => {
@@ -1328,6 +1340,86 @@ describe("TsconfigPathsPlugin", () => {
 				);
 				done();
 			});
+		});
+	});
+
+	describe("bug: circular project references should not cause infinite recursion", () => {
+		it("should handle circular references without hanging or crashing", (done) => {
+			const aDir = path.join(referencesCircularDir, "a");
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: {
+					configFile: path.join(aDir, "tsconfig.json"),
+					references: "auto",
+				},
+			});
+
+			// a references b, b references a — should not stack overflow
+			resolver.resolve({}, aDir, "@a/index", {}, (err, result) => {
+				if (err) return done(err);
+				if (!result) return done(new Error("No result"));
+				expect(result).toEqual(path.join(aDir, "src", "index.ts"));
+				done();
+			});
+		});
+
+		it("should resolve paths from a circular-referenced project", (done) => {
+			const aDir = path.join(referencesCircularDir, "a");
+			const bDir = path.join(referencesCircularDir, "b");
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: {
+					configFile: path.join(aDir, "tsconfig.json"),
+					references: "auto",
+				},
+			});
+
+			// From b's context, @b/* should resolve via b's own paths
+			resolver.resolve({}, bDir, "@b/index", {}, (err, result) => {
+				if (err) return done(err);
+				if (!result) return done(new Error("No result"));
+				expect(result).toEqual(path.join(bDir, "src", "index.ts"));
+				done();
+			});
+		});
+	});
+
+	describe("bug: unscoped npm package in extends field", () => {
+		it("should resolve paths inherited from an unscoped npm package tsconfig (extends 'my-base-config')", (done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: path.join(extendsUnscopedPkgDir, "tsconfig.json"),
+			});
+
+			resolver.resolve(
+				{},
+				extendsUnscopedPkgDir,
+				"@pkg/util",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					if (!result) return done(new Error("No result"));
+					expect(result).toEqual(
+						path.join(
+							extendsUnscopedPkgDir,
+							"node_modules",
+							"my-base-config",
+							"src",
+							"util.ts",
+						),
+					);
+					done();
+				},
+			);
 		});
 	});
 });


### PR DESCRIPTION
**Summary**

Fix multiple bugs and performance issues in `TsconfigPathsPlugin`:

- **Circular project references → stack overflow**: When project references form a cycle (A references B, B references A) with `references: "auto"`, `_loadTsconfigReferences` recurses infinitely. Fixed by tracking visited reference config paths in a `Set` and skipping already-visited ones.
- **Unscoped npm package extends not resolved**: `extends: "my-base-config"` (unscoped package, no sub-path) failed to resolve to `node_modules/my-base-config/tsconfig.json`. The existing fallback logic only handled scoped packages (`@scope/name`) and sub-path packages (`pkg/tsconfig`). Added an else branch for unscoped packages.
- **`readFile` used for existence check**: `_loadTsconfigFromExtends` called `readFile` just to check if a path exists, discarding the buffer. Changed to `stat` which avoids reading the entire file content unnecessarily.
- **`substituteConfigDir` regex on every call**: The regex replacement ran even when paths contained no `${configDir}`. Added a fast `includes` check to skip the regex when not needed.

**What kind of change does this PR introduce?**

fix, perf

**Did you add tests for your changes?**

Yes. Added 3 new test cases:
- `test/tsconfig-paths.test.js`: "should handle circular references without hanging or crashing"
- `test/tsconfig-paths.test.js`: "should resolve paths from a circular-referenced project"
- `test/tsconfig-paths.test.js`: "should resolve paths inherited from an unscoped npm package tsconfig"

Test fixtures added:
- `test/fixtures/tsconfig-paths/references-circular/` — A↔B circular reference project
- `test/fixtures/tsconfig-paths/extends-unscoped-pkg/` — unscoped npm package extends

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes needed.

**Use of AI**

This PR was authored with the assistance of Claude Code (Claude Opus 4.6). The bugs were identified through code review, test cases were written first to reproduce, then fixes were applied and verified.