### PR TITLE
perf: batch cached fs callbacks from one burst into a single tick

### DIFF
--- a/.changeset/batch-cached-fs-callback-dispatch.md
+++ b/.changeset/batch-cached-fs-callback-dispatch.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Batch cached filesystem callbacks from one synchronous burst into a single tick.

--- a/benchmark/cases/cached-fs-burst/fixture/file-0.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-0.js
@@ -1,0 +1,1 @@
+module.exports = 0;

--- a/benchmark/cases/cached-fs-burst/fixture/file-1.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-1.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/benchmark/cases/cached-fs-burst/fixture/file-10.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-10.js
@@ -1,0 +1,1 @@
+module.exports = 10;

--- a/benchmark/cases/cached-fs-burst/fixture/file-11.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-11.js
@@ -1,0 +1,1 @@
+module.exports = 11;

--- a/benchmark/cases/cached-fs-burst/fixture/file-12.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-12.js
@@ -1,0 +1,1 @@
+module.exports = 12;

--- a/benchmark/cases/cached-fs-burst/fixture/file-13.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-13.js
@@ -1,0 +1,1 @@
+module.exports = 13;

--- a/benchmark/cases/cached-fs-burst/fixture/file-14.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-14.js
@@ -1,0 +1,1 @@
+module.exports = 14;

--- a/benchmark/cases/cached-fs-burst/fixture/file-15.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-15.js
@@ -1,0 +1,1 @@
+module.exports = 15;

--- a/benchmark/cases/cached-fs-burst/fixture/file-2.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-2.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/benchmark/cases/cached-fs-burst/fixture/file-3.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-3.js
@@ -1,0 +1,1 @@
+module.exports = 3;

--- a/benchmark/cases/cached-fs-burst/fixture/file-4.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-4.js
@@ -1,0 +1,1 @@
+module.exports = 4;

--- a/benchmark/cases/cached-fs-burst/fixture/file-5.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-5.js
@@ -1,0 +1,1 @@
+module.exports = 5;

--- a/benchmark/cases/cached-fs-burst/fixture/file-6.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-6.js
@@ -1,0 +1,1 @@
+module.exports = 6;

--- a/benchmark/cases/cached-fs-burst/fixture/file-7.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-7.js
@@ -1,0 +1,1 @@
+module.exports = 7;

--- a/benchmark/cases/cached-fs-burst/fixture/file-8.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-8.js
@@ -1,0 +1,1 @@
+module.exports = 8;

--- a/benchmark/cases/cached-fs-burst/fixture/file-9.js
+++ b/benchmark/cases/cached-fs-burst/fixture/file-9.js
@@ -1,0 +1,1 @@
+module.exports = 9;

--- a/benchmark/cases/cached-fs-burst/index.bench.mjs
+++ b/benchmark/cases/cached-fs-burst/index.bench.mjs
@@ -1,0 +1,56 @@
+/*
+ * cached-fs-burst
+ *
+ * Measures CachedInputFileSystem's cached-hit dispatch directly, without a
+ * resolver in front. Cache hits are delivered asynchronously; hits issued
+ * from one synchronous burst share a single `process.nextTick` (the first
+ * hit is held in dedicated slots, later ones spill into a queue drained by
+ * the same tick). The concurrent task tracks that batching, the sequential
+ * task guards the single-hit slot path against regressions.
+ *
+ * The cache duration is Infinity so TTL decay never evicts entries
+ * mid-measurement — every call after warmup is a pure cache hit.
+ */
+
+import fs from "fs";
+import path from "path";
+import enhanced from "../../../lib/index.js";
+
+const { CachedInputFileSystem } = enhanced;
+
+/**
+ * @param {import("tinybench").Bench} bench bench
+ * @param {{ fixtureDir: string }} ctx ctx
+ */
+export default function register(bench, { fixtureDir }) {
+	const cachedFs = new CachedInputFileSystem(fs, Infinity);
+
+	const files = Array.from({ length: 16 }, (_, i) =>
+		path.join(fixtureDir, `file-${i}.js`),
+	);
+
+	/**
+	 * @param {string} file file
+	 * @returns {Promise<import("fs").Stats>} stats
+	 */
+	const stat = (file) =>
+		new Promise((resolve, reject) => {
+			cachedFs.stat(file, (err, result) =>
+				err ? reject(err) : resolve(result),
+			);
+		});
+
+	bench.add("cached-fs-burst: 64 concurrent cached stat calls", async () => {
+		const promises = [];
+		for (let round = 0; round < 4; round++) {
+			for (const file of files) promises.push(stat(file));
+		}
+		await Promise.all(promises);
+	});
+
+	bench.add("cached-fs-burst: 64 sequential cached stat calls", async () => {
+		for (let round = 0; round < 4; round++) {
+			for (const file of files) await stat(file);
+		}
+	});
+}

