### PR TITLE
feat(profiler): add resolution performance profiler plugin

### DIFF
--- a/lib/ProfilerPlugin.js
+++ b/lib/ProfilerPlugin.js
@@ -1,0 +1,178 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author jhonsnow456
+*/
+
+"use strict";
+
+/** @typedef {import("./Resolver")} Resolver */
+/** @typedef {import("./Resolver").ResolveStepHook} ResolveStepHook */
+/** @typedef {import("./Resolver").ResolveRequest} ResolveRequest */
+/** @typedef {import("./Resolver").ResolveContext} ResolveContext */
+
+/**
+ * @typedef {object} ProfileHookEntry
+ * @property {string} name hook name
+ * @property {number} count number of times this hook was entered
+ * @property {number} totalTime total wall-clock time in milliseconds
+ */
+
+/**
+ * @typedef {object} ProfileData
+ * @property {number} startTime when the resolve started (Date.now() epoch)
+ * @property {number} endTime when the resolve completed
+ * @property {number} duration total duration in milliseconds
+ * @property {string} specifier the request string that was resolved
+ * @property {string} parent the parent path resolution started from
+ * @property {boolean} success whether the resolution succeeded
+ * @property {string | null} result the resolved path, or null on failure
+ * @property {Map<string, ProfileHookEntry>} hooks per-hook profiling data
+ */
+
+const now = () => Date.now();
+
+module.exports = class ProfilerPlugin {
+	/**
+	 * @param {(profile: ProfileData) => void=} profileCallback optional callback
+	 */
+	constructor(profileCallback) {
+		this.profileCallback = profileCallback;
+	}
+
+	/**
+	 * @param {Resolver} resolver the resolver
+	 * @returns {void}
+	 */
+	apply(resolver) {
+		const { profileCallback } = this;
+		const { hooks } = resolver;
+		const resolveStepHook = hooks.resolveStep;
+		const resultHook = hooks.result;
+		const noResolveHook = hooks.noResolve;
+
+		/** @type {{ name: string, lastEventTime: number }[]} */
+		const frameStack = [];
+
+		/** @type {Map<string, ProfileHookEntry>} */
+		let hookStats = new Map();
+
+		/** @type {ProfileData | null} */
+		let currentProfile = null;
+
+		/**
+		 * Pop all remaining frames and attribute remaining time.
+		 * @param {number} endTime end timestamp
+		 */
+		function finalizeFrames(endTime) {
+			while (frameStack.length > 0) {
+				const frameEntry = frameStack.pop();
+				if (!frameEntry) break;
+				const elapsed = endTime - frameEntry.lastEventTime;
+				const stats = hookStats.get(frameEntry.name);
+				if (stats) {
+					stats.totalTime += elapsed;
+				}
+			}
+		}
+
+		/**
+		 * Deliver profile data to the caller.
+		 * @param {ResolveContext} resolveContext resolve context
+		 * @param {ProfileData} profile profile data to deliver
+		 */
+		function emitProfile(resolveContext, profile) {
+			const callback =
+				typeof resolveContext.profile === "function"
+					? resolveContext.profile
+					: profileCallback;
+			if (typeof callback === "function") {
+				callback(profile);
+			}
+			if (resolveContext.log) {
+				resolveContext.log(
+					`profile: resolved "${profile.specifier}" in ${profile.duration.toFixed(2)}ms`,
+				);
+				for (const hookStatsEntry of profile.hooks.values()) {
+					resolveContext.log(
+						`  ${hookStatsEntry.name}: ${hookStatsEntry.count}x, ${hookStatsEntry.totalTime.toFixed(2)}ms`,
+					);
+				}
+			}
+		}
+
+		resolveStepHook.tap("ProfilerPlugin", (hook, request) => {
+			const time = now();
+			const name = typeof hook === "string" ? hook : hook.name || "unknown";
+
+			if (frameStack.length === 0) {
+				currentProfile = {
+					startTime: time,
+					endTime: 0,
+					duration: 0,
+					specifier: request.request || "",
+					parent: request.path || "",
+					success: false,
+					result: null,
+					hooks: hookStats,
+				};
+			}
+
+			if (frameStack.length > 0) {
+				const parent = frameStack[frameStack.length - 1];
+				const elapsed = time - parent.lastEventTime;
+				const parentStats = hookStats.get(parent.name);
+				if (parentStats) {
+					parentStats.totalTime += elapsed;
+				}
+			}
+
+			let stats = hookStats.get(name);
+			if (!stats) {
+				stats = { name, count: 0, totalTime: 0 };
+				hookStats.set(name, stats);
+			}
+			stats.count++;
+
+			frameStack.push({ name, lastEventTime: time });
+		});
+
+		/**
+		 * Finalize profiling when resolution completes successfully.
+		 */
+		resultHook.tapAsync("ProfilerPlugin", (request, ctx, callback) => {
+			if (currentProfile) {
+				const time = now();
+				currentProfile.endTime = time;
+				currentProfile.duration = time - currentProfile.startTime;
+				currentProfile.success = true;
+				currentProfile.result = request.path || null;
+
+				finalizeFrames(time);
+				emitProfile(ctx, currentProfile);
+				currentProfile = null;
+				hookStats = new Map();
+			}
+			callback(null);
+		});
+
+		/**
+		 * Finalize profiling when resolution fails.
+		 */
+		noResolveHook.tap("ProfilerPlugin", (_request, _error) => {
+			if (currentProfile) {
+				const time = now();
+				currentProfile.endTime = time;
+				currentProfile.duration = time - currentProfile.startTime;
+				currentProfile.success = false;
+				currentProfile.result = null;
+
+				finalizeFrames(time);
+				if (typeof profileCallback === "function") {
+					profileCallback(currentProfile);
+				}
+				currentProfile = null;
+				hookStats = new Map();
+			}
+		});
+	}
+};

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -555,6 +555,7 @@ class StackEntry {
  * @property {StackEntry | Set<string>=} stack tip of the resolver call stack (a singly-linked list with Set-like API). For instance, `resolve → parsedResolve → describedResolve`. Accepts a legacy `Set<string>` for back-compat with older callers; it is normalized internally without a hot-path branch.
  * @property {((str: string) => void)=} log log function
  * @property {ResolveContextYield=} yield yield result, if provided plugins can return several results
+ * @property {((profile: import("./ProfilerPlugin").ProfileData) => void)=} profile profile callback — called with timing data when resolve completes
  */
 
 /** @typedef {AsyncSeriesBailHook<[ResolveRequest, ResolveContext], ResolveRequest | null>} ResolveStepHook */

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -26,6 +26,7 @@ const ModulesInRootPlugin = require("./ModulesInRootPlugin");
 const NextPlugin = require("./NextPlugin");
 const ParsePlugin = require("./ParsePlugin");
 const PnpPlugin = require("./PnpPlugin");
+const ProfilerPlugin = require("./ProfilerPlugin");
 const Resolver = require("./Resolver");
 const RestrictionsPlugin = require("./RestrictionsPlugin");
 const ResultPlugin = require("./ResultPlugin");
@@ -104,6 +105,7 @@ const { PathType, getType, toPath } = require("./util/path");
  * @property {boolean=} preferRelative Prefer to resolve module requests as relative requests before falling back to modules
  * @property {boolean=} preferAbsolute Prefer to resolve server-relative urls as absolute paths before falling back to resolve in roots
  * @property {string | URL | boolean | UserTsconfigOptions=} tsconfig TypeScript config file path (or `file:` `URL` instance) or config object with configFile and references
+ * @property {boolean | ((profile: import("./ProfilerPlugin").ProfileData) => void)=} profile Enable resolution profiling, optionally with a callback to receive profile data
  */
 
 /**
@@ -137,6 +139,7 @@ const { PathType, getType, toPath } = require("./util/path");
  * @property {boolean} preferRelative prefer relative
  * @property {boolean} preferAbsolute prefer absolute
  * @property {string | boolean | TsconfigOptions} tsconfig tsconfig file path or config object
+ * @property {boolean | ((profile: import("./ProfilerPlugin").ProfileData) => void)} profile enable resolution profiling
  */
 
 /**
@@ -367,6 +370,7 @@ function createOptions(options) {
 				options.restrictions.map((r) => (r instanceof RegExp ? r : toPath(r))),
 		),
 		tsconfig: normalizeTsconfig(options.tsconfig),
+		profile: options.profile === undefined ? false : options.profile,
 	};
 }
 
@@ -407,9 +411,15 @@ module.exports.createResolver = function createResolver(options) {
 		restrictions,
 		roots,
 		tsconfig,
+		profile,
 	} = normalizedOptions;
 
 	const plugins = [...userPlugins];
+
+	if (profile) {
+		const profileCallback = typeof profile === "function" ? profile : undefined;
+		plugins.push(new ProfilerPlugin(profileCallback));
+	}
 
 	const resolver =
 		customResolver || new Resolver(fileSystem, normalizedOptions);

--- a/lib/createInnerContext.js
+++ b/lib/createInnerContext.js
@@ -52,5 +52,6 @@ module.exports = function createInnerContext(parent, stack, message) {
 		contextDependencies: parent.contextDependencies,
 		missingDependencies: parent.missingDependencies,
 		stack,
+		profile: parent.profile,
 	};
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -301,6 +301,9 @@ module.exports = mergeExports(resolve, {
 	get LogInfoPlugin() {
 		return require("./LogInfoPlugin");
 	},
+	get ProfilerPlugin() {
+		return require("./ProfilerPlugin");
+	},
 	get TsconfigPathsPlugin() {
 		return require("./TsconfigPathsPlugin");
 	},

--- a/test/profiler.test.js
+++ b/test/profiler.test.js
@@ -1,0 +1,206 @@
+"use strict";
+
+const assert = require("assert");
+const { Volume } = require("memfs");
+const { ResolverFactory } = require("../");
+const { describe, it } = require("./_runner");
+
+describe("ProfilerPlugin", () => {
+	it("should collect profile data via resolveContext.profile callback", (t, done) => {
+		const fileSystem = Volume.fromJSON({
+			"/a/index.js": "",
+		});
+
+		const resolver = ResolverFactory.createResolver({
+			// @ts-expect-error for tests
+			fileSystem,
+			extensions: [".js"],
+			profile: true,
+		});
+
+		const profiles = [];
+		resolver.resolve(
+			{},
+			"/a",
+			"./index",
+			{
+				profile: (data) => profiles.push(data),
+			},
+			(err, result) => {
+				assert.ifError(err);
+				assert.strictEqual(result, "/a/index.js");
+				assert.strictEqual(profiles.length, 1);
+				const [profile] = profiles;
+				assert.ok(typeof profile.duration === "number");
+				assert.ok(profile.duration >= 0);
+				assert.strictEqual(profile.success, true);
+				assert.strictEqual(profile.specifier, "./index");
+				assert.strictEqual(profile.parent, "/a");
+				assert.ok(profile.hooks instanceof Map);
+				assert.ok(profile.hooks.size > 0);
+				done();
+			},
+		);
+	});
+
+	it("should collect profile data for failed resolutions via factory callback", (t, done) => {
+		const fileSystem = Volume.fromJSON({
+			"/a/index.js": "",
+		});
+
+		const profiles = [];
+		const resolver = ResolverFactory.createResolver({
+			// @ts-expect-error for tests
+			fileSystem,
+			extensions: [".js"],
+			profile: (data) => profiles.push(data),
+		});
+
+		resolver.resolve({}, "/a", "./does-not-exist", {}, (_err, _result) => {
+			assert.strictEqual(profiles.length, 1);
+			const [profile] = profiles;
+			assert.strictEqual(profile.success, false);
+			assert.strictEqual(profile.result, null);
+			assert.ok(profile.duration >= 0);
+			done();
+		});
+	});
+
+	it("should report hook counts", (t, done) => {
+		const fileSystem = Volume.fromJSON({
+			"/a/index.js": "",
+		});
+
+		const resolver = ResolverFactory.createResolver({
+			// @ts-expect-error for tests
+			fileSystem,
+			extensions: [".js"],
+			profile: true,
+		});
+
+		const profiles = [];
+		resolver.resolve(
+			{},
+			"/a",
+			"./index",
+			{
+				profile: (data) => profiles.push(data),
+			},
+			(err) => {
+				assert.ifError(err);
+				const [profile] = profiles;
+				const { hooks } = profile;
+				const resolveHook = hooks.get("resolve");
+				assert.ok(resolveHook, "should have 'resolve' hook entry");
+				assert.ok(resolveHook.count >= 1);
+				const existingFile = hooks.get("existingFile");
+				assert.ok(existingFile, "should have 'existingFile' hook entry");
+				assert.ok(existingFile.count >= 1);
+				assert.ok(existingFile.totalTime >= 0);
+				done();
+			},
+		);
+	});
+
+	it("should work with multiple resolve calls", (t, done) => {
+		const fileSystem = Volume.fromJSON({
+			"/a/index.js": "",
+			"/a/lib/util.js": "",
+		});
+
+		const resolver = ResolverFactory.createResolver({
+			// @ts-expect-error for tests
+			fileSystem,
+			extensions: [".js"],
+			profile: true,
+		});
+
+		let callCount = 0;
+		resolver.resolve(
+			{},
+			"/a",
+			"./index",
+			{
+				profile: (data) => {
+					callCount++;
+					assert.ok(data.hooks.size > 0);
+				},
+			},
+			(err) => {
+				assert.ifError(err);
+				resolver.resolve(
+					{},
+					"/a",
+					"./lib/util",
+					{
+						profile: (data) => {
+							callCount++;
+							assert.ok(data.hooks.size > 0);
+						},
+					},
+					(err2) => {
+						assert.ifError(err2);
+						assert.strictEqual(callCount, 2);
+						done();
+					},
+				);
+			},
+		);
+	});
+
+	it("should work with profile callback in factory options", (t, done) => {
+		const fileSystem = Volume.fromJSON({
+			"/a/index.js": "",
+		});
+
+		const profiles = [];
+		const resolver = ResolverFactory.createResolver({
+			// @ts-expect-error for tests
+			fileSystem,
+			extensions: [".js"],
+			profile: (data) => profiles.push(data),
+		});
+
+		resolver.resolve({}, "/a", "./index", {}, (err) => {
+			assert.ifError(err);
+			assert.strictEqual(profiles.length, 1);
+			const [profile] = profiles;
+			assert.ok(profile.duration >= 0);
+			assert.strictEqual(profile.success, true);
+			done();
+		});
+	});
+
+	it("should log profile data when resolveContext.log is provided", (t, done) => {
+		const fileSystem = Volume.fromJSON({
+			"/a/index.js": "",
+		});
+
+		const resolver = ResolverFactory.createResolver({
+			// @ts-expect-error for tests
+			fileSystem,
+			extensions: [".js"],
+			profile: true,
+		});
+
+		const logs = [];
+		resolver.resolve(
+			{},
+			"/a",
+			"./index",
+			{
+				log: (msg) => logs.push(msg),
+				profile: () => {},
+			},
+			(err) => {
+				assert.ifError(err);
+				const profileLogs = logs.filter((m) => m.trim().startsWith("profile:"));
+				assert.ok(profileLogs.length > 0);
+				assert.ok(
+					profileLogs.some((m) => m.trim().startsWith("profile: resolved")),
+				);
+				done();
+			},
+		);
+	});
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -652,13 +652,7 @@ declare interface JoinCacheEntry {
 }
 declare interface JsonObject {
 	[index: string]:
-		| undefined
-		| null
-		| string
-		| number
-		| boolean
-		| JsonObject
-		| JsonValue[];
+		undefined | null | string | number | boolean | JsonObject | JsonValue[];
 }
 type JsonValue = null | string | number | boolean | JsonObject | JsonValue[];
 declare interface KnownContext {
@@ -855,13 +849,73 @@ declare interface PnpApi {
 		options: { considerBuiltins: boolean },
 	) => null | string;
 }
+declare interface ProfileData {
+	/**
+	 * when the resolve started (Date.now() epoch)
+	 */
+	startTime: number;
+
+	/**
+	 * when the resolve completed
+	 */
+	endTime: number;
+
+	/**
+	 * total duration in milliseconds
+	 */
+	duration: number;
+
+	/**
+	 * the request string that was resolved
+	 */
+	specifier: string;
+
+	/**
+	 * the parent path resolution started from
+	 */
+	parent: string;
+
+	/**
+	 * whether the resolution succeeded
+	 */
+	success: boolean;
+
+	/**
+	 * the resolved path, or null on failure
+	 */
+	result: null | string;
+
+	/**
+	 * per-hook profiling data
+	 */
+	hooks: Map<string, ProfileHookEntry>;
+}
+declare interface ProfileHookEntry {
+	/**
+	 * hook name
+	 */
+	name: string;
+
+	/**
+	 * number of times this hook was entered
+	 */
+	count: number;
+
+	/**
+	 * total wall-clock time in milliseconds
+	 */
+	totalTime: number;
+}
+declare class ProfilerPlugin {
+	constructor(profileCallback?: (profile: ProfileData) => void);
+	profileCallback?: (profile: ProfileData) => void;
+	apply(resolver: Resolver): void;
+}
 declare interface ReadFile {
 	(
 		path: PathOrFileDescriptor,
 		options:
-			| undefined
-			| null
-			| ({ encoding?: null; flag?: string } & Abortable),
+			undefined | null | ({ encoding?: null; flag?: string } & Abortable),
 		callback: (err: null | NodeJS.ErrnoException, result?: Buffer) => void,
 	): void;
 	(
@@ -1209,6 +1263,11 @@ declare interface ResolveContext {
 	 * yield result, if provided plugins can return several results
 	 */
 	yield?: (request: ResolveRequest) => void;
+
+	/**
+	 * profile callback — called with timing data when resolve completes
+	 */
+	profile?: (profile: ProfileData) => void;
 }
 declare interface ResolveFunction {
 	(
@@ -1428,6 +1487,11 @@ declare interface ResolveOptionsResolverFactoryObject_1 {
 	 * tsconfig file path or config object
 	 */
 	tsconfig: string | boolean | TsconfigOptions;
+
+	/**
+	 * enable resolution profiling
+	 */
+	profile: boolean | ((profile: ProfileData) => void);
 }
 declare interface ResolveOptionsResolverFactoryObject_2 {
 	/**
@@ -1524,9 +1588,7 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	 * A list of main fields in description files
 	 */
 	mainFields?: (
-		| string
-		| string[]
-		| { name: string | string[]; forceRelative: boolean }
+		string | string[] | { name: string | string[]; forceRelative: boolean }
 	)[];
 
 	/**
@@ -1583,6 +1645,11 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	 * TypeScript config file path (or `file:` `URL` instance) or config object with configFile and references
 	 */
 	tsconfig?: string | boolean | URL_url | UserTsconfigOptions;
+
+	/**
+	 * Enable resolution profiling, optionally with a callback to receive profile data
+	 */
+	profile?: boolean | ((profile: ProfileData) => void);
 }
 type ResolveRequest = BaseResolveRequest & Partial<ParsedIdentifier>;
 declare abstract class Resolver {
@@ -1943,10 +2010,7 @@ declare interface UserAliasOptionEntry {
 	onlyModule?: boolean;
 }
 type UserAliasOptionNewRequest =
-	| string
-	| false
-	| URL_url
-	| (string | URL_url)[];
+	string | false | URL_url | (string | URL_url)[];
 declare interface UserAliasOptions {
 	[index: string]: UserAliasOptionNewRequest;
 }
@@ -2040,6 +2104,7 @@ declare namespace exports {
 		CachedInputFileSystem,
 		CloneBasenamePlugin,
 		LogInfoPlugin,
+		ProfilerPlugin,
 		TsconfigPathsPlugin,
 		ResolveOptionsOptionalFS,
 		BaseFileSystem,


### PR DESCRIPTION
Implements the ProfilerPlugin that taps the resolveStep sync hook to record per-hook entry timestamps, maintains a frame stack for duration tracking, and delivers profile data via resolveContext.profile callback or factory-level profileCallback.

The \`profile\` option is added to ResolverFactory.createResolver options:
- \`profile: true\` enables profiling with per-call resolveContext.profile
- \`profile: (data) => {}\` enables profiling with a factory-level callback
- profile is propagated through createInnerContext for nested resolves

Changes:
- lib/ProfilerPlugin.js: new plugin with frame-stack timing
- lib/ResolverFactory.js: profile option + wiring
- lib/Resolver.js: profile field in ResolveContext typedef
- lib/createInnerContext.js: propagate profile to inner context
- lib/index.js: export ProfilerPlugin via lazy getter
- types.d.ts: ProfileData, ProfileHookEntry, ProfilerPlugin types
- test/profiler.test.js: 6 tests covering all delivery paths
