### PR TITLE
fix(RestrictionsPlugin): accept a restriction ending with a separator

### DIFF
--- a/.changeset/restrictions-path-separator-escape.md
+++ b/.changeset/restrictions-path-separator-escape.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Stop a filename containing a backslash from escaping a string `restrictions` entry on posix, by only accepting the platform separator as a segment boundary.

--- a/.changeset/restrictions-trailing-separator.md
+++ b/.changeset/restrictions-trailing-separator.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Accept a string `restrictions` entry that ends with a path separator, which previously rejected everything inside it.

--- a/lib/RestrictionsPlugin.js
+++ b/lib/RestrictionsPlugin.js
@@ -5,11 +5,12 @@
 
 "use strict";
 
+const { sep } = require("path");
+
 /** @typedef {import("./Resolver")} Resolver */
 /** @typedef {import("./Resolver").ResolveStepHook} ResolveStepHook */
 
-const slashCode = "/".charCodeAt(0);
-const backslashCode = "\\".charCodeAt(0);
+const sepCode = sep.charCodeAt(0);
 
 /**
  * @param {string} path path
@@ -19,8 +20,7 @@ const backslashCode = "\\".charCodeAt(0);
 const isInside = (path, parent) => {
 	if (!path.startsWith(parent)) return false;
 	if (path.length === parent.length) return true;
-	const charCode = path.charCodeAt(parent.length);
-	return charCode === slashCode || charCode === backslashCode;
+	return path.charCodeAt(parent.length) === sepCode;
 };
 
 module.exports = class RestrictionsPlugin {

--- a/lib/RestrictionsPlugin.js
+++ b/lib/RestrictionsPlugin.js
@@ -20,7 +20,10 @@ const sepCode = sep.charCodeAt(0);
 const isInside = (path, parent) => {
 	if (!path.startsWith(parent)) return false;
 	if (path.length === parent.length) return true;
-	return path.charCodeAt(parent.length) === sepCode;
+	return (
+		parent.charCodeAt(parent.length - 1) === sepCode ||
+		path.charCodeAt(parent.length) === sepCode
+	);
 };
 
 module.exports = class RestrictionsPlugin {

--- a/lib/util/path-browser.js
+++ b/lib/util/path-browser.js
@@ -5,8 +5,9 @@
 "use strict";
 
 // A browser shim for the Node `path` builtin, exposing only the subset used by
-// `lib/util/path.js`: `posix.normalize`, `posix.dirname`, `win32.normalize`,
-// `win32.dirname` and a (posix) `basename`. It is a faithful port of Node's
+// `lib/util/path.js` and `lib/RestrictionsPlugin.js`: `posix.normalize`,
+// `posix.dirname`, `win32.normalize`, `win32.dirname`, a (posix) `basename`
+// and `sep`. It is a faithful port of Node's
 // `path` implementation and is wired in through the package `browser` field, so
 // Node, Deno and Bun keep using their native `path` and only browser bundles
 // use this. Inputs are always strings here, so Node's `validateString` guards
@@ -402,6 +403,8 @@ function basename(path, suffix) {
 
 module.exports = {
 	basename,
+	// A browser has no host platform, and its paths are posix-like
+	sep: "/",
 	posix: { normalize: posixNormalize, dirname: posixDirname },
 	win32: { normalize: win32Normalize, dirname: win32Dirname },
 };

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -11,6 +11,32 @@ const { after, describe, it } = require("./_runner");
 const fixture = path.resolve(__dirname, "fixtures", "restrictions");
 const nodeFileSystem = new CachedInputFileSystem(fs, 4000);
 
+const isWindows = process.platform === "win32";
+const describeOnPosix = isWindows ? describe.skip : describe;
+const describeOnWindows = isWindows ? describe : describe.skip;
+
+const createFileSystem = (files) => {
+	const existing = new Set(files);
+	const enoent = (file) => {
+		const err = /** @type {NodeJS.ErrnoException} */ (
+			new Error(`ENOENT: no such file or directory, '${file}'`)
+		);
+		err.code = "ENOENT";
+		throw err;
+	};
+	const fileSystem = {
+		statSync: (file) =>
+			existing.has(file)
+				? { isFile: () => true, isDirectory: () => false }
+				: enoent(file),
+		lstatSync: (file) => fileSystem.statSync(file),
+		readFileSync: enoent,
+		readdirSync: enoent,
+		readlinkSync: enoent,
+	};
+	return fileSystem;
+};
+
 describe("restrictions", () => {
 	it("should respect RegExp restriction", (t, done) => {
 		const resolver = ResolverFactory.createResolver({
@@ -56,6 +82,42 @@ describe("restrictions", () => {
 			if (!err) return done(new Error(`expect error, got ${result}`));
 			assert.ok(err instanceof Error);
 			done();
+		});
+	});
+
+	describeOnPosix("on posix", () => {
+		it("should not treat a backslash as a path separator", (t, done) => {
+			const resolver = ResolverFactory.createResolver({
+				extensions: [".js"],
+				useSyncFileSystemCalls: true,
+				// @ts-expect-error for test
+				fileSystem: createFileSystem(["/a/b/c\\sibling.js"]),
+				restrictions: ["/a/b/c"],
+			});
+
+			resolver.resolve({}, "/a/b", "./c\\sibling.js", {}, (err, result) => {
+				if (!err) return done(new Error(`expect error, got ${result}`));
+				assert.ok(err instanceof Error);
+				done();
+			});
+		});
+	});
+
+	describeOnWindows("on windows", () => {
+		it("should treat a backslash as a path separator", (t, done) => {
+			const resolver = ResolverFactory.createResolver({
+				extensions: [".js"],
+				useSyncFileSystemCalls: true,
+				// @ts-expect-error for test
+				fileSystem: createFileSystem(["C:\\a\\b\\c\\index.js"]),
+				restrictions: ["C:\\a\\b\\c"],
+			});
+
+			resolver.resolve({}, "C:\\a\\b\\c", "./index.js", {}, (err, result) => {
+				if (err) return done(err);
+				assert.deepStrictEqual(result, "C:\\a\\b\\c\\index.js");
+				done();
+			});
 		});
 	});
 

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -85,6 +85,24 @@ describe("restrictions", () => {
 		});
 	});
 
+	it("should respect string restriction ending with a separator", (t, done) => {
+		const resolver = ResolverFactory.createResolver({
+			extensions: [".js"],
+			fileSystem: nodeFileSystem,
+			restrictions: [fixture + path.sep],
+		});
+
+		resolver.resolve({}, fixture, "pck1", {}, (err, result) => {
+			if (err) return done(err);
+			if (!result) return done(new Error("No result"));
+			assert.deepStrictEqual(
+				result,
+				path.resolve(fixture, "node_modules/pck1/index.js"),
+			);
+			done();
+		});
+	});
+
 	describeOnPosix("on posix", () => {
 		it("should not treat a backslash as a path separator", (t, done) => {
 			const resolver = ResolverFactory.createResolver({


### PR DESCRIPTION
> Stacked on #639 — its commit is included here because a cross-fork PR cannot use another fork branch as its base. Only the second commit belongs to this PR.

## Why

A string restriction that ends with a separator rejects everything inside it.

`isInside` checks the character *after* the restriction for a separator, which assumes the restriction does not end with one. With `restrictions: ["/a/b/c/"]` and the path `/a/b/c/index.js`, that character is `i` — the first character of the filename — so the file is reported as outside the restriction and resolution fails.

| restriction | request | before | after |
| --- | --- | --- | --- |
| `/a/b/c` | `/a/b/c/index.js` | allowed | allowed |
| `/a/b/c/` | `/a/b/c/index.js` | **rejected** | allowed |

A restriction already ending with a separator carries its own boundary, so `startsWith` is enough.