### PR TITLE
chore: improve AGENTS.md to enforce upstream workflow and project scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
-# Development Guide
+> CLAUDE.md is a symlink to AGENTS.md. They are the same file.
 
-> Note: CLAUDE.md is a symlink to AGENTS.md. They are the same file.
+**Before starting any task, you MUST:**
 
-For common webpack org rules (CLA, commit identity, PR template, AI policy, changeset conventions), see **[webpack/webpack AGENTS.md](https://github.com/webpack/webpack/blob/main/AGENTS.md)**.
-
-Specific commands (test, lint, format) may differ across repos — refer to `scripts` in `package.json`.
+1. Fetch and read [webpack/webpack AGENTS.md](https://github.com/webpack/webpack/blob/main/AGENTS.md) — it defines the required workflow for all webpack repos.
+2. Read `scripts` in `package.json` — commands for testing, linting, formatting, and type generation differ across repos. Always use them, never run tools directly via `npx`.


### PR DESCRIPTION
**Summary**

The previous AGENTS.md passively pointed to the upstream webpack AGENTS.md ("see ..."), which AI agents tended to skip — missing key rules like test-first for bug fixes and commit identity for CLA. It also said "refer to `scripts` in `package.json`" without being explicit enough, leading agents to use `npx` instead of project scripts.

This change makes the instructions actionable:
1. **MUST fetch and read** the upstream AGENTS.md before starting any task
2. **MUST use project scripts** from `package.json`, never `npx`

This file is designed to be copied across all webpack sub-repos.

**What kind of change does this PR introduce?**

chore

**Did you add tests for your changes?**

N/A — documentation only.

**Does this PR introduce a breaking change?**

No.

**Use of AI**

This PR was authored with the assistance of Claude Code (Claude Opus 4.6), based on workflow issues identified during a prior bug-fix session.