### PR TITLE
fix: TsconfigPathsPlugin should fall through when mapped path does not exist

### DIFF
--- a/.changeset/tsconfig-paths-scoped-pkg-fallthrough.md
+++ b/.changeset/tsconfig-paths-scoped-pkg-fallthrough.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+TsconfigPathsPlugin now falls through to normal module resolution when a `paths` pattern matches but the mapped path does not exist, matching TypeScript's native resolution behavior. Previously, patterns like `"@*"` would block scoped npm packages (e.g. `@sentry/react`) from resolving via `node_modules`.

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -272,7 +272,15 @@ module.exports = class TsconfigPathsPlugin {
 							aliasTarget,
 							request,
 							resolveContext,
-							callback,
+							(err, result) => {
+								if (err) return callback(err);
+								if (result) return callback(null, result);
+								// https://github.com/webpack/webpack/issues/20944
+								// Unlike resolve.alias, tsconfig paths should fall through
+								// when a pattern matches but the mapped path does not exist
+								// (matching TypeScript's native resolution behavior).
+								return callback();
+							},
 						);
 					},
 				);

--- a/test/fixtures/tsconfig-paths/scoped-pkg-fallthrough/node_modules/@sentry/react/index.js
+++ b/test/fixtures/tsconfig-paths/scoped-pkg-fallthrough/node_modules/@sentry/react/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/fixtures/tsconfig-paths/scoped-pkg-fallthrough/node_modules/@sentry/react/package.json
+++ b/test/fixtures/tsconfig-paths/scoped-pkg-fallthrough/node_modules/@sentry/react/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@sentry/react",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/fixtures/tsconfig-paths/scoped-pkg-fallthrough/src/helper/index.ts
+++ b/test/fixtures/tsconfig-paths/scoped-pkg-fallthrough/src/helper/index.ts
@@ -1,0 +1,4 @@
+import * as sentry from "@sentry/react";
+
+export const helper = true;
+export { sentry };

--- a/test/fixtures/tsconfig-paths/scoped-pkg-fallthrough/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/scoped-pkg-fallthrough/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@*": ["./src/*"]
+    }
+  }
+}

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -1390,6 +1390,59 @@ describe("TsconfigPathsPlugin", () => {
 		});
 	});
 
+	describe("bug: '@*' pattern should fall through for scoped npm packages (#20944)", () => {
+		const scopedPkgDir = path.resolve(
+			__dirname,
+			"fixtures",
+			"tsconfig-paths",
+			"scoped-pkg-fallthrough",
+		);
+
+		it("should resolve '@helper' via the '@*' mapping when the mapped path exists", (done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx", ".js"],
+				mainFields: ["main"],
+				mainFiles: ["index"],
+				tsconfig: path.join(scopedPkgDir, "tsconfig.json"),
+			});
+
+			resolver.resolve({}, scopedPkgDir, "@helper", {}, (err, result) => {
+				if (err) return done(err);
+				if (!result) return done(new Error("No result"));
+				expect(result).toEqual(
+					path.join(scopedPkgDir, "src", "helper", "index.ts"),
+				);
+				done();
+			});
+		});
+
+		it("should fall through to node_modules for '@sentry/react' when '@*' mapping does not resolve", (done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx", ".js"],
+				mainFields: ["main"],
+				mainFiles: ["index"],
+				tsconfig: path.join(scopedPkgDir, "tsconfig.json"),
+			});
+
+			resolver.resolve({}, scopedPkgDir, "@sentry/react", {}, (err, result) => {
+				if (err) return done(err);
+				if (!result) return done(new Error("No result"));
+				expect(result).toEqual(
+					path.join(
+						scopedPkgDir,
+						"node_modules",
+						"@sentry",
+						"react",
+						"index.js",
+					),
+				);
+				done();
+			});
+		});
+	});
+
 	describe("bug: unscoped npm package in extends field", () => {
 		it("should resolve paths inherited from an unscoped npm package tsconfig (extends 'my-base-config')", (done) => {
 			const resolver = ResolverFactory.createResolver({


### PR DESCRIPTION
## Summary

- When tsconfig `paths` contains a broad pattern like `"@*": ["./src/*"]`, scoped npm packages such as `@sentry/react` are matched by the wildcard but the mapped path (`./src/sentry/react`) does not exist. Previously, `aliasResolveHandler` returned `callback(null, null)` which bailed the entire `raw-resolve` hook pipeline, blocking normal `node_modules` resolution. Now TsconfigPathsPlugin wraps the callback to convert a "matched but not found" result into a fallthrough, matching TypeScript's native resolution behavior.
- Fixes webpack/webpack#20944

## What kind of change does this PR introduce?

fix

## Did you add tests for your changes?

Yes — `test/tsconfig-paths.test.js`: two new tests under `"bug: '@*' pattern should fall through for scoped npm packages (#20944)"`:
  - `@helper` resolves via the `@*` mapping when the mapped path exists
  - `@sentry/react` falls through to `node_modules` when the `@*` mapping does not resolve

## Does this PR introduce a breaking change?

No. Only affects tsconfig `paths` resolution — `resolve.alias` behavior is unchanged.