### PR TITLE
fix: enforce restrictions on real path of in-root symlinks

### DIFF
--- a/.changeset/fix-restrictions-symlink-bypass.md
+++ b/.changeset/fix-restrictions-symlink-bypass.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Fix `restrictions` bypass via an in-root symlink pointing outside the root.

--- a/lib/SymlinkPlugin.js
+++ b/lib/SymlinkPlugin.js
@@ -112,7 +112,18 @@ module.exports = class SymlinkPlugin {
 							obj,
 							`resolved symlink to ${result}`,
 							resolveContext,
-							callback,
+							(err, innerResult) => {
+								if (err) return callback(err);
+								// The symlink-resolved (real) path is authoritative. If
+								// resolving it produced a result, use it. If it did not —
+								// e.g. a `restrictions` rule rejected the real target —
+								// stop here with no result instead of letting the next
+								// plugin report the original in-root symlink path, which
+								// would leave the symlink unresolved and bypass
+								// `restrictions`.
+								if (innerResult) return callback(null, innerResult);
+								return callback(null, null);
+							},
 						);
 					},
 				);

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -177,7 +177,25 @@ describe("restrictions", () => {
 		}
 
 		afterAll(() => {
-			fs.rmSync(symlinkRoot, { recursive: true, force: true });
+			for (const file of [
+				path.join(allowed, "link.js"),
+				path.join(allowed, "rel-link.js"),
+				path.join(allowed, "real.js"),
+				path.join(outside, "secret.js"),
+			]) {
+				try {
+					fs.unlinkSync(file);
+				} catch (_err) {
+					// ignore
+				}
+			}
+			for (const dir of [allowed, outside, symlinkRoot]) {
+				try {
+					fs.rmdirSync(dir);
+				} catch (_err) {
+					// ignore
+				}
+			}
 		});
 
 		if (canSymlink) {

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -150,4 +150,83 @@ describe("restrictions", () => {
 			},
 		);
 	});
+
+	describe("with symlinks", () => {
+		const symlinkRoot = path.resolve(__dirname, "temp-restrictions-symlink");
+		const allowed = path.join(symlinkRoot, "allowed");
+		const outside = path.join(symlinkRoot, "outside");
+
+		let canSymlink = true;
+		try {
+			fs.mkdirSync(allowed, { recursive: true });
+			fs.mkdirSync(outside, { recursive: true });
+			fs.writeFileSync(path.join(outside, "secret.js"), "module.exports = 1;");
+			fs.writeFileSync(path.join(allowed, "real.js"), "module.exports = 2;");
+			fs.symlinkSync(
+				path.join(outside, "secret.js"),
+				path.join(allowed, "link.js"),
+				"file",
+			);
+			fs.symlinkSync(
+				path.join("..", "outside", "secret.js"),
+				path.join(allowed, "rel-link.js"),
+				"file",
+			);
+		} catch (_err) {
+			canSymlink = false;
+		}
+
+		afterAll(() => {
+			fs.rmSync(symlinkRoot, { recursive: true, force: true });
+		});
+
+		if (canSymlink) {
+			it("should reject an in-root symlink whose real target is outside the restriction", (done) => {
+				const resolver = ResolverFactory.createResolver({
+					fileSystem: nodeFileSystem,
+					extensions: [".js"],
+					restrictions: [allowed],
+				});
+
+				resolver.resolve({}, allowed, "./link.js", {}, (err, result) => {
+					if (!err) return done(new Error(`expect error, got ${result}`));
+					expect(err).toBeInstanceOf(Error);
+					done();
+				});
+			});
+
+			it("should reject an in-root relative symlink whose real target is outside the restriction", (done) => {
+				const resolver = ResolverFactory.createResolver({
+					fileSystem: nodeFileSystem,
+					extensions: [".js"],
+					restrictions: [allowed],
+				});
+
+				resolver.resolve({}, allowed, "./rel-link.js", {}, (err, result) => {
+					if (!err) return done(new Error(`expect error, got ${result}`));
+					expect(err).toBeInstanceOf(Error);
+					done();
+				});
+			});
+
+			it("should still resolve a real in-root file under the restriction", (done) => {
+				const resolver = ResolverFactory.createResolver({
+					fileSystem: nodeFileSystem,
+					extensions: [".js"],
+					restrictions: [allowed],
+				});
+
+				resolver.resolve({}, allowed, "./real.js", {}, (err, result) => {
+					if (err) return done(err);
+					expect(result).toEqual(path.join(allowed, "real.js"));
+					done();
+				});
+			});
+		} else {
+			// eslint-disable-next-line jest/expect-expect
+			it("cannot test symlinks because we have no permission to create them", () => {
+				// Nothing
+			});
+		}
+	});
 });


### PR DESCRIPTION
When a path component is an in-root symlink whose real target is outside
a configured `restrictions` root, the resolver rejected the resolved real
path but then fell through and reported the original in-root symlink path
as a successful result, bypassing the restriction (GHSA-fvr2-82rg-p3pp).

Make the symlink-resolved path authoritative in SymlinkPlugin: if
resolving the real target yields no result, stop with no result instead
of falling through to report the unresolved symlink path.

https://claude.ai/code/session_01AzLgPaEox5YTEhbJMaKxmC