### PR TITLE
fix: resolve tsconfig extends packages from ancestor node_modules

### DIFF
--- a/.changeset/tsconfig-extends-node-modules-hoisting.md
+++ b/.changeset/tsconfig-extends-node-modules-hoisting.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Resolve tsconfig `extends` package specifiers from ancestor node_modules directories (workspace hoisting).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
           rm -f package-lock.json
           npm config set progress false
           npm install -g npm@7
-          npm install -D jest@^27 memfs@^3 --ignore-scripts --no-audit --prefer-offline --no-save --no-package-lock
+          npm install -D jest@^27 memfs@^3 --ignore-scripts --no-audit --no-save --no-package-lock
 
       - name: Install dependencies
         if: matrix.node-version != '10.x' && matrix.node-version != '12.x' && matrix.node-version != '14.x' && matrix.node-version != '16.x'

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -624,47 +624,10 @@ module.exports = class TsconfigPathsPlugin {
 			extendedConfigValue,
 		);
 
-		fileSystem.stat(initialExtendedConfigPath, (existsErr) => {
-			let extendedConfigPath = initialExtendedConfigPath;
-			if (existsErr) {
-				// Handle scoped package extends like "@scope/name" (no sub-path):
-				// "@scope/name" should resolve to node_modules/@scope/name/tsconfig.json,
-				// not node_modules/@scope/name.json
-				// See: test/fixtures/tsconfig-paths/extends-pkg-entry/
-				if (
-					typeof originalExtendedConfigValue === "string" &&
-					originalExtendedConfigValue.startsWith("@") &&
-					originalExtendedConfigValue.split("/").length === 2
-				) {
-					extendedConfigPath = resolver.join(
-						currentDir,
-						normalize(
-							`node_modules/${originalExtendedConfigValue}/${DEFAULT_CONFIG_FILE}`,
-						),
-					);
-				} else if (extendedConfigValue.includes("/")) {
-					// Handle package sub-path extends like "react/tsconfig":
-					// "react/tsconfig" resolves to node_modules/react/tsconfig.json
-					// See: test/fixtures/tsconfig-paths/extends-npm/
-					extendedConfigPath = resolver.join(
-						currentDir,
-						normalize(`node_modules/${extendedConfigValue}`),
-					);
-				} else if (
-					!originalExtendedConfigValue.startsWith(".") &&
-					!originalExtendedConfigValue.startsWith("/")
-				) {
-					// Handle unscoped package extends like "my-base-config" (no sub-path):
-					// "my-base-config" should resolve to node_modules/my-base-config/tsconfig.json
-					extendedConfigPath = resolver.join(
-						currentDir,
-						normalize(
-							`node_modules/${originalExtendedConfigValue}/${DEFAULT_CONFIG_FILE}`,
-						),
-					);
-				}
-			}
-
+		/**
+		 * @param {string} extendedConfigPath resolved config path to load
+		 */
+		const loadExtended = (extendedConfigPath) => {
 			this._loadTsconfig(
 				resolver,
 				extendedConfigPath,
@@ -692,7 +655,79 @@ module.exports = class TsconfigPathsPlugin {
 					callback(null, cfg);
 				},
 			);
+		};
+
+		fileSystem.stat(initialExtendedConfigPath, (existsErr) => {
+			if (!existsErr) return loadExtended(initialExtendedConfigPath);
+
+			// The relative form does not exist — treat the value as a package
+			// specifier and compute its `node_modules/<...>` sub-path.
+			let nodeModulesSubPath = null;
+			if (
+				typeof originalExtendedConfigValue === "string" &&
+				originalExtendedConfigValue.startsWith("@") &&
+				originalExtendedConfigValue.split("/").length === 2
+			) {
+				// Scoped package, no sub-path ("@scope/name") →
+				// node_modules/@scope/name/tsconfig.json (not @scope/name.json).
+				// See: test/fixtures/tsconfig-paths/extends-pkg-entry/
+				nodeModulesSubPath = `${originalExtendedConfigValue}/${DEFAULT_CONFIG_FILE}`;
+			} else if (extendedConfigValue.includes("/")) {
+				// Package sub-path ("react/tsconfig", "@scope/name/tsconfig") →
+				// node_modules/react/tsconfig.json.
+				// See: test/fixtures/tsconfig-paths/extends-npm/
+				nodeModulesSubPath = extendedConfigValue;
+			} else if (
+				!originalExtendedConfigValue.startsWith(".") &&
+				!originalExtendedConfigValue.startsWith("/")
+			) {
+				// Unscoped package, no sub-path ("my-base-config") →
+				// node_modules/my-base-config/tsconfig.json.
+				nodeModulesSubPath = `${originalExtendedConfigValue}/${DEFAULT_CONFIG_FILE}`;
+			}
+
+			// Not a package specifier (relative/absolute) — load the missing
+			// path anyway so the read surfaces its own ENOENT.
+			if (nodeModulesSubPath === null) {
+				return loadExtended(initialExtendedConfigPath);
+			}
+
+			// Walk ancestor node_modules like Node.js/TypeScript so a package
+			// hoisted to a parent workspace directory is found. #21457
+			const subPath = normalize(`node_modules/${nodeModulesSubPath}`);
+			this._findExtendsInNodeModules(resolver, currentDir, subPath, (found) => {
+				loadExtended(found || resolver.join(currentDir, subPath));
+			});
 		});
+	}
+
+	/**
+	 * Walk up from startDir looking for `<dir>/<subPath>` (a
+	 * `node_modules/...` sub-path), matching Node.js module resolution so a
+	 * package hoisted to a parent workspace's node_modules is found.
+	 * @param {Resolver} resolver the resolver
+	 * @param {string} startDir directory to start searching from
+	 * @param {string} subPath node_modules-relative sub-path to look for
+	 * @param {(found: string | null) => void} callback receives the found path or null
+	 * @returns {void}
+	 */
+	_findExtendsInNodeModules(resolver, startDir, subPath, callback) {
+		const { fileSystem } = resolver;
+
+		/**
+		 * @param {string} dir current directory
+		 */
+		const check = (dir) => {
+			const candidate = resolver.join(dir, subPath);
+			fileSystem.stat(candidate, (statErr) => {
+				if (!statErr) return callback(candidate);
+				const parentDir = resolver.dirname(dir);
+				if (parentDir === dir) return callback(null);
+				check(parentDir);
+			});
+		};
+
+		check(startDir);
 	}
 
 	/**

--- a/test/fixtures/tsconfig-paths/extends-missing-relative/src/y.ts
+++ b/test/fixtures/tsconfig-paths/extends-missing-relative/src/y.ts
@@ -1,0 +1,1 @@
+export const y = "y";

--- a/test/fixtures/tsconfig-paths/extends-missing-relative/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/extends-missing-relative/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": ".missing-base",
+  "compilerOptions": {
+    "paths": {
+      "@x/*": ["./src/*"]
+    }
+  }
+}

--- a/test/fixtures/tsconfig-paths/extends-npm-workspace/node_modules/@my-tsconfig/base/package.json
+++ b/test/fixtures/tsconfig-paths/extends-npm-workspace/node_modules/@my-tsconfig/base/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@my-tsconfig/base",
+  "version": "1.0.0",
+  "main": "tsconfig.json"
+}

--- a/test/fixtures/tsconfig-paths/extends-npm-workspace/node_modules/@my-tsconfig/base/src/util.ts
+++ b/test/fixtures/tsconfig-paths/extends-npm-workspace/node_modules/@my-tsconfig/base/src/util.ts
@@ -1,0 +1,1 @@
+export const util = "util";

--- a/test/fixtures/tsconfig-paths/extends-npm-workspace/node_modules/@my-tsconfig/base/tsconfig.node.json
+++ b/test/fixtures/tsconfig-paths/extends-npm-workspace/node_modules/@my-tsconfig/base/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@pkg/*": ["./src/*"]
+    }
+  }
+}

--- a/test/fixtures/tsconfig-paths/extends-npm-workspace/packages/app/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/extends-npm-workspace/packages/app/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@my-tsconfig/base/tsconfig.node"
+}

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -1650,6 +1650,31 @@ describe("TsconfigPathsPlugin", () => {
 		});
 	});
 
+	describe("extends a non-existent dot-prefixed value (not a package specifier)", () => {
+		const missingRelativeDir = path.resolve(
+			__dirname,
+			"fixtures",
+			"tsconfig-paths",
+			"extends-missing-relative",
+		);
+
+		it("surfaces the load error instead of searching node_modules", (t, done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: path.join(missingRelativeDir, "tsconfig.json"),
+			});
+
+			resolver.resolve({}, missingRelativeDir, "@x/y", {}, (err, result) => {
+				assert.ok(err instanceof Error);
+				assert.strictEqual(result, undefined);
+				done();
+			});
+		});
+	});
+
 	describe("bug: npm package in extends field hoisted to a parent node_modules (#21457)", () => {
 		it("should resolve a scoped package extends from a parent workspace node_modules", (t, done) => {
 			const appDir = path.join(extendsNpmWorkspaceDir, "packages", "app");

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -53,6 +53,12 @@ const extendsUnscopedPkgDir = path.resolve(
 	"tsconfig-paths",
 	"extends-unscoped-pkg",
 );
+const extendsNpmWorkspaceDir = path.resolve(
+	__dirname,
+	"fixtures",
+	"tsconfig-paths",
+	"extends-npm-workspace",
+);
 
 describe("TsconfigPathsPlugin", () => {
 	it("resolves exact mapped path '@components/*' via tsconfig option (example)", (t, done) => {
@@ -1641,6 +1647,36 @@ describe("TsconfigPathsPlugin", () => {
 					done();
 				},
 			);
+		});
+	});
+
+	describe("bug: npm package in extends field hoisted to a parent node_modules (#21457)", () => {
+		it("should resolve a scoped package extends from a parent workspace node_modules", (t, done) => {
+			const appDir = path.join(extendsNpmWorkspaceDir, "packages", "app");
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: path.join(appDir, "tsconfig.json"),
+			});
+
+			resolver.resolve({}, appDir, "@pkg/util", {}, (err, result) => {
+				if (err) return done(err);
+				if (!result) return done(new Error("No result"));
+				assert.deepStrictEqual(
+					result,
+					path.join(
+						extendsNpmWorkspaceDir,
+						"node_modules",
+						"@my-tsconfig",
+						"base",
+						"src",
+						"util.ts",
+					),
+				);
+				done();
+			});
 		});
 	});
 });

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -1658,19 +1658,18 @@ describe("TsconfigPathsPlugin", () => {
 			"extends-missing-relative",
 		);
 
-		it("surfaces the load error instead of searching node_modules", (t, done) => {
+		it("surfaces the load error instead of searching node_modules", () => {
 			const resolver = ResolverFactory.createResolver({
 				fileSystem,
 				extensions: [".ts", ".tsx"],
 				mainFields: ["browser", "main"],
 				mainFiles: ["index"],
 				tsconfig: path.join(missingRelativeDir, "tsconfig.json"),
+				useSyncFileSystemCalls: true,
 			});
 
-			resolver.resolve({}, missingRelativeDir, "@x/y", {}, (err, result) => {
-				assert.ok(err instanceof Error);
-				assert.strictEqual(result, undefined);
-				done();
+			assert.throws(() => {
+				resolver.resolveSync({}, missingRelativeDir, "@x/y");
 			});
 		});
 	});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

A tsconfig `extends` package specifier was only looked up in the config file's own `node_modules`, so a shared config hoisted to a parent workspace's `node_modules` failed to resolve. `_loadTsconfigFromExtends` now walks up ancestor directories like Node.js/TypeScript module resolution. Fixes webpack/webpack#21457.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — a regression test and `extends-npm-workspace` fixture in `test/tsconfig-paths.test.js` covering a scoped package extends hoisted to a parent `node_modules`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to locate the faulty `node_modules` lookup, implement the ancestor-directory walk, and write the regression test; all changes were reviewed by a human.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PL88GL3z2br6o4KDTQumVH)_