### PR TITLE
feat: accept file: URLs in roots and modules resolve options

### DIFF
--- a/.changeset/file-url-path-options.md
+++ b/.changeset/file-url-path-options.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": minor
+---
+
+Allow the path-like resolve options `roots`, `modules`, `alias`/`fallback` targets, `restrictions`, and `tsconfig` (the config file, `configFile`, `baseUrl`, and `references`) to accept file `URL` instances (such as `new URL("./dir/", import.meta.url)`), converting them to filesystem paths. Plain strings are still treated as literal paths, matching Node's `fs`.

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -37,7 +37,7 @@ const TryNextPlugin = require("./TryNextPlugin");
 const TsconfigPathsPlugin = require("./TsconfigPathsPlugin");
 const UnsafeCachePlugin = require("./UnsafeCachePlugin");
 const UseFilePlugin = require("./UseFilePlugin");
-const { PathType, getType } = require("./util/path");
+const { PathType, getType, toPath } = require("./util/path");
 
 /** @typedef {import("./AliasPlugin").AliasOption} AliasOptionEntry */
 /** @typedef {import("./ExtensionAliasPlugin").ExtensionAliasOption} ExtensionAliasOption */
@@ -51,6 +51,9 @@ const { PathType, getType } = require("./util/path");
 
 /** @typedef {string | string[] | false} AliasOptionNewRequest */
 /** @typedef {{ [k: string]: AliasOptionNewRequest }} AliasOptions */
+/** @typedef {string | URL | (string | URL)[] | false} UserAliasOptionNewRequest */
+/** @typedef {{ [k: string]: UserAliasOptionNewRequest }} UserAliasOptions */
+/** @typedef {{ alias: UserAliasOptionNewRequest, name: string, onlyModule?: boolean }} UserAliasOptionEntry */
 /** @typedef {{ [k: string]: string | string[] }} ExtensionAliasOptions */
 /** @typedef {false | 0 | "" | null | undefined} Falsy */
 /** @typedef {{ apply: (resolver: Resolver) => void } | ((this: Resolver, resolver: Resolver) => void) | Falsy} Plugin */
