### PR TITLE
fix: fall back when an exports target is filtered out by restrictions

### DIFF
--- a/.changeset/exports-field-restrictions-fallback.md
+++ b/.changeset/exports-field-restrictions-fallback.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Fall back to the next `modules` entry when a package `exports` target is filtered out by `restrictions`, instead of throwing.

--- a/lib/ExportsFieldPlugin.js
+++ b/lib/ExportsFieldPlugin.js
@@ -239,6 +239,8 @@ module.exports = class ExportsFieldPlugin {
 								),
 							);
 						}
+						// Drop the internal marker before it reaches the result.
+						if (restrictionsMarker) delete result.__restrictionsMarker;
 						callback(null, result);
 					},
 				);

--- a/lib/ExportsFieldPlugin.js
+++ b/lib/ExportsFieldPlugin.js
@@ -199,8 +199,13 @@ module.exports = class ExportsFieldPlugin {
 							relativePath,
 							query,
 							fragment,
-							__restrictionsMarker: restrictionsMarker,
 						};
+						// Attach the marker only when restrictions are configured, so
+						// resolves without restrictions keep their request shape and
+						// never leak the property onto the result.
+						if (restrictionsMarker) {
+							obj.__restrictionsMarker = restrictionsMarker;
+						}
 
 						resolver.doResolve(
 							target,

--- a/lib/ExportsFieldPlugin.js
+++ b/lib/ExportsFieldPlugin.js
@@ -27,12 +27,14 @@ module.exports = class ExportsFieldPlugin {
 	 * @param {Set<string>} conditionNames condition names
 	 * @param {string | string[]} fieldNamePath name path
 	 * @param {string | ResolveStepHook} target target
+	 * @param {boolean=} restrictions whether `restrictions` are configured (enables exports-target fallback when a target is filtered out)
 	 */
-	constructor(source, conditionNames, fieldNamePath, target) {
+	constructor(source, conditionNames, fieldNamePath, target, restrictions) {
 		this.source = source;
 		this.target = target;
 		this.conditionNames = conditionNames;
 		this.fieldName = fieldNamePath;
+		this.restrictions = Boolean(restrictions);
 		// `null` is cached for description files that have no exports field,
 		// so subsequent resolves against the same package.json skip the
 		// `DescriptionFileUtils.getField` walk entirely.
@@ -136,6 +138,13 @@ module.exports = class ExportsFieldPlugin {
 					);
 				}
 
+				// When `restrictions` are configured, share a marker down the
+				// chain so RestrictionsPlugin can tell us it filtered out an
+				// otherwise-valid target — then we fall back instead of erroring.
+				const restrictionsMarker = this.restrictions
+					? { blocked: false }
+					: undefined;
+
 				forEachBail(
 					paths,
 					/**
@@ -190,6 +199,7 @@ module.exports = class ExportsFieldPlugin {
 							relativePath,
 							query,
 							fragment,
+							__restrictionsMarker: restrictionsMarker,
 						};
 
 						resolver.doResolve(
@@ -218,6 +228,11 @@ module.exports = class ExportsFieldPlugin {
 						// is a hard error, not a signal to continue searching up the directory tree.
 						// See: https://github.com/webpack/enhanced-resolve/issues/399
 						if (!result) {
+							// Exception: the target existed but `restrictions` filtered it
+							// out — return no result so the next `modules` entry is tried.
+							if (restrictionsMarker && restrictionsMarker.blocked) {
+								return callback(null, null);
+							}
 							return callback(
 								new Error(
 									`Package path ${remainingRequest} is exported from package ${request.descriptionFileRoot}, but no valid target file was found (see exports field in ${request.descriptionFilePath})`,

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -403,6 +403,7 @@ const HASH_ESCAPE_RE = /#/g;
  * @property {string=} __innerRequest inner request for internal usage
  * @property {string=} __innerRequest_request inner request for internal usage
  * @property {string=} __innerRequest_relativePath inner relative path for internal usage
+ * @property {{ blocked: boolean }=} __restrictionsMarker internal: shared marker `RestrictionsPlugin` flips when it filters out an existing target, letting `ExportsFieldPlugin` fall back instead of erroring
  */
 
 /** @typedef {BaseResolveRequest & Partial<ParsedIdentifier>} ResolveRequest */

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -612,6 +612,7 @@ module.exports.createResolver = function createResolver(options) {
 				conditionNames,
 				exportsField,
 				exportsFieldTarget,
+				restrictions.size > 0,
 			),
 		);
 	}

--- a/lib/RestrictionsPlugin.js
+++ b/lib/RestrictionsPlugin.js
@@ -51,6 +51,11 @@ module.exports = class RestrictionsPlugin {
 										`${path} is not inside of the restriction ${rule}`,
 									);
 								}
+								// Target existed (FileExistsPlugin already passed) but is
+								// outside the jail; signal ExportsFieldPlugin to fall back.
+								if (request.__restrictionsMarker) {
+									request.__restrictionsMarker.blocked = true;
+								}
 								return callback(null, null);
 							}
 						} else if (!rule.test(path)) {
@@ -58,6 +63,9 @@ module.exports = class RestrictionsPlugin {
 								resolveContext.log(
 									`${path} doesn't match the restriction ${rule}`,
 								);
+							}
+							if (request.__restrictionsMarker) {
+								request.__restrictionsMarker.blocked = true;
 							}
 							return callback(null, null);
 						}