--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -64,6 +64,87 @@ const runCallbacks = (callbacks, err, result) => {
 // eslint-disable-next-line jsdoc/reject-any-type
 /** @typedef {any} EXPECTED_ANY */
 
+/**
+ * The first pending cache hit is held in these slots (a scheduled tick is
+ * pending iff `firstCallback` is set); later hits from the same synchronous
+ * burst spill into `dispatchQueue` as flat [callback, err, result] triples
+ * and are drained by the same tick. This keeps the common single-hit case
+ * as cheap as a plain `nextTick` while bursts share one tick.
+ * @type {FileSystemCallback<EXPECTED_ANY> | undefined}
+ */
+let firstCallback;
+/** @type {Error | null} */
+let firstErr = null;
+/** @type {EXPECTED_ANY} */
+let firstResult;
+/** @type {EXPECTED_ANY[]} */
+let dispatchQueue = [];
+/** @type {EXPECTED_ANY[]} */
+let spareQueue = [];
+
+const runDispatch = () => {
+	const callback = /** @type {FileSystemCallback<EXPECTED_ANY>} */ (
+		firstCallback
+	);
+	const err = firstErr;
+	const result = firstResult;
+	// clear before calling: hits made from inside a callback start a new tick
+	firstCallback = undefined;
+	firstErr = null;
+	firstResult = undefined;
+	if (dispatchQueue.length === 0) {
+		// single hit: no queue bookkeeping, a throw affects nobody else
+		callback(err, result);
+		return;
+	}
+	const queue = dispatchQueue;
+	// ping-pong the two arrays so draining never allocates
+	dispatchQueue = spareQueue;
+	let i = -3;
+	try {
+		callback(err, result);
+		for (i = 0; i < queue.length; i += 3) {
+			queue[i](queue[i + 1], queue[i + 2]);
+		}
+	} finally {
+		// a throwing callback must not starve the rest: re-schedule the
+		// remainder (ahead of hits queued during this drain) and rethrow
+		i += 3;
+		if (i < queue.length) {
+			const rest = queue.slice(i);
+			if (firstCallback === undefined) {
+				// no reentrant hit took the slot, so `dispatchQueue` is empty
+				[firstCallback, firstErr, firstResult] = rest;
+				nextTick(runDispatch);
+				if (rest.length > 3) dispatchQueue = rest.slice(3);
+			} else {
+				dispatchQueue =
+					dispatchQueue.length > 0 ? [...rest, ...dispatchQueue] : rest;
+			}
+		}
+		queue.length = 0;
+		spareQueue = queue;
+	}
+};
+
+/**
+ * Cache hits stay asynchronous, but all hits from the same synchronous
+ * execution share a single `nextTick` instead of scheduling one each.
+ * @param {FileSystemCallback<EXPECTED_ANY>} callback callback
+ * @param {Error | null} err error
+ * @param {EXPECTED_ANY} result result
+ */
+const scheduleDispatch = (callback, err, result) => {
+	if (firstCallback === undefined) {
+		firstCallback = callback;
+		firstErr = err;
+		firstResult = result;
+		nextTick(runDispatch);
+	} else {
+		dispatchQueue.push(callback, err, result);
+	}
+};
+
 class OperationMergerBackend {
 	/**
 	 * @param {EXPECTED_FUNCTION | undefined} provider async method in filesystem
@@ -264,8 +345,10 @@ class CacheBackend {
 		// Check in cache
 		const cacheEntry = this._data.get(strPath);
 		if (cacheEntry !== undefined) {
-			if (cacheEntry.err) return nextTick(callback, cacheEntry.err);
-			return nextTick(callback, null, cacheEntry.result);
+			if (cacheEntry.err) {
+				return scheduleDispatch(callback, cacheEntry.err, undefined);
+			}
+			return scheduleDispatch(callback, null, cacheEntry.result);
 		}
 
 		// Check if there is already the same operation running

--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -82,6 +82,8 @@ let dispatchQueue = [];
 let dispatchQueueLength = 0;
 /** @type {EXPECTED_ANY[]} */
 let spareQueue = [];
+// upper bound on the spill-array capacity kept alive between bursts
+const MAX_RETAINED_QUEUE_LENGTH = 1024;
 
 const runDispatch = () => {
 	const callback = /** @type {FileSystemCallback<EXPECTED_ANY>} */ (
@@ -136,7 +138,9 @@ const runDispatch = () => {
 		// does not have to re-grow the array from scratch
 		for (let j = 0; j < length; j++) queue[j] = undefined;
 		// bound the permanently retained capacity after a rare giant burst
-		if (queue.length > 1024) queue.length = 1024;
+		if (queue.length > MAX_RETAINED_QUEUE_LENGTH) {
+			queue.length = MAX_RETAINED_QUEUE_LENGTH;
+		}
 		spareQueue = queue;
 	}
 };

--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -79,6 +79,7 @@ let firstErr = null;
 let firstResult;
 /** @type {EXPECTED_ANY[]} */
 let dispatchQueue = [];
+let dispatchQueueLength = 0;
 /** @type {EXPECTED_ANY[]} */
 let spareQueue = [];
 
@@ -92,37 +93,48 @@ const runDispatch = () => {
 	firstCallback = undefined;
 	firstErr = null;
 	firstResult = undefined;
-	if (dispatchQueue.length === 0) {
+	if (dispatchQueueLength === 0) {
 		// single hit: no queue bookkeeping, a throw affects nobody else
 		callback(err, result);
 		return;
 	}
 	const queue = dispatchQueue;
+	const length = dispatchQueueLength;
 	// ping-pong the two arrays so draining never allocates
 	dispatchQueue = spareQueue;
+	dispatchQueueLength = 0;
 	let i = -3;
 	try {
 		callback(err, result);
-		for (i = 0; i < queue.length; i += 3) {
+		for (i = 0; i < length; i += 3) {
 			queue[i](queue[i + 1], queue[i + 2]);
 		}
 	} finally {
 		// a throwing callback must not starve the rest: re-schedule the
 		// remainder (ahead of hits queued during this drain) and rethrow
 		i += 3;
-		if (i < queue.length) {
-			const rest = queue.slice(i);
+		if (i < length) {
 			if (firstCallback === undefined) {
 				// no reentrant hit took the slot, so `dispatchQueue` is empty
-				[firstCallback, firstErr, firstResult] = rest;
+				firstCallback = queue[i];
+				firstErr = queue[i + 1];
+				firstResult = queue[i + 2];
 				nextTick(runDispatch);
-				if (rest.length > 3) dispatchQueue = rest.slice(3);
+				for (let j = i + 3; j < length; j++) {
+					dispatchQueue[dispatchQueueLength++] = queue[j];
+				}
 			} else {
-				dispatchQueue =
-					dispatchQueue.length > 0 ? [...rest, ...dispatchQueue] : rest;
+				const rest = queue.slice(i, length);
+				for (let j = 0; j < dispatchQueueLength; j++) {
+					rest.push(dispatchQueue[j]);
+				}
+				dispatchQueue = rest;
+				dispatchQueueLength = rest.length;
 			}
 		}
-		queue.length = 0;
+		// release references but keep the backing store, so the next burst
+		// does not have to re-grow the array from scratch
+		for (let j = 0; j < length; j++) queue[j] = undefined;
 		spareQueue = queue;
 	}
 };
@@ -141,7 +153,11 @@ const scheduleDispatch = (callback, err, result) => {
 		firstResult = result;
 		nextTick(runDispatch);
 	} else {
-		dispatchQueue.push(callback, err, result);
+		const queue = dispatchQueue;
+		queue[dispatchQueueLength] = callback;
+		queue[dispatchQueueLength + 1] = err;
+		queue[dispatchQueueLength + 2] = result;
+		dispatchQueueLength += 3;
 	}
 };
 

--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -135,6 +135,8 @@ const runDispatch = () => {
 		// release references but keep the backing store, so the next burst
 		// does not have to re-grow the array from scratch
 		for (let j = 0; j < length; j++) queue[j] = undefined;
+		// bound the permanently retained capacity after a rare giant burst
+		if (queue.length > 1024) queue.length = 1024;
 		spareQueue = queue;
 	}
 };

--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -113,8 +113,8 @@ const runDispatch = () => {
 		}
 	} finally {
 		// a throwing callback must not starve the rest: re-schedule the
-		// remainder and rethrow; it runs before hits spilled during this
-		// drain, but after a reentrant hit that already claimed the slot
+		// remainder ahead of anything scheduled during this drain (matching
+		// the old per-tick FIFO order) and rethrow
 		i += 3;
 		if (i < length) {
 			if (firstCallback === undefined) {
@@ -127,12 +127,16 @@ const runDispatch = () => {
 					dispatchQueue[dispatchQueueLength++] = queue[j];
 				}
 			} else {
+				// a reentrant hit claimed the slot (and scheduled the tick);
+				// displace it behind the remainder to keep FIFO order
 				const rest = queue.slice(i, length);
+				rest.push(firstCallback, firstErr, firstResult);
 				for (let j = 0; j < dispatchQueueLength; j++) {
 					rest.push(dispatchQueue[j]);
 				}
-				dispatchQueue = rest;
-				dispatchQueueLength = rest.length;
+				[firstCallback, firstErr, firstResult] = rest;
+				dispatchQueue = rest.slice(3);
+				dispatchQueueLength = dispatchQueue.length;
 			}
 		}
 		// release references but keep the backing store, so the next burst

--- a/lib/CachedInputFileSystem.js
+++ b/lib/CachedInputFileSystem.js
@@ -113,7 +113,8 @@ const runDispatch = () => {
 		}
 	} finally {
 		// a throwing callback must not starve the rest: re-schedule the
-		// remainder (ahead of hits queued during this drain) and rethrow
+		// remainder and rethrow; it runs before hits spilled during this
+		// drain, but after a reentrant hit that already claimed the slot
 		i += 3;
 		if (i < length) {
 			if (firstCallback === undefined) {

--- a/test/CachedInputFileSystem.test.js
+++ b/test/CachedInputFileSystem.test.js
@@ -423,6 +423,39 @@ describe("cachedInputFileSystem CacheBackend", () => {
 		});
 	});
 
+	it("should call cached callbacks asynchronously and in order", (t, done) => {
+		fs.stat("a", () => {
+			// cache for "a" is now populated; a burst of cached calls must
+			// stay asynchronous and preserve issue order
+			/** @type {number[]} */
+			const order = [];
+			let sync = true;
+			fs.stat("a", () => order.push(1));
+			fs.stat("a", () => order.push(2));
+			fs.stat("a", () => {
+				order.push(3);
+				assert.strictEqual(sync, false);
+				assert.deepStrictEqual(order, [1, 2, 3]);
+				done();
+			});
+			assert.deepStrictEqual(order, []);
+			sync = false;
+		});
+	});
+
+	it("should stay asynchronous for cached calls made from a cached callback", (t, done) => {
+		fs.stat("a", () => {
+			fs.stat("a", () => {
+				let sync = true;
+				fs.stat("a", () => {
+					assert.strictEqual(sync, false);
+					done();
+				});
+				sync = false;
+			});
+		});
+	});
+
 	it("should cache undefined value", (t, done) => {
 		fs.stat(undefined, (_err, result) => {
 			assert.strictEqual(result, undefined);

--- a/test/CachedInputFileSystem.test.js
+++ b/test/CachedInputFileSystem.test.js
@@ -449,17 +449,22 @@ describe("cachedInputFileSystem CacheBackend", () => {
 			// capacity cap after the drain
 			const total = 600;
 			let called = 0;
+			/** @type {boolean[]} */
+			const delivered = Array.from({ length: total }, () => false);
 			/**
-			 * @param {Error | null} err error
-			 * @param {unknown} result result
+			 * @param {number} index index
+			 * @returns {(err: Error | null, result: unknown) => void} callback
 			 */
-			const onStat = (err, result) => {
+			const makeCallback = (index) => (err, result) => {
 				assert.strictEqual(err, null);
 				assert.notStrictEqual(result, undefined);
+				// a duplicate delivery for this request fails here
+				assert.strictEqual(delivered[index], false);
+				delivered[index] = true;
 				called++;
 				if (called === total) done();
 			};
-			for (let i = 0; i < total; i++) fs.stat("a", onStat);
+			for (let i = 0; i < total; i++) fs.stat("a", makeCallback(i));
 		});
 	});
 

--- a/test/CachedInputFileSystem.test.js
+++ b/test/CachedInputFileSystem.test.js
@@ -443,6 +443,26 @@ describe("cachedInputFileSystem CacheBackend", () => {
 		});
 	});
 
+	it("should deliver a giant burst of cached calls exactly once each", (t, done) => {
+		fs.stat("a", () => {
+			// 600 hits spill ~1800 queue elements, exercising the retained
+			// capacity cap after the drain
+			const total = 600;
+			let called = 0;
+			/**
+			 * @param {Error | null} err error
+			 * @param {unknown} result result
+			 */
+			const onStat = (err, result) => {
+				assert.strictEqual(err, null);
+				assert.notStrictEqual(result, undefined);
+				called++;
+				if (called === total) done();
+			};
+			for (let i = 0; i < total; i++) fs.stat("a", onStat);
+		});
+	});
+
 	it("should stay asynchronous for cached calls made from a cached callback", (t, done) => {
 		fs.stat("a", () => {
 			fs.stat("a", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Every `CacheBackend` cache hit scheduled its own `process.nextTick(callback, err, result)` — millions per large build; hits issued from the same synchronous burst now share one tick (first hit held in dedicated slots so the sequential single-hit path costs the same as before, later hits spill into a queue drained by that tick, and a throwing callback re-schedules the remainder to keep per-callback isolation). The `concurrent-batch` benchmark roughly doubles (978 → 1914 ops/s) and the new `cached-fs-burst` case shows ~5x on concurrent cached stat calls, with sequential cases unchanged.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes — new cases in `test/CachedInputFileSystem.test.js` (cached callbacks stay asynchronous and in order across a burst; reentrant cached calls from a cached callback stay asynchronous) and a new `benchmark/cases/cached-fs-burst/` benchmark with concurrent and sequential variants.

**Does this PR introduce a breaking change?**

No — cache hits remain asynchronous; only the number of ticks shared by a burst changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was implemented with AI assistance (Claude Code) under maintainer direction; the change, tests, and benchmark results were reviewed and verified by the maintainer.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Vj6cXMN24KsSyDTafq19c)_