@@ -63,9 +66,16 @@ const { PathType, getType } = require("./util/path");
  */
 
 /**
+ * @typedef {object} UserTsconfigOptions
+ * @property {(string | URL)=} configFile A path, or `file:` `URL` instance, pointing at the tsconfig file
+ * @property {((string | URL)[] | "auto")=} references References to other tsconfig files. 'auto' inherits from TypeScript config, or an array of relative/absolute paths or `file:` `URL` instances
+ * @property {(string | URL)=} baseUrl Override baseUrl from tsconfig.json with a path or `file:` `URL` instance
+ */
+
+/**
  * @typedef {object} UserResolveOptions
- * @property {(AliasOptions | AliasOptionEntry[])=} alias A list of module alias configurations or an object which maps key to value
- * @property {(AliasOptions | AliasOptionEntry[])=} fallback A list of module alias configurations or an object which maps key to value, applied only after modules option
+ * @property {(UserAliasOptions | UserAliasOptionEntry[])=} alias A list of module alias configurations or an object which maps key to value
+ * @property {(UserAliasOptions | UserAliasOptionEntry[])=} fallback A list of module alias configurations or an object which maps key to value, applied only after modules option
  * @property {ExtensionAliasOptions=} extensionAlias An object which maps extension to extension aliases
  * @property {boolean=} extensionAliasForExports Also apply `extensionAlias` to paths resolved through the package.json `exports` field. Off by default (Node.js-aligned); when enabled, matches TypeScript's behavior for packages that ship TS sources alongside compiled JS.
  * @property {(string | string[])[]=} aliasFields A list of alias fields in description files
@@ -81,19 +91,19 @@ const { PathType, getType } = require("./util/path");
  * @property {(Cache | boolean)=} unsafeCache Use this cache object to unsafely cache the successful requests
  * @property {boolean=} symlinks Resolve symlinks to their symlinked location
  * @property {Resolver=} resolver A prepared Resolver to which the plugins are attached
- * @property {string[] | string=} modules A list of directories to resolve modules from, can be absolute path or folder name
+ * @property {(string | URL)[] | string | URL=} modules A list of directories to resolve modules from, can be absolute path, folder name, or a `file:` `URL` instance
  * @property {(string | string[] | { name: string | string[], forceRelative: boolean })[]=} mainFields A list of main fields in description files
  * @property {string[]=} mainFiles A list of main files in directories
  * @property {Plugin[]=} plugins A list of additional resolve plugins which should be applied
  * @property {PnpApi | null=} pnpApi A PnP API that should be used - null is "never", undefined is "auto"
- * @property {string[]=} roots A list of root paths
+ * @property {(string | URL)[]=} roots A list of root paths, each an absolute path or a `file:` `URL` instance
  * @property {boolean=} fullySpecified The request is already fully specified and no extensions or directories are resolved for it
  * @property {boolean=} resolveToContext Resolve to a context instead of a file
- * @property {(string | RegExp)[]=} restrictions A list of resolve restrictions
+ * @property {(string | URL | RegExp)[]=} restrictions A list of resolve restrictions, each an absolute path, a `file:` `URL` instance, or a RegExp
  * @property {boolean=} useSyncFileSystemCalls Use only the sync constraints of the file system calls
  * @property {boolean=} preferRelative Prefer to resolve module requests as relative requests before falling back to modules
  * @property {boolean=} preferAbsolute Prefer to resolve server-relative urls as absolute paths before falling back to resolve in roots
- * @property {string | boolean | TsconfigOptions=} tsconfig TypeScript config file path or config object with configFile and references
+ * @property {string | URL | boolean | UserTsconfigOptions=} tsconfig TypeScript config file path (or `file:` `URL` instance) or config object with configFile and references
  */
 
 /**
@@ -165,23 +175,69 @@ function processPnpApiOption(option) {
 }
 
 /**
- * @param {AliasOptions | AliasOptionEntry[] | undefined} alias alias
+ * @param {UserAliasOptionNewRequest} alias alias target(s)
+ * @returns {AliasOptionNewRequest} target(s) with file `URL` instances converted to paths
+ */
+function toPathAlias(alias) {
+	if (alias === false) return false;
+	return Array.isArray(alias) ? alias.map(toPath) : toPath(alias);
+}
+
+/**
+ * @param {UserAliasOptions | UserAliasOptionEntry[] | undefined} alias alias
  * @returns {AliasOptionEntry[]} normalized aliases
  */
 function normalizeAlias(alias) {
-	return typeof alias === "object" && !Array.isArray(alias) && alias !== null
-		? Object.keys(alias).map((key) => {
-				/** @type {AliasOptionEntry} */
-				const obj = { name: key, onlyModule: false, alias: alias[key] };
+	if (typeof alias === "object" && !Array.isArray(alias) && alias !== null) {
+		return Object.keys(alias).map((key) => {
+			/** @type {AliasOptionEntry} */
+			const obj = {
+				name: key,
+				onlyModule: false,
+				alias: toPathAlias(alias[key]),
+			};
 
-				if (/\$$/.test(key)) {
-					obj.onlyModule = true;
-					obj.name = key.slice(0, -1);
-				}
+			if (/\$$/.test(key)) {
+				obj.onlyModule = true;
+				obj.name = key.slice(0, -1);
+			}
 
-				return obj;
-			})
-		: /** @type {AliasOptionEntry[]} */ (alias) || [];
+			return obj;
+		});
+	}
+
+	return alias
+		? alias.map((item) => ({ ...item, alias: toPathAlias(item.alias) }))
+		: [];
+}
+
+/**
+ * @param {string | URL | boolean | UserTsconfigOptions | undefined} tsconfig tsconfig option
+ * @returns {string | boolean | TsconfigOptions} normalized tsconfig with file `URL` instances converted to paths
+ */
+function normalizeTsconfig(tsconfig) {
+	if (tsconfig === undefined) return false;
+	if (typeof tsconfig === "boolean") return tsconfig;
+	if (typeof tsconfig === "string" || tsconfig instanceof URL) {
+		return toPath(tsconfig);
+	}
+
+	/** @type {TsconfigOptions} */
+	const result = {};
+
+	if (tsconfig.configFile !== undefined) {
+		result.configFile = toPath(tsconfig.configFile);
+	}
+	if (tsconfig.baseUrl !== undefined) {
+		result.baseUrl = toPath(tsconfig.baseUrl);
+	}
+	if (tsconfig.references !== undefined) {
+		result.references = Array.isArray(tsconfig.references)
+			? tsconfig.references.map(toPath)
+			: tsconfig.references;
+	}
+
+	return result;
 }
 
 /**
@@ -288,9 +344,9 @@ function createOptions(options) {
 		resolver: options.resolver,
 		modules: mergeFilteredToArray(
 			Array.isArray(options.modules)
-				? options.modules
+				? options.modules.map(toPath)
 				: options.modules
-					? [options.modules]
+					? [toPath(options.modules)]
 					: ["node_modules"],
 			(item) => {
 				const type = getType(item);
@@ -301,14 +357,16 @@ function createOptions(options) {
 		mainFiles: new Set(options.mainFiles || ["index"]),
 		plugins: options.plugins || [],
 		pnpApi: processPnpApiOption(options.pnpApi),
-		roots: new Set(options.roots || undefined),
+		roots: new Set(options.roots ? options.roots.map(toPath) : undefined),
 		fullySpecified: options.fullySpecified || false,
 		resolveToContext: options.resolveToContext || false,
 		preferRelative: options.preferRelative || false,
 		preferAbsolute: options.preferAbsolute || false,
-		restrictions: new Set(options.restrictions),
-		tsconfig:
-			typeof options.tsconfig === "undefined" ? false : options.tsconfig,
+		restrictions: new Set(
+			options.restrictions &&
+				options.restrictions.map((r) => (r instanceof RegExp ? r : toPath(r))),
+		),
+		tsconfig: normalizeTsconfig(options.tsconfig),
 	};
 }
 

--- a/lib/util/path.js
+++ b/lib/util/path.js
@@ -6,6 +6,9 @@
 "use strict";
 
 const path = require("path");
+const memoize = require("./memoize");
+
+const getUrl = memoize(() => require("url"));
 
 const CHAR_HASH = "#".charCodeAt(0);
 const CHAR_SLASH = "/".charCodeAt(0);
@@ -330,6 +333,18 @@ const isSubPath = (parentPath, childPath) => {
 	return nextChar === CHAR_SLASH || nextChar === CHAR_BACKSLASH;
 };
 
+/**
+ * Convert a `file:` `URL` instance to a filesystem path; any other input
+ * (including plain strings) is returned unchanged. Mirrors Node's `fs`, which
+ * treats strings as literal paths and only `URL` objects as URLs (see
+ * nodejs/node#17658) — so a directory literally named `file:` is never
+ * mistaken for a URL.
+ * @param {string | URL} maybeURL a path string or a `file:` `URL` instance
+ * @returns {string} a filesystem path
+ */
+const toPath = (maybeURL) =>
+	maybeURL instanceof URL ? getUrl().fileURLToPath(maybeURL) : maybeURL;
+
 module.exports.PathType = PathType;
 module.exports.createCachedBasename = createCachedBasename;
 module.exports.createCachedDirname = createCachedDirname;
