### PR TITLE
fix: TsconfigPathsPlugin walks up parent directories when tsconfig is true

### DIFF
--- a/.changeset/tsconfig-true-upward-traversal.md
+++ b/.changeset/tsconfig-true-upward-traversal.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+When `tsconfig: true` is used, walk up parent directories to find `tsconfig.json`, matching TypeScript's own `findConfigFile` behavior.

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -337,6 +337,32 @@ module.exports = class TsconfigPathsPlugin {
 			return callback(null, cached);
 		}
 
+		if (this.isAutoConfigFile) {
+			this._findTsconfigUpward(
+				resolver,
+				request.path || process.cwd(),
+				(err, result) => {
+					if (err) {
+						request.tsconfigPathsMap = null;
+						return callback(err);
+					}
+					if (!result) {
+						request.tsconfigPathsMap = null;
+						return callback(null, null);
+					}
+					const map = /** @type {TsconfigPathsMap} */ (result);
+					request.tsconfigPathsMap = map;
+					if (resolveContext.fileDependencies) {
+						for (const fileDependency of map.fileDependencies) {
+							resolveContext.fileDependencies.add(fileDependency);
+						}
+					}
+					callback(null, map);
+				},
+			);
+			return;
+		}
+
 		const absTsconfigPath = resolver.join(
 			request.path || process.cwd(),
 			this.configFile,
@@ -344,12 +370,6 @@ module.exports = class TsconfigPathsPlugin {
 		this._loadTsconfigPathsMap(resolver, absTsconfigPath, (err, result) => {
 			if (err) {
 				request.tsconfigPathsMap = null;
-				if (
-					this.isAutoConfigFile &&
-					/** @type {NodeJS.ErrnoException} */ (err).code === "ENOENT"
-				) {
-					return callback(null, null);
-				}
 				return callback(err);
 			}
 
@@ -362,6 +382,45 @@ module.exports = class TsconfigPathsPlugin {
 			}
 			callback(null, map);
 		});
+	}
+
+	/**
+	 * Walk up from startDir to the filesystem root looking for tsconfig.json.
+	 * Like TypeScript's own `findConfigFile` / `forEachAncestorDirectory`.
+	 * @param {Resolver} resolver the resolver
+	 * @param {string} startDir the directory to start searching from
+	 * @param {(err: Error | null, result?: TsconfigPathsMap | null) => void} callback the callback
+	 * @returns {void}
+	 */
+	_findTsconfigUpward(resolver, startDir, callback) {
+		const { fileSystem } = resolver;
+		const configFileName = this.configFile;
+
+		/**
+		 * @param {string} dir current directory
+		 */
+		const check = (dir) => {
+			const candidate = resolver.join(dir, configFileName);
+			fileSystem.stat(candidate, (statErr) => {
+				if (!statErr) {
+					// Found — load it
+					this._loadTsconfigPathsMap(resolver, candidate, (loadErr, result) => {
+						if (loadErr) return callback(loadErr);
+						callback(null, result);
+					});
+					return;
+				}
+				// Not found — move to parent
+				const parentDir = resolver.dirname(dir);
+				if (parentDir === dir) {
+					// Reached filesystem root, no tsconfig.json found
+					return callback(null, null);
+				}
+				check(parentDir);
+			});
+		};
+
+		check(startDir);
 	}
 
 	/**

--- a/test/fixtures/tsconfig-paths/upward-traversal/src/app/index.ts
+++ b/test/fixtures/tsconfig-paths/upward-traversal/src/app/index.ts
@@ -1,0 +1,1 @@
+import { helper } from "@utils/helper";

--- a/test/fixtures/tsconfig-paths/upward-traversal/src/utils/helper.ts
+++ b/test/fixtures/tsconfig-paths/upward-traversal/src/utils/helper.ts
@@ -1,0 +1,1 @@
+export const helper = "helper";

--- a/test/fixtures/tsconfig-paths/upward-traversal/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/upward-traversal/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@utils/*": ["./src/utils/*"]
+    }
+  }
+}

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -1268,6 +1268,65 @@ describe("TsconfigPathsPlugin", () => {
 		});
 	});
 
+	describe("tsconfig: true should walk up parent directories", () => {
+		const upwardDir = path.resolve(
+			__dirname,
+			"fixtures",
+			"tsconfig-paths",
+			"upward-traversal",
+		);
+
+		it("should find tsconfig.json in parent directory when resolving from subdirectory", (done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: true,
+			});
+
+			// resolve from src/app/ — tsconfig.json is in upward-traversal/ (parent's parent)
+			resolver.resolve(
+				{},
+				path.join(upwardDir, "src", "app"),
+				"@utils/helper",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					if (!result) return done(new Error("No result"));
+					expect(result).toEqual(
+						path.join(upwardDir, "src", "utils", "helper.ts"),
+					);
+					done();
+				},
+			);
+		});
+
+		it("should still fall through when no tsconfig.json exists anywhere up", (done) => {
+			const noTsconfigDir = path.resolve(
+				__dirname,
+				"fixtures",
+				"tsconfig-paths",
+				"no-tsconfig",
+			);
+
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: true,
+			});
+
+			resolver.resolve({}, noTsconfigDir, "./src/index", {}, (err, result) => {
+				if (err) return done(err);
+				if (!result) return done(new Error("No result"));
+				expect(result).toEqual(path.join(noTsconfigDir, "src", "index.ts"));
+				done();
+			});
+		});
+	});
+
 	describe("JSONC support (comments in tsconfig.json)", () => {
 		const jsoncExampleDir = path.resolve(
 			__dirname,


### PR DESCRIPTION
## Summary

When `tsconfig: true` is used, the plugin now searches from the source file's directory upward to the filesystem root for `tsconfig.json`, matching TypeScript's own `findConfigFile` behavior. Previously it only checked the immediate `request.path` directory, so if `tsconfig.json` lived in a parent directory (e.g. project root), it was not found.

Fixes webpack/webpack#20965

## What kind of change does this PR introduce?

fix

## Did you add tests for your changes?

Yes — `test/tsconfig-paths.test.js`: two new tests under `"tsconfig: true should walk up parent directories"`:
- Finds `tsconfig.json` in parent directory when resolving from a subdirectory
- Falls through normally when no `tsconfig.json` exists anywhere up the tree

## Does this PR introduce a breaking change?

No. Only affects `tsconfig: true` auto-discovery. Explicit path behavior is unchanged.

## Documentation needed?

n/a

## Use of AI

Claude Code drafted the implementation under human review.