--- a/test/fixtures/restrictions/build/node_modules/exports-pck/lib/index.js
+++ b/test/fixtures/restrictions/build/node_modules/exports-pck/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = "build";

--- a/test/fixtures/restrictions/build/node_modules/exports-pck/package.json
+++ b/test/fixtures/restrictions/build/node_modules/exports-pck/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "exports-pck",
+  "exports": {
+    ".": "./lib/index.js"
+  }
+}

--- a/test/fixtures/restrictions/node_modules/exports-pck/lib/index.js
+++ b/test/fixtures/restrictions/node_modules/exports-pck/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = "node_modules";

--- a/test/fixtures/restrictions/node_modules/exports-pck/package.json
+++ b/test/fixtures/restrictions/node_modules/exports-pck/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "exports-pck",
+  "exports": {
+    ".": "./lib/index.js"
+  }
+}

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -115,14 +115,22 @@ describe("restrictions", () => {
 			restrictions: [buildModules],
 		});
 
-		resolver.resolve({}, fixture, "exports-pck", {}, (err, result) => {
-			if (err) return done(err);
-			if (!result) return done(new Error("No result"));
-			expect(result).toEqual(
-				path.resolve(buildModules, "exports-pck/lib/index.js"),
-			);
-			done();
-		});
+		resolver.resolve(
+			{},
+			fixture,
+			"exports-pck",
+			{},
+			(err, result, resolveRequest) => {
+				if (err) return done(err);
+				if (!result) return done(new Error("No result"));
+				expect(result).toEqual(
+					path.resolve(buildModules, "exports-pck/lib/index.js"),
+				);
+				// the internal carrier must not leak onto the result
+				expect(resolveRequest).not.toHaveProperty("__restrictionsMarker");
+				done();
+			},
+		);
 	});
 
 	it("should still throw when an exports target has no in-restriction fallback", (done) => {

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -133,6 +133,24 @@ describe("restrictions", () => {
 		);
 	});
 
+	it("should fall back when an exports target fails a RegExp restriction", (done) => {
+		const buildModules = path.resolve(fixture, "build/node_modules");
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: nodeFileSystem,
+			modules: ["node_modules", buildModules],
+			restrictions: [/[\\/]build[\\/]node_modules[\\/]/],
+		});
+
+		resolver.resolve({}, fixture, "exports-pck", {}, (err, result) => {
+			if (err) return done(err);
+			if (!result) return done(new Error("No result"));
+			expect(result).toEqual(
+				path.resolve(buildModules, "exports-pck/lib/index.js"),
+			);
+			done();
+		});
+	});
+
 	it("should not leak the internal marker when restrictions are not configured", (done) => {
 		const resolver = ResolverFactory.createResolver({
 			fileSystem: nodeFileSystem,

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -133,6 +133,28 @@ describe("restrictions", () => {
 		);
 	});
 
+	it("should not leak the internal marker when restrictions are not configured", (done) => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: nodeFileSystem,
+			modules: ["node_modules"],
+		});
+
+		resolver.resolve(
+			{},
+			fixture,
+			"exports-pck",
+			{},
+			(err, result, resolveRequest) => {
+				if (err) return done(err);
+				expect(result).toEqual(
+					path.resolve(fixture, "node_modules/exports-pck/lib/index.js"),
+				);
+				expect(resolveRequest).not.toHaveProperty("__restrictionsMarker");
+				done();
+			},
+		);
+	});
+
 	it("should still throw when an exports target has no in-restriction fallback", (done) => {
 		const resolver = ResolverFactory.createResolver({
 			fileSystem: nodeFileSystem,

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -107,6 +107,38 @@ describe("restrictions", () => {
 		);
 	});
 
+	it("should fall back to the next modules entry when an exports target is outside the restriction", (done) => {
+		const buildModules = path.resolve(fixture, "build/node_modules");
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: nodeFileSystem,
+			modules: ["node_modules", buildModules],
+			restrictions: [buildModules],
+		});
+
+		resolver.resolve({}, fixture, "exports-pck", {}, (err, result) => {
+			if (err) return done(err);
+			if (!result) return done(new Error("No result"));
+			expect(result).toEqual(
+				path.resolve(buildModules, "exports-pck/lib/index.js"),
+			);
+			done();
+		});
+	});
+
+	it("should still throw when an exports target has no in-restriction fallback", (done) => {
+		const resolver = ResolverFactory.createResolver({
+			fileSystem: nodeFileSystem,
+			modules: ["node_modules"],
+			restrictions: [path.resolve(fixture, "build/node_modules")],
+		});
+
+		resolver.resolve({}, fixture, "exports-pck", {}, (err, result) => {
+			if (!err) return done(new Error(`expect error, got ${result}`));
+			expect(err).toBeInstanceOf(Error);
+			done();
+		});
+	});
+
 	it("should throw an error when the path is outside a string restriction", (done) => {
 		const resolver = ResolverFactory.createResolver({
 			fileSystem: nodeFileSystem,

--- a/types.d.ts
+++ b/types.d.ts
@@ -85,6 +85,11 @@ declare interface BaseResolveRequest {
 	 * inner relative path for internal usage
 	 */
 	__innerRequest_relativePath?: string;
+
+	/**
+	 * internal: shared marker `RestrictionsPlugin` flips when it filters out an existing target, letting `ExportsFieldPlugin` fall back instead of erroring
+	 */
+	__restrictionsMarker?: { blocked: boolean };
 }
 declare interface BasenameCacheEntry {
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`restrictions` already drives fallback across multiple `modules` entries for plain packages, but a package with an `exports` field threw a hard `"… no valid target file was found"` error instead of falling back when its matched target was filtered out by `restrictions`. The resolver couldn't tell "target filtered by the jail" apart from "target missing on disk" (both surface as a null result), so the Node.js ESM hard-error fired for both. This makes restriction-driven fallback consistent for `exports` packages while preserving the hard error for genuinely missing targets. Refs webpack/webpack#21080.

`RestrictionsPlugin` runs after `FileExistsPlugin`, so a restriction rejection always concerns a file that exists; it flips a shared marker on the request, and `ExportsFieldPlugin` uses that marker to return no result (→ next `modules` entry) instead of erroring. The marker is only attached when `restrictions` are configured, so resolves without restrictions are unaffected, and it is stripped before reaching the result.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/restrictions.test.js` adds a fallback case and a "no in-restriction fallback still throws" case, backed by a new `exports-pck` fixture present in both `node_modules` and `build/node_modules`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Yes — Claude Code was used to investigate the linked discussion, design and implement the fix, and write the tests; all changes were reviewed before submitting.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ceezE9qgsnfVGiLd3sTRS)_