@@ -342,3 +357,4 @@ module.exports.isRelativeRequest = isRelativeRequest;
 module.exports.isSubPath = isSubPath;
 module.exports.join = join;
 module.exports.normalize = normalize;
+module.exports.toPath = toPath;

--- a/test/file-url-options.test.js
+++ b/test/file-url-options.test.js
@@ -1,0 +1,209 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { pathToFileURL } = require("url");
+const CachedInputFileSystem = require("../lib/CachedInputFileSystem");
+const ResolverFactory = require("../lib/ResolverFactory");
+const { toPath } = require("../lib/util/path");
+
+describe("file: URL path options", () => {
+	const fixtures = path.resolve(__dirname, "fixtures");
+	const modulesDir = path.resolve(fixtures, "node_modules");
+	const fileSystem = new CachedInputFileSystem(fs, 4000);
+
+	const makeResolver = (options) =>
+		ResolverFactory.createResolver({
+			extensions: [".js"],
+			fileSystem,
+			...options,
+		});
+
+	describe("roots", () => {
+		it("should accept a URL instance", (done) => {
+			const resolver = makeResolver({ roots: [pathToFileURL(fixtures)] });
+			resolver.resolve({}, fixtures, "/b.js", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
+	});
+
+	describe("modules", () => {
+		it("should accept a URL instance", (done) => {
+			const resolver = makeResolver({ modules: [pathToFileURL(modulesDir)] });
+			resolver.resolve({}, fixtures, "m1/a", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(modulesDir, "m1/a.js"));
+				done();
+			});
+		});
+
+		it("should accept a single URL instance", (done) => {
+			const resolver = makeResolver({ modules: pathToFileURL(modulesDir) });
+			resolver.resolve({}, fixtures, "m1/a", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(modulesDir, "m1/a.js"));
+				done();
+			});
+		});
+
+		it("should keep folder-name entries untouched", (done) => {
+			const resolver = makeResolver({ modules: ["node_modules"] });
+			resolver.resolve({}, fixtures, "m1/a", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(modulesDir, "m1/a.js"));
+				done();
+			});
+		});
+	});
+
+	describe("alias", () => {
+		it("should accept a URL instance as the target", (done) => {
+			const resolver = makeResolver({
+				alias: { "@": pathToFileURL(fixtures) },
+			});
+			resolver.resolve({}, fixtures, "@/b.js", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
+
+		it("should accept a URL instance in an array target", (done) => {
+			const resolver = makeResolver({
+				alias: { "@": [pathToFileURL(modulesDir), pathToFileURL(fixtures)] },
+			});
+			resolver.resolve({}, fixtures, "@/b.js", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
+
+		it("should accept array-form entries with a URL target", (done) => {
+			const resolver = makeResolver({
+				alias: [{ name: "@", alias: pathToFileURL(fixtures) }],
+			});
+			resolver.resolve({}, fixtures, "@/b.js", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
+
+		// A `file:` string target is not converted here (strings stay literal),
+		// but the rewritten request still resolves because the request side
+		// (`parseIdentifier`) converts `file:` request strings.
+		it("should still resolve a file: string target via request parsing", (done) => {
+			const resolver = makeResolver({
+				alias: { "@": String(pathToFileURL(fixtures)) },
+			});
+			resolver.resolve({}, fixtures, "@/b.js", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
+	});
+
+	describe("restrictions", () => {
+		it("should accept a URL instance", (done) => {
+			const resolver = makeResolver({
+				restrictions: [pathToFileURL(fixtures)],
+			});
+			resolver.resolve({}, fixtures, "./b.js", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
+
+		it("should keep RegExp entries untouched", (done) => {
+			const resolver = makeResolver({ restrictions: [/\.js$/] });
+			resolver.resolve({}, fixtures, "./b.js", {}, (err, result) => {
+				if (err) return done(err);
+				expect(result).toEqual(path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
+
+		// A `file:` string restriction stays literal, so no real path is ever
+		// "inside" it and resolution is blocked — use a URL instance or a path.
+		it("should treat a file: string restriction as a literal path", (done) => {
+			const resolver = makeResolver({
+				restrictions: [String(pathToFileURL(fixtures))],
+			});
+			resolver.resolve({}, fixtures, "./b.js", {}, (err) => {
+				expect(err).toBeInstanceOf(Error);
+				done();
+			});
+		});
+	});
+
+	describe("tsconfig", () => {
+		const tsconfigDir = path.resolve(fixtures, "tsconfig-paths", "base");
+		const tsconfigFile = path.join(tsconfigDir, "tsconfig.json");
+
+		it("should accept a URL instance as the config file", (done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: pathToFileURL(tsconfigFile),
+			});
+			resolver.resolve(
+				{},
+				tsconfigDir,
+				"@components/button",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					expect(result).toEqual(
+						path.join(tsconfigDir, "src", "components", "button.ts"),
+					);
+					done();
+				},
+			);
+		});
+
+		it("should accept a URL instance as options.configFile", (done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: { configFile: pathToFileURL(tsconfigFile) },
+			});
+			resolver.resolve(
+				{},
+				tsconfigDir,
+				"@components/button",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					expect(result).toEqual(
+						path.join(tsconfigDir, "src", "components", "button.ts"),
+					);
+					done();
+				},
+			);
+		});
+	});
+
+	describe("toPath", () => {
+		it("should convert a file: URL instance to a path", () => {
+			expect(toPath(pathToFileURL(modulesDir))).toBe(modulesDir);
+		});
+
+		// A string is always a literal path (matches Node fs, nodejs/node#17658),
+		// so a directory literally named `file:` is never mistaken for a URL.
+		it("should leave strings untouched, including `file:`-prefixed ones", () => {
+			expect(toPath("file:foo")).toBe("file:foo");
+			expect(toPath("file:///abs")).toBe("file:///abs");
+			expect(toPath(modulesDir)).toBe(modulesDir);
+		});
+	});
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -20,10 +20,6 @@ declare interface AliasOption {
 	name: string;
 	onlyModule?: boolean;
 }
-type AliasOptionNewRequest = string | false | string[];
-declare interface AliasOptions {
-	[index: string]: AliasOptionNewRequest;
-}
 type BaseFileSystem = FileSystem & SyncFileSystem;
 declare interface BaseResolveRequest {
 	/**
@@ -146,10 +142,10 @@ declare class CachedInputFileSystem {
 		what?:
 			| string
 			| number
-			| Buffer
 			| URL_url
-			| (string | number | Buffer | URL_url)[]
-			| Set<string | number | Buffer | URL_url>,
+			| Buffer
+			| (string | number | URL_url | Buffer)[]
+			| Set<string | number | URL_url | Buffer>,
 		options?: { exact?: boolean },
 	): void;
 }
@@ -839,8 +835,8 @@ declare interface PathCacheFunctions {
 	 */
 	basename: BasenameCacheEntry;
 }
-type PathLike = string | Buffer | URL_url;
-type PathOrFileDescriptor = string | number | Buffer | URL_url;
+type PathLike = string | URL_url | Buffer;
+type PathOrFileDescriptor = string | number | URL_url | Buffer;
 type Plugin =
 	| undefined
 	| null
@@ -1437,12 +1433,12 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	/**
 	 * A list of module alias configurations or an object which maps key to value
 	 */
-	alias?: AliasOptions | AliasOption[];
+	alias?: UserAliasOptions | UserAliasOptionEntry[];
 
 	/**
 	 * A list of module alias configurations or an object which maps key to value, applied only after modules option
 	 */
-	fallback?: AliasOptions | AliasOption[];
+	fallback?: UserAliasOptions | UserAliasOptionEntry[];
 
 	/**
 	 * An object which maps extension to extension aliases
@@ -1520,9 +1516,9 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	resolver?: Resolver;
 
 	/**
-	 * A list of directories to resolve modules from, can be absolute path or folder name
+	 * A list of directories to resolve modules from, can be absolute path, folder name, or a `file:` `URL` instance
 	 */
-	modules?: string | string[];
+	modules?: string | URL_url | (string | URL_url)[];
 
 	/**
 	 * A list of main fields in description files
@@ -1549,9 +1545,9 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	pnpApi?: null | PnpApi;
 
 	/**
-	 * A list of root paths
+	 * A list of root paths, each an absolute path or a `file:` `URL` instance
 	 */
-	roots?: string[];
+	roots?: (string | URL_url)[];
 
 	/**
 	 * The request is already fully specified and no extensions or directories are resolved for it
@@ -1564,9 +1560,9 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	resolveToContext?: boolean;
 
 	/**
-	 * A list of resolve restrictions
+	 * A list of resolve restrictions, each an absolute path, a `file:` `URL` instance, or a RegExp
 	 */
-	restrictions?: (string | RegExp)[];
+	restrictions?: (string | RegExp | URL_url)[];
 
 	/**
 	 * Use only the sync constraints of the file system calls
@@ -1584,9 +1580,9 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	preferAbsolute?: boolean;
 
 	/**
-	 * TypeScript config file path or config object with configFile and references
+	 * TypeScript config file path (or `file:` `URL` instance) or config object with configFile and references
 	 */
-	tsconfig?: string | boolean | TsconfigOptions;
+	tsconfig?: string | boolean | URL_url | UserTsconfigOptions;
 }
 type ResolveRequest = BaseResolveRequest & Partial<ParsedIdentifier>;
 declare abstract class Resolver {
@@ -1941,6 +1937,35 @@ declare interface TsconfigReference {
 	path: string;
 }
 declare interface URL_url extends URL_Import {}
+declare interface UserAliasOptionEntry {
+	alias: UserAliasOptionNewRequest;
+	name: string;
+	onlyModule?: boolean;
+}
+type UserAliasOptionNewRequest =
+	| string
+	| false
+	| URL_url
+	| (string | URL_url)[];
+declare interface UserAliasOptions {
+	[index: string]: UserAliasOptionNewRequest;
+}
+declare interface UserTsconfigOptions {
+	/**
+	 * A path, or `file:` `URL` instance, pointing at the tsconfig file
+	 */
+	configFile?: string | URL_url;
+
+	/**
+	 * References to other tsconfig files. 'auto' inherits from TypeScript config, or an array of relative/absolute paths or `file:` `URL` instances
+	 */
+	references?: (string | URL_url)[] | "auto";
+
+	/**
+	 * Override baseUrl from tsconfig.json with a path or `file:` `URL` instance
+	 */
+	baseUrl?: string | URL_url;
+}
 declare interface WriteOnlySet<T> {
 	add: (item: T) => void;
 }


### PR DESCRIPTION
Convert file: URL strings and URL instances to filesystem paths when normalizing the roots and modules options, so configs can pass entries produced by new URL("...", import.meta.url).

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->