### PR TITLE
fix: don't add configDir to modules when tsconfig has no baseUrl

### DIFF
--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -149,7 +149,7 @@ function tsconfigPathsToResolveOptions(configDir, paths, resolver, baseUrl) {
 		}
 	}
 
-	if (absoluteBaseUrl && !modules.includes(absoluteBaseUrl)) {
+	if (baseUrl && absoluteBaseUrl && !modules.includes(absoluteBaseUrl)) {
 		modules.push(absoluteBaseUrl);
 	}
 

--- a/test/fixtures/tsconfig-paths/no-baseurl-upward/package.json
+++ b/test/fixtures/tsconfig-paths/no-baseurl-upward/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "no-baseurl-upward",
+  "version": "1.0.0"
+}

--- a/test/fixtures/tsconfig-paths/no-baseurl-upward/subdir/index.ts
+++ b/test/fixtures/tsconfig-paths/no-baseurl-upward/subdir/index.ts
@@ -1,0 +1,1 @@
+import value from "pkg";

--- a/test/fixtures/tsconfig-paths/no-baseurl-upward/subdir/node_modules/package/index.js
+++ b/test/fixtures/tsconfig-paths/no-baseurl-upward/subdir/node_modules/package/index.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/fixtures/tsconfig-paths/no-baseurl-upward/subdir/node_modules/package/package.json
+++ b/test/fixtures/tsconfig-paths/no-baseurl-upward/subdir/node_modules/package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package",
+  "version": "1.0.0"
+}

--- a/test/fixtures/tsconfig-paths/no-baseurl-upward/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/no-baseurl-upward/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs"
+  }
+}

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -1327,6 +1327,51 @@ describe("TsconfigPathsPlugin", () => {
 		});
 	});
 
+	describe("tsconfig without baseUrl should not add configDir to module search paths", () => {
+		const noBaseUrlDir = path.resolve(
+			__dirname,
+			"fixtures",
+			"tsconfig-paths",
+			"no-baseurl-upward",
+		);
+
+		it("should resolve node_modules package instead of matching a file at tsconfig root", (done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".js", ".json"],
+				mainFields: ["main"],
+				mainFiles: ["index"],
+				tsconfig: true,
+			});
+
+			// Resolve "package" from subdir/ which has node_modules/package/.
+			// The parent tsconfig.json (without baseUrl) should NOT cause the
+			// tsconfig root to become a module search path — otherwise "package"
+			// would incorrectly match <root>/package.json instead of the real
+			// node_modules/package/index.js.
+			resolver.resolve(
+				{},
+				path.join(noBaseUrlDir, "subdir"),
+				"package",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					if (!result) return done(new Error("No result"));
+					expect(result).toEqual(
+						path.join(
+							noBaseUrlDir,
+							"subdir",
+							"node_modules",
+							"package",
+							"index.js",
+						),
+					);
+					done();
+				},
+			);
+		});
+	});
+
 	describe("JSONC support (comments in tsconfig.json)", () => {
 		const jsoncExampleDir = path.resolve(
 			__dirname,


### PR DESCRIPTION
## Summary
Fixes https://github.com/webpack/webpack/actions/runs/26091453506/job/76736654246?pr=20966

When `tsconfig: true` and `_findTsconfigUpward` walks up the directory tree to find a `tsconfig.json` **without `baseUrl`**, `tsconfigPathsToResolveOptions` was unconditionally adding the tsconfig's directory (`configDir`) to the resolver's `modules` list.

This caused bare specifiers to incorrectly resolve against files in the tsconfig root directory. For example, `import value from "package"` would resolve to `<tsconfig_root>/package.json` (a JSON module) instead of `node_modules/package/index.js`.

### Root cause

In `tsconfigPathsToResolveOptions`:

```js
const absoluteBaseUrl = !baseUrl ? configDir : resolver.join(configDir, baseUrl);
// ...
if (absoluteBaseUrl && !modules.includes(absoluteBaseUrl)) {
    modules.push(absoluteBaseUrl);  // ← bug: adds configDir even without baseUrl
}
```

When `baseUrl` is `undefined`, `absoluteBaseUrl` falls back to `configDir`. The guard only checks truthiness, so it always adds it.

### Fix

Only add `absoluteBaseUrl` to `modules` when `baseUrl` was explicitly set in the tsconfig:

```js
if (baseUrl && absoluteBaseUrl && !modules.includes(absoluteBaseUrl)) {
```

### Reproduction

A subdirectory with `node_modules/package/index.js` and a parent `tsconfig.json` (no `baseUrl`):

```
root/
├── tsconfig.json          # { "compilerOptions": { "target": "ES2017" } }
├── package.json           # { "name": "myproject" }
└── subdir/
    └── node_modules/
        └── package/
            ├── index.js   # module.exports = 42;
            └── package.json
```

Resolving `"package"` from `subdir/` with `tsconfig: true`:
- **Before**: resolves to `root/package.json` (wrong)
- **After**: resolves to `subdir/node_modules/package/index.js` (correct)

This bug was discovered through a webpack test failure (`ConfigTestCases › managedPaths › futureDefaults`) where `experiments.futureDefaults` enables `resolve.tsconfig: true`.

**Use of AI**: Claude Code was used to investigate and draft this fix under human review.