### PR TITLE
chore: modernize package metadata URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "enhanced-resolve",
   "version": "5.24.1",
   "description": "Offers a async require.resolve function. It's highly configurable.",
-  "homepage": "http://github.com/webpack/enhanced-resolve",
+  "homepage": "https://github.com/webpack/enhanced-resolve#readme",
   "repository": {
     "type": "git",
-    "url": "git://github.com/webpack/enhanced-resolve.git"
+    "url": "git+https://github.com/webpack/enhanced-resolve.git"
   },
   "license": "MIT",
   "author": "Tobias Koppers @sokra",


### PR DESCRIPTION
﻿<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Modernizes the package metadata URLs in `package.json` so npm consumers and registry tooling use HTTPS links. This replaces the deprecated `git://` repository transport and points the homepage at the README URL.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

chore

**Did you add tests for your changes?**

No; this is a package metadata-only change. I verified the updated fields with a package metadata assertion, checked `package.json` formatting with Prettier, and ran `npm pack --dry-run --ignore-scripts --json`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used to identify and prepare this small package metadata cleanup. I manually reviewed the diff and validation results before opening the PR.
