### PR TITLE
docs: document resolve() public API and rename params to parent/specifier

### DIFF
--- a/.changeset/resolve-parent-specifier-args.md
+++ b/.changeset/resolve-parent-specifier-args.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Rename the positional `resolve`/`resolveSync`/`resolvePromise` parameters to `parent`/`specifier` (from `path`/`request`) for ESM-aligned naming and document them in the README. Purely cosmetic — arguments are positional, so there is no behavior or API change.

--- a/README.md
+++ b/README.md
@@ -60,28 +60,30 @@ myResolve("/some/path/to/folder", "ts-module", (err, result) => {
 
 All of the following are exposed from `require("enhanced-resolve")`.
 
-#### `resolve(context?, path, request, resolveContext?, callback)`
+#### `resolve(context?, parent, specifier, resolveContext?, callback)`
 
 Async Node-style resolver using the built-in defaults (`conditionNames: ["node"]`, `extensions: [".js", ".json", ".node"]`). Both `context` and `resolveContext` are optional, so the function accepts four shapes:
 
 ```js
-resolve(context, path, request, resolveContext, callback);
-resolve(context, path, request, callback);
-resolve(path, request, resolveContext, callback);
-resolve(path, request, callback); // most common
+resolve(context, parent, specifier, resolveContext, callback);
+resolve(context, parent, specifier, callback);
+resolve(parent, specifier, resolveContext, callback);
+resolve(parent, specifier, callback); // most common
 ```
+
+The `parent` / `specifier` naming mirrors the ECMAScript resolution terms (as in `import.meta.resolve(specifier, parent)`): `parent` is the location you resolve **from**, and `specifier` is the string being resolved.
 
 ##### Arguments — what each one is and when to pass it
 
 | Argument         | Required | What it is                                                                                                                                                                                                                                           | When to pass it                                                                                                               |
 | ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `context`        | no       | Extra info about _who_ is requesting, e.g. `{ environments: ["node+es3+es5+process+native"] }`. Plugins can read arbitrary keys off it. When omitted, a built-in Node context is used.                                                               | Pass it only when a plugin you use reads from it. Most callers omit it.                                                       |
-| `path`           | yes      | The absolute directory to resolve **from** (the "lookup start path").                                                                                                                                                                                | Always.                                                                                                                       |
-| `request`        | yes      | The string to resolve — a relative request (`./utils`), a bare module (`lodash/merge`), an alias, etc.                                                                                                                                               | Always.                                                                                                                       |
+| `parent`         | yes      | The absolute directory to resolve **from** — the location the `specifier` is relative to (the ECMAScript "parent", historically called the "lookup start path").                                                                                     | Always.                                                                                                                       |
+| `specifier`      | yes      | The string to resolve — a relative specifier (`./utils`), a bare module (`lodash/merge`), an alias, etc. (the ECMAScript "specifier", historically called the "request").                                                                            | Always.                                                                                                                       |
 | `resolveContext` | no       | A collector object the resolver writes into / reads from: `fileDependencies`, `contextDependencies`, `missingDependencies` (`Set`s it fills in), `log` (a function it calls for trace output).                                                       | Pass it when you need to know which files/dirs were touched (e.g. to set up a watcher) or want a log of the resolution steps. |
 | `callback`       | yes      | `(err, result, resolveRequest) => void`. `result` is the resolved absolute path (or `false` if the request resolves to an ignored module). `resolveRequest` is the full request object with `path`, `query`, `fragment`, `descriptionFilePath`, etc. | Always.                                                                                                                       |
 
-##### Minimal form — just `path`, `request`, `callback`
+##### Minimal form — just `parent`, `specifier`, `callback`
 
 ```js
 const resolve = require("enhanced-resolve");
@@ -148,7 +150,7 @@ resolve(
 );
 ```
 
-#### `resolve.sync(context?, path, request, resolveContext?) => string | false`
+#### `resolve.sync(context?, parent, specifier, resolveContext?) => string | false`
 
 Synchronous variant. Throws on failure, returns `false` when the resolve yields no result.
 
@@ -156,7 +158,7 @@ Synchronous variant. Throws on failure, returns `false` when the resolve yields 
 const file = resolve.sync(__dirname, "./utils");
 ```
 
-#### `resolve.promise(context?, path, request, resolveContext?) => Promise<string | false>`
+#### `resolve.promise(context?, parent, specifier, resolveContext?) => Promise<string | false>`
 
 Promise variant of `resolve`.
 
@@ -196,7 +198,7 @@ const file = await resolveTsPromise(__dirname, "./component");
 
 #### `ResolverFactory.createResolver(options) => Resolver`
 
-Lower-level factory. Returns a `Resolver` whose `resolve`, `resolveSync`, and `resolvePromise` methods accept `(context, path, request, resolveContext, [callback])`. Use this when you need a reusable resolver instance or access to its `hooks` (see the [Plugins](#plugins) section). `fileSystem` is required here — the high-level `resolve.create` defaults it for you.
+Lower-level factory. Returns a `Resolver` whose `resolve`, `resolveSync`, and `resolvePromise` methods accept `(context, parent, specifier, resolveContext, [callback])`. Use this when you need a reusable resolver instance or access to its `hooks` (see the [Plugins](#plugins) section). `fileSystem` is required here — the high-level `resolve.create` defaults it for you.
 
 ```js
 const fs = require("fs");
@@ -279,15 +281,15 @@ const myResolver = ResolverFactory.createResolver({
 
 // resolve a file with the new resolver
 const context = {};
-const lookupStartPath = "/Users/webpack/some/root/dir";
-const request = "./path/to-look-up.js";
+const parent = "/Users/webpack/some/root/dir"; // directory to resolve from
+const specifier = "./path/to-look-up.js"; // string to resolve
 const resolveContext = {};
 
 // callback
 myResolver.resolve(
 	context,
-	lookupStartPath,
-	request,
+	parent,
+	specifier,
 	resolveContext,
 	(err /* Error */, filepath /* string */) => {
 		// Do something with the path
@@ -298,8 +300,8 @@ myResolver.resolve(
 try {
 	const filepath = await myResolver.resolvePromise(
 		context,
-		lookupStartPath,
-		request,
+		parent,
+		specifier,
 		resolveContext,
 	);
 	// Do something with the path
@@ -308,7 +310,7 @@ try {
 }
 
 // sync (requires a sync fileSystem, e.g. the default Node.js one)
-const filepath = myResolver.resolveSync(context, lookupStartPath, request);
+const filepath = myResolver.resolveSync(context, parent, specifier);
 ```
 
 #### Resolver Options

--- a/README.md
+++ b/README.md
@@ -62,14 +62,90 @@ All of the following are exposed from `require("enhanced-resolve")`.
 
 #### `resolve(context?, path, request, resolveContext?, callback)`
 
-Async Node-style resolver using the built-in defaults (`conditionNames: ["node"]`, `extensions: [".js", ".json", ".node"]`). `context` is optional; when omitted, a built-in Node context is used.
+Async Node-style resolver using the built-in defaults (`conditionNames: ["node"]`, `extensions: [".js", ".json", ".node"]`). Both `context` and `resolveContext` are optional, so the function accepts four shapes:
+
+```js
+resolve(context, path, request, resolveContext, callback);
+resolve(context, path, request, callback);
+resolve(path, request, resolveContext, callback);
+resolve(path, request, callback); // most common
+```
+
+##### Arguments — what each one is and when to pass it
+
+| Argument         | Required | What it is                                                                                                                                                                                                                                           | When to pass it                                                                                                               |
+| ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `context`        | no       | Extra info about _who_ is requesting, e.g. `{ environments: ["node+es3+es5+process+native"] }`. Plugins can read arbitrary keys off it. When omitted, a built-in Node context is used.                                                               | Pass it only when a plugin you use reads from it. Most callers omit it.                                                       |
+| `path`           | yes      | The absolute directory to resolve **from** (the "lookup start path").                                                                                                                                                                                | Always.                                                                                                                       |
+| `request`        | yes      | The string to resolve — a relative request (`./utils`), a bare module (`lodash/merge`), an alias, etc.                                                                                                                                               | Always.                                                                                                                       |
+| `resolveContext` | no       | A collector object the resolver writes into / reads from: `fileDependencies`, `contextDependencies`, `missingDependencies` (`Set`s it fills in), `log` (a function it calls for trace output).                                                       | Pass it when you need to know which files/dirs were touched (e.g. to set up a watcher) or want a log of the resolution steps. |
+| `callback`       | yes      | `(err, result, resolveRequest) => void`. `result` is the resolved absolute path (or `false` if the request resolves to an ignored module). `resolveRequest` is the full request object with `path`, `query`, `fragment`, `descriptionFilePath`, etc. | Always.                                                                                                                       |
+
+##### Minimal form — just `path`, `request`, `callback`
 
 ```js
 const resolve = require("enhanced-resolve");
 
 resolve(__dirname, "./utils", (err, result) => {
-	// result === "/abs/path/to/utils.js"
+	if (err) throw err;
+	result; // === "/abs/path/to/utils.js"
 });
+```
+
+##### Inspecting the full result via the third callback argument
+
+```js
+resolve(__dirname, "./utils?query#frag", (err, result, resolveRequest) => {
+	result; // === "/abs/path/to/utils.js?query#frag" — path with query/fragment appended
+	resolveRequest.path; // === "/abs/path/to/utils.js" (the bare path, no query/fragment)
+	resolveRequest.query; // === "?query"  (empty string if the request has none)
+	resolveRequest.fragment; // === "#frag"   (empty string if the request has none)
+	resolveRequest.descriptionFilePath; // path to the nearest package.json, if any
+});
+```
+
+##### With `resolveContext` — collect dependencies and a log
+
+Pass a `resolveContext` when you need the resolver to report back _what it looked at_. The `Set`s you provide are filled in during resolution, and `log` is called with each step:
+
+```js
+const fileDependencies = new Set();
+const missingDependencies = new Set();
+const contextDependencies = new Set();
+const logs = [];
+
+resolve(
+	__dirname,
+	"./utils",
+	{
+		fileDependencies, // files that were read/checked
+		missingDependencies, // paths that were probed but didn't exist
+		contextDependencies, // directories that were read
+		log: (msg) => logs.push(msg), // trace of each resolution step
+	},
+	(err, result) => {
+		result; // === "/abs/path/to/utils.js"
+		fileDependencies; // Set { ".../utils.js", ".../package.json", ... }
+		missingDependencies; // Set { ".../utils", ".../utils.json", ... } (candidates tried)
+		// `fileDependencies` / `missingDependencies` are exactly what you'd feed
+		// a file watcher so a rebuild re-runs when any of them changes.
+	},
+);
+```
+
+##### With a custom `context`
+
+Pass a `context` when a plugin reads from it. The default resolver only uses `environments`, but custom plugins may key off anything you put here:
+
+```js
+resolve(
+	{ environments: ["node+es3+es5+process+native"] }, // context
+	__dirname,
+	"./utils",
+	(err, result) => {
+		result; // === "/abs/path/to/utils.js"
+	},
+);
 ```
 
 #### `resolve.sync(context?, path, request, resolveContext?) => string | false`

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -693,27 +693,27 @@ class Resolver {
 
 	/**
 	 * @overload
-	 * @param {string | URL} path context path or a `file:` URL instance
-	 * @param {string | URL} request request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL instance
+	 * @param {string | URL} specifier request string or a `file:` URL instance
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {string | false} result
 	 */
 	/**
 	 * @overload
 	 * @param {Context} context context information object
-	 * @param {string | URL} path context path or a `file:` URL instance
-	 * @param {string | URL} request request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL instance
+	 * @param {string | URL} specifier request string or a `file:` URL instance
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {string | false} result
 	 */
 	/**
 	 * @param {Context | string | URL} context context information object, or the context path (string or `file:` URL instance) when no context is provided
-	 * @param {string | URL | ResolveContext=} path context path (string or `file:` URL instance) or resolve context when no context is provided
-	 * @param {string | URL | ResolveContext=} request request string (or `file:` URL instance) or resolve context when no context is provided
+	 * @param {string | URL | ResolveContext=} parent context path (string or `file:` URL instance) or resolve context when no context is provided
+	 * @param {string | URL | ResolveContext=} specifier request string (or `file:` URL instance) or resolve context when no context is provided
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {string | false} result
 	 */
-	resolveSync(context, path, request, resolveContext) {
+	resolveSync(context, parent, specifier, resolveContext) {
 		/** @type {Error | null | undefined} */
 		let err;
 		/** @type {string | false | undefined} */
@@ -724,8 +724,8 @@ class Resolver {
 		// caller supplied a resolveContext.
 		this.resolve(
 			/** @type {Context} */ (context),
-			/** @type {string} */ (path),
-			/** @type {string} */ (request),
+			/** @type {string} */ (parent),
+			/** @type {string} */ (specifier),
 			/** @type {ResolveContext} */ (resolveContext) || {},
 			(_err, r) => {
 				err = _err;
@@ -745,49 +745,49 @@ class Resolver {
 
 	/**
 	 * @overload
-	 * @param {string | URL} path context path or a `file:` URL instance
-	 * @param {string | URL} request request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL instance
+	 * @param {string | URL} specifier request string or a `file:` URL instance
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {Promise<string | false>} result
 	 */
 	/**
 	 * @overload
 	 * @param {Context} context context information object
-	 * @param {string | URL} path context path or a `file:` URL instance
-	 * @param {string | URL} request request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL instance
+	 * @param {string | URL} specifier request string or a `file:` URL instance
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {Promise<string | false>} result
 	 */
 	/**
 	 * @param {Context | string | URL} context context information object, or the context path (string or `file:` URL instance) when no context is provided
-	 * @param {string | URL | ResolveContext=} path context path (string or `file:` URL instance) or resolve context when no context is provided
-	 * @param {string | URL | ResolveContext=} request request string (or `file:` URL instance) or resolve context when no context is provided
+	 * @param {string | URL | ResolveContext=} parent context path (string or `file:` URL instance) or resolve context when no context is provided
+	 * @param {string | URL | ResolveContext=} specifier request string (or `file:` URL instance) or resolve context when no context is provided
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {Promise<string | false>} result
 	 */
-	resolvePromise(context, path, request, resolveContext) {
+	resolvePromise(context, parent, specifier, resolveContext) {
 		// `|| {}` ensures the 5-arg fast path inside `resolve()` is reached
 		// even when the caller doesn't pass a resolveContext.
 		return _withResolvers(
 			this,
 			/** @type {Context} */ (context),
-			/** @type {string} */ (path),
-			/** @type {string} */ (request),
+			/** @type {string} */ (parent),
+			/** @type {string} */ (specifier),
 			/** @type {ResolveContext} */ (resolveContext) || {},
 		);
 	}
 
 	/**
 	 * @overload
-	 * @param {string | URL} path context path or a `file:` URL instance
-	 * @param {string | URL} request request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL instance
+	 * @param {string | URL} specifier request string or a `file:` URL instance
 	 * @param {ResolveCallback} callback callback function
 	 * @returns {void}
 	 */
 	/**
 	 * @overload
-	 * @param {string | URL} path context path or a `file:` URL instance
-	 * @param {string | URL} request request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL instance
+	 * @param {string | URL} specifier request string or a `file:` URL instance
 	 * @param {ResolveContext} resolveContext resolve context
 	 * @param {ResolveCallback} callback callback function
 	 * @returns {void}
@@ -795,29 +795,29 @@ class Resolver {
 	/**
 	 * @overload
 	 * @param {Context} context context information object
-	 * @param {string | URL} path context path or a `file:` URL instance
-	 * @param {string | URL} request request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL instance
+	 * @param {string | URL} specifier request string or a `file:` URL instance
 	 * @param {ResolveCallback} callback callback function
 	 * @returns {void}
 	 */
 	/**
 	 * @overload
 	 * @param {Context} context context information object
-	 * @param {string | URL} path context path or a `file:` URL instance
-	 * @param {string | URL} request request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL instance
+	 * @param {string | URL} specifier request string or a `file:` URL instance
 	 * @param {ResolveContext} resolveContext resolve context
 	 * @param {ResolveCallback} callback callback function
 	 * @returns {void}
 	 */
 	/**
 	 * @param {Context | string | URL} context context information object, or the context path (string or `file:` URL instance) when no context is provided
-	 * @param {string | URL | ResolveContext | ResolveCallback=} path context path (string or `file:` URL instance) or (when no context) resolve context or callback
-	 * @param {string | URL | ResolveContext | ResolveCallback=} request request string (or `file:` URL instance) or (when no context) resolve context or callback
+	 * @param {string | URL | ResolveContext | ResolveCallback=} parent context path (string or `file:` URL instance) or (when no context) resolve context or callback
+	 * @param {string | URL | ResolveContext | ResolveCallback=} specifier request string (or `file:` URL instance) or (when no context) resolve context or callback
 	 * @param {ResolveContext | ResolveCallback=} resolveContext resolve context or callback when no resolve context is provided
 	 * @param {ResolveCallback=} callback callback function
 	 * @returns {void}
 	 */
-	resolve(context, path, request, resolveContext, callback) {
+	resolve(context, parent, specifier, resolveContext, callback) {
 		// Fast path for the common 5-arg call (`resolver.resolve(ctx, from,
 		// req, resolveCtx, cb)`) — every call from `resolveSync` /
 		// `resolvePromise` plus the vast majority of direct API callers.
@@ -836,7 +836,7 @@ class Resolver {
 			// proceed straight to per-arg validation below
 		} else {
 			// Slow path: shift positional args based on what was supplied.
-			// Shift when context is omitted (first positional arg is the path,
+			// Shift when context is omitted (first positional arg is the parent,
 			// either a string or a `file:` URL instance).
 			if (typeof context === "string" || context instanceof URL) {
 				// Keep an already-supplied callback (resolveSync / resolvePromise
@@ -847,9 +847,11 @@ class Resolver {
 					);
 				}
 				resolveContext =
-					/** @type {ResolveContext | ResolveCallback | undefined} */ (request);
-				request = /** @type {string} */ (path);
-				path = context;
+					/** @type {ResolveContext | ResolveCallback | undefined} */ (
+						specifier
+					);
+				specifier = /** @type {string} */ (parent);
+				parent = context;
 				context = {};
 			}
 			// 4-arg form: the resolveContext slot holds the callback.
@@ -866,24 +868,24 @@ class Resolver {
 				context = {};
 			}
 		}
-		// Accept `file:` URL instances for path/request, converting to a
+		// Accept `file:` URL instances for parent/specifier, converting to a
 		// filesystem path (mirrors the URL support in resolve options). The
 		// `instanceof` check sits on the error branch, so the common string
 		// case keeps its single `typeof` check on this hot path.
-		if (typeof path !== "string") {
-			if (path instanceof URL) path = toPath(path);
+		if (typeof parent !== "string") {
+			if (parent instanceof URL) parent = toPath(parent);
 			else return callback(new Error("path argument is not a string"));
 		}
-		if (typeof request !== "string") {
-			if (request instanceof URL) request = toPath(request);
+		if (typeof specifier !== "string") {
+			if (specifier instanceof URL) specifier = toPath(specifier);
 			else return callback(new Error("request argument is not a string"));
 		}
 
 		/** @type {ResolveRequest} */
 		const obj = {
 			context,
-			path,
-			request,
+			path: parent,
+			request: specifier,
 		};
 
 		/** @type {ResolveContextYield | undefined} */
@@ -912,7 +914,7 @@ class Resolver {
 			};
 		}
 
-		const message = `resolve '${request}' in '${path}'`;
+		const message = `resolve '${specifier}' in '${parent}'`;
 
 		/**
 		 * @param {ResolveRequest} result result

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,24 +21,24 @@ const memoize = require("./util/memoize");
 
 /**
  * @typedef {{
- * (context: Context, path: string | URL, request: string | URL, resolveContext: ResolveContext, callback: ResolveCallback): void,
- * (context: Context, path: string | URL, request: string | URL, callback: ResolveCallback): void,
- * (path: string | URL, request: string | URL, resolveContext: ResolveContext, callback: ResolveCallback): void,
- * (path: string | URL, request: string | URL, callback: ResolveCallback): void,
+ * (context: Context, parent: string | URL, specifier: string | URL, resolveContext: ResolveContext, callback: ResolveCallback): void,
+ * (context: Context, parent: string | URL, specifier: string | URL, callback: ResolveCallback): void,
+ * (parent: string | URL, specifier: string | URL, resolveContext: ResolveContext, callback: ResolveCallback): void,
+ * (parent: string | URL, specifier: string | URL, callback: ResolveCallback): void,
  * }} ResolveFunctionAsync
  */
 
 /**
  * @typedef {{
- * (context: Context, path: string | URL, request: string | URL, resolveContext?: ResolveContext): string | false,
- * (path: string | URL, request: string | URL, resolveContext?: ResolveContext): string | false,
+ * (context: Context, parent: string | URL, specifier: string | URL, resolveContext?: ResolveContext): string | false,
+ * (parent: string | URL, specifier: string | URL, resolveContext?: ResolveContext): string | false,
  * }} ResolveFunction
  */
 
 /**
  * @typedef {{
- * (context: Context, path: string | URL, request: string | URL, resolveContext?: ResolveContext): Promise<string | false>,
- * (path: string | URL, request: string | URL, resolveContext?: ResolveContext): Promise<string | false>,
+ * (context: Context, parent: string | URL, specifier: string | URL, resolveContext?: ResolveContext): Promise<string | false>,
+ * (parent: string | URL, specifier: string | URL, resolveContext?: ResolveContext): Promise<string | false>,
  * }} ResolveFunctionPromise
  */
 
@@ -71,17 +71,17 @@ const getAsyncResolver = memoize(() =>
 const resolve =
 	/**
 	 * @param {object | string | URL} context context
-	 * @param {string | URL} path path
-	 * @param {string | URL | ResolveContext | ResolveCallback} request request
+	 * @param {string | URL} parent parent path
+	 * @param {string | URL | ResolveContext | ResolveCallback} specifier specifier to resolve
 	 * @param {ResolveContext | ResolveCallback=} resolveContext resolve context
 	 * @param {ResolveCallback=} callback callback
 	 */
-	(context, path, request, resolveContext, callback) => {
+	(context, parent, specifier, resolveContext, callback) => {
 		if (typeof context === "string" || context instanceof URL) {
 			callback = /** @type {ResolveCallback} */ (resolveContext);
-			resolveContext = /** @type {ResolveContext} */ (request);
-			request = path;
-			path = context;
+			resolveContext = /** @type {ResolveContext} */ (specifier);
+			specifier = parent;
+			parent = context;
 			context = getNodeContext();
 		}
 		if (typeof callback !== "function") {
@@ -89,8 +89,8 @@ const resolve =
 		}
 		getAsyncResolver().resolve(
 			context,
-			path,
-			/** @type {string} */ (request),
+			parent,
+			/** @type {string} */ (specifier),
 			/** @type {ResolveContext} */ (resolveContext),
 			/** @type {ResolveCallback} */ (callback),
 		);
@@ -111,22 +111,22 @@ const getSyncResolver = memoize(() =>
 const resolveSync =
 	/**
 	 * @param {object | string | URL} context context
-	 * @param {string | URL} path path
-	 * @param {string | URL | ResolveContext | undefined} request request
+	 * @param {string | URL} parent parent path
+	 * @param {string | URL | ResolveContext | undefined} specifier specifier to resolve
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {string | false} resolved path
 	 */
-	(context, path, request, resolveContext) => {
+	(context, parent, specifier, resolveContext) => {
 		if (typeof context === "string" || context instanceof URL) {
-			resolveContext = /** @type {ResolveContext} */ (request);
-			request = path;
-			path = context;
+			resolveContext = /** @type {ResolveContext} */ (specifier);
+			specifier = parent;
+			parent = context;
 			context = getNodeContext();
 		}
 		return getSyncResolver().resolveSync(
 			context,
-			path,
-			/** @type {string} */ (request),
+			parent,
+			/** @type {string} */ (specifier),
 			/** @type {ResolveContext} */ (resolveContext),
 		);
 	};
@@ -137,22 +137,22 @@ const resolveSync =
 const resolvePromise =
 	/**
 	 * @param {object | string | URL} context context
-	 * @param {string | URL} path path
-	 * @param {string | URL | ResolveContext | undefined} request request
+	 * @param {string | URL} parent parent path
+	 * @param {string | URL | ResolveContext | undefined} specifier specifier to resolve
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {Promise<string | false>} resolved path
 	 */
-	(context, path, request, resolveContext) => {
+	(context, parent, specifier, resolveContext) => {
 		if (typeof context === "string" || context instanceof URL) {
-			resolveContext = /** @type {ResolveContext} */ (request);
-			request = path;
-			path = context;
+			resolveContext = /** @type {ResolveContext} */ (specifier);
+			specifier = parent;
+			parent = context;
 			context = getNodeContext();
 		}
 		return getAsyncResolver().resolvePromise(
 			context,
-			path,
-			/** @type {string} */ (request),
+			parent,
+			/** @type {string} */ (specifier),
 			/** @type {ResolveContext} */ (resolveContext),
 		);
 	};
@@ -170,17 +170,17 @@ function create(options) {
 	});
 	/**
 	 * @param {object | string | URL} context Custom context
-	 * @param {string | URL} path Base path
-	 * @param {string | URL | ResolveContext | ResolveCallback} request String to resolve
+	 * @param {string | URL} parent Base/parent path
+	 * @param {string | URL | ResolveContext | ResolveCallback} specifier Specifier to resolve
 	 * @param {ResolveContext | ResolveCallback=} resolveContext Resolve context
 	 * @param {ResolveCallback=} callback Result callback
 	 */
-	return function create(context, path, request, resolveContext, callback) {
+	return function create(context, parent, specifier, resolveContext, callback) {
 		if (typeof context === "string" || context instanceof URL) {
 			callback = /** @type {ResolveCallback} */ (resolveContext);
-			resolveContext = /** @type {ResolveContext} */ (request);
-			request = path;
-			path = context;
+			resolveContext = /** @type {ResolveContext} */ (specifier);
+			specifier = parent;
+			parent = context;
 			context = getNodeContext();
 		}
 		if (typeof callback !== "function") {
@@ -188,8 +188,8 @@ function create(options) {
 		}
 		resolver.resolve(
 			context,
-			path,
-			/** @type {string} */ (request),
+			parent,
+			/** @type {string} */ (specifier),
 			/** @type {ResolveContext} */ (resolveContext),
 			callback,
 		);
@@ -208,22 +208,22 @@ function createSync(options) {
 	});
 	/**
 	 * @param {object | string | URL} context custom context
-	 * @param {string | URL} path base path
-	 * @param {string | URL | ResolveContext | undefined} request request to resolve
+	 * @param {string | URL} parent base/parent path
+	 * @param {string | URL | ResolveContext | undefined} specifier specifier to resolve
 	 * @param {ResolveContext=} resolveContext Resolve context
 	 * @returns {string | false} Resolved path or false
 	 */
-	return function createSync(context, path, request, resolveContext) {
+	return function createSync(context, parent, specifier, resolveContext) {
 		if (typeof context === "string" || context instanceof URL) {
-			resolveContext = /** @type {ResolveContext} */ (request);
-			request = path;
-			path = context;
+			resolveContext = /** @type {ResolveContext} */ (specifier);
+			specifier = parent;
+			parent = context;
 			context = getNodeContext();
 		}
 		return resolver.resolveSync(
 			context,
-			path,
-			/** @type {string} */ (request),
+			parent,
+			/** @type {string} */ (specifier),
 			/** @type {ResolveContext} */ (resolveContext),
 		);
 	};
@@ -240,22 +240,22 @@ function createPromise(options) {
 	});
 	/**
 	 * @param {object | string | URL} context Custom context
-	 * @param {string | URL} path Base path
-	 * @param {string | URL | ResolveContext | undefined} request String to resolve
+	 * @param {string | URL} parent Base/parent path
+	 * @param {string | URL | ResolveContext | undefined} specifier Specifier to resolve
 	 * @param {ResolveContext=} resolveContext Resolve context
 	 * @returns {Promise<string | false>} resolved path
 	 */
-	return function createPromise(context, path, request, resolveContext) {
+	return function createPromise(context, parent, specifier, resolveContext) {
 		if (typeof context === "string" || context instanceof URL) {
-			resolveContext = /** @type {ResolveContext} */ (request);
-			request = path;
-			path = context;
+			resolveContext = /** @type {ResolveContext} */ (specifier);
+			specifier = parent;
+			parent = context;
 			context = getNodeContext();
 		}
 		return resolver.resolvePromise(
 			context,
-			path,
-			/** @type {string} */ (request),
+			parent,
+			/** @type {string} */ (specifier),
 			/** @type {ResolveContext} */ (resolveContext),
 		);
 	};

--- a/types.d.ts
+++ b/types.d.ts
@@ -1213,21 +1213,21 @@ declare interface ResolveContext {
 declare interface ResolveFunction {
 	(
 		context: Context,
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext?: ResolveContext,
 	): string | false;
 	(
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext?: ResolveContext,
 	): string | false;
 }
 declare interface ResolveFunctionAsync {
 	(
 		context: Context,
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext: ResolveContext,
 		callback: (
 			err: null | ErrorWithDetail,
@@ -1237,8 +1237,8 @@ declare interface ResolveFunctionAsync {
 	): void;
 	(
 		context: Context,
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		callback: (
 			err: null | ErrorWithDetail,
 			res?: string | false,
@@ -1246,8 +1246,8 @@ declare interface ResolveFunctionAsync {
 		) => void,
 	): void;
 	(
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext: ResolveContext,
 		callback: (
 			err: null | ErrorWithDetail,
@@ -1256,8 +1256,8 @@ declare interface ResolveFunctionAsync {
 		) => void,
 	): void;
 	(
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		callback: (
 			err: null | ErrorWithDetail,
 			res?: string | false,
@@ -1268,13 +1268,13 @@ declare interface ResolveFunctionAsync {
 declare interface ResolveFunctionPromise {
 	(
 		context: Context,
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext?: ResolveContext,
 	): Promise<string | false>;
 	(
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext?: ResolveContext,
 	): Promise<string | false>;
 }
@@ -1613,30 +1613,30 @@ declare abstract class Resolver {
 		null | ResolveRequest
 	>;
 	resolveSync(
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext?: ResolveContext,
 	): string | false;
 	resolveSync(
 		context: Context,
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext?: ResolveContext,
 	): string | false;
 	resolvePromise(
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext?: ResolveContext,
 	): Promise<string | false>;
 	resolvePromise(
 		context: Context,
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext?: ResolveContext,
 	): Promise<string | false>;
 	resolve(
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		callback: (
 			err: null | ErrorWithDetail,
 			res?: string | false,
@@ -1644,8 +1644,8 @@ declare abstract class Resolver {
 		) => void,
 	): void;
 	resolve(
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext: ResolveContext,
 		callback: (
 			err: null | ErrorWithDetail,
@@ -1655,8 +1655,8 @@ declare abstract class Resolver {
 	): void;
 	resolve(
 		context: Context,
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		callback: (
 			err: null | ErrorWithDetail,
 			res?: string | false,
@@ -1665,8 +1665,8 @@ declare abstract class Resolver {
 	): void;
 	resolve(
 		context: Context,
-		path: string | URL_url,
-		request: string | URL_url,
+		parent: string | URL_url,
+		specifier: string | URL_url,
 		resolveContext: ResolveContext,
 		callback: (
 			err: null | ErrorWithDetail,
@@ -1971,8 +1971,8 @@ declare interface WriteOnlySet<T> {
 }
 declare function exports(
 	context: Context,
-	path: string | URL_url,
-	request: string | URL_url,
+	parent: string | URL_url,
+	specifier: string | URL_url,
 	resolveContext: ResolveContext,
 	callback: (
 		err: null | ErrorWithDetail,
@@ -1982,8 +1982,8 @@ declare function exports(
 ): void;
 declare function exports(
 	context: Context,
-	path: string | URL_url,
-	request: string | URL_url,
+	parent: string | URL_url,
+	specifier: string | URL_url,
 	callback: (
 		err: null | ErrorWithDetail,
 		res?: string | false,
@@ -1991,8 +1991,8 @@ declare function exports(
 	) => void,
 ): void;
 declare function exports(
-	path: string | URL_url,
-	request: string | URL_url,
+	parent: string | URL_url,
+	specifier: string | URL_url,
 	resolveContext: ResolveContext,
 	callback: (
 		err: null | ErrorWithDetail,
@@ -2001,8 +2001,8 @@ declare function exports(
 	) => void,
 ): void;
 declare function exports(
-	path: string | URL_url,
-	request: string | URL_url,
+	parent: string | URL_url,
+	specifier: string | URL_url,
 	callback: (
 		err: null | ErrorWithDetail,
 		res?: string | false,


### PR DESCRIPTION
**Summary**

Expands the README Public API section with per-argument examples for `resolve()` (context, parent, specifier, resolveContext, callback) and renames the positional parameters from `path`/`request` to `parent`/`specifier` across the docs, `lib/index.js`, and `lib/Resolver.js` to align with ECMAScript resolution terminology (`import.meta.resolve(specifier, parent)`).

**What kind of change does this PR introduce?**

A documentation and cosmetic refactor — the arguments are positional, so the rename has no behavior or API change (the `ResolveRequest` object keys `.path`/`.request` and the existing error message strings are kept unchanged).

**Did you add tests for your changes?**

No, because there is no behavior change; the existing suite (1074 tests, snapshots) and full lint pass unmodified.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented and/or communicated to users?**

The README and regenerated `types.d.ts` already reflect the new `parent`/`specifier` parameter labels.

**Use of AI**

This PR was prepared with the assistance of Claude Code, with all changes reviewed against the codebase, lint, and tests by the author.

https://claude.ai/code/session_01BgX7dKFgaAgQPeCdqovhqU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgX7dKFgaAgQPeCdqovhqU)_