### PR TITLE
fix: keep the original request resolvable when extensionAlias lists its own extension

### DIFF
--- a/.changeset/010-extension-alias-original-request-fallback.md
+++ b/.changeset/010-extension-alias-original-request-fallback.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Keep the original request resolvable when `extensionAlias` lists its own extension.

--- a/lib/ExtensionAliasPlugin.js
+++ b/lib/ExtensionAliasPlugin.js
@@ -114,6 +114,14 @@ module.exports = class ExtensionAliasPlugin {
 				const stoppingCallback = (err, result) => {
 					if (err) return callback(err);
 					if (result) return callback(null, result);
+					// Listing the source extension among its own aliases keeps the
+					// original request valid, so it must still be resolvable in its
+					// normal (not fully specified) form: as a directory, or with
+					// extensions appended. Only a mapping that drops the source
+					// extension is strict.
+					if (isAliasString ? alias === extension : alias.includes(extension)) {
+						return callback();
+					}
 					// Don't allow other aliasing or raw request
 					return callback(null, null);
 				};

--- a/test/extension-alias.test.js
+++ b/test/extension-alias.test.js
@@ -67,6 +67,52 @@ describe("extension-alias", () => {
 		});
 	});
 
+	describe("fallback to the original request", () => {
+		it("should resolve a directory whose name ends with the aliased extension", (t, done) => {
+			resolver.resolve({}, fixture, "./dir3.js", {}, (err, result) => {
+				if (err) return done(err);
+				assert.deepStrictEqual(
+					result,
+					path.resolve(fixture, "dir3.js", "index.js"),
+				);
+				done();
+			});
+		});
+
+		it("should resolve a package whose name ends with the aliased extension behind an alias", (t, done) => {
+			const aliasResolver = ResolverFactory.createResolver({
+				extensions: [".js"],
+				fileSystem: nodeFileSystem,
+				mainFields: ["main"],
+				mainFiles: ["index"],
+				modules: ["node_modules"],
+				alias: { vendor: path.resolve(fixture, "node_modules") },
+				extensionAlias: { ".js": [".ts", ".js"] },
+			});
+			aliasResolver.resolve({}, fixture, "vendor/pkg.js", {}, (err, result) => {
+				if (err) return done(err);
+				assert.deepStrictEqual(
+					result,
+					path.resolve(fixture, "node_modules", "pkg.js", "dist", "main.js"),
+				);
+				done();
+			});
+		});
+
+		it("should not fall back when the original extension is not an alias", (t, done) => {
+			const strictResolver = ResolverFactory.createResolver({
+				extensions: [".js"],
+				fileSystem: nodeFileSystem,
+				mainFiles: ["index.js"],
+				extensionAlias: { ".js": [".ts"] },
+			});
+			strictResolver.resolve({}, fixture, "./dir3.js", {}, (err, _result) => {
+				assert.ok(err instanceof Error);
+				done();
+			});
+		});
+	});
+
 	it("should try multiple extension aliases in order and logs each failure", (t, done) => {
 		const resolver = ResolverFactory.createResolver({
 			fileSystem: nodeFileSystem,

--- a/test/fixtures/extension-alias/dir3.js/index.js
+++ b/test/fixtures/extension-alias/dir3.js/index.js
@@ -1,0 +1,1 @@
+module.exports = "dir3.js/index.js";

--- a/test/fixtures/extension-alias/node_modules/pkg.js/dist/main.js
+++ b/test/fixtures/extension-alias/node_modules/pkg.js/dist/main.js
@@ -1,0 +1,1 @@
+module.exports = "pkg.js";

--- a/test/fixtures/extension-alias/node_modules/pkg.js/package.json
+++ b/test/fixtures/extension-alias/node_modules/pkg.js/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pkg.js",
+  "version": "1.0.0",
+  "main": "dist/main.js"
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`ExtensionAliasPlugin` marks every candidate `fullySpecified: true` and then refuses to fall back, so a request ending in an aliased extension can only ever resolve as an exact file — never as a directory or via `package.json#main`. With the source extension listed among its own aliases (`{ ".js": [".js", ".ts"] }` — the documented TypeScript recipe, and what `experiments.typescript` sets in webpack) that entry is meant to keep the original request valid, but it is tried fully specified too, so any package or directory whose name ends in `.js` becomes unreachable. This makes the identity entry mean what it says: after the fully specified candidates fail, fall through to normal resolution. A mapping that drops the source extension (`{ ".js": [".ts"] }`, `{ ".mjs": ".mts" }`) stays strict.

Refs webpack/webpack#21541. That regression is fixed on the webpack side in webpack/webpack#21542 and does not need this; this closes the same failure for projects that genuinely enable TypeScript today, and ahead of TypeScript becoming a default.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes — three cases in `test/extension-alias.test.js` (directory named `dir3.js`, an aliased absolute path to a `pkg.js` package, and a strict mapping that must keep failing) plus the matching fixtures.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No — it only turns previously failing resolutions into successes; exact-file candidates are still tried first, so nothing that resolves today resolves differently.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

`extensionAlias` docs should say that listing an extension among its own aliases keeps the original request resolvable in its normal form, while omitting it makes the mapping strict.

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

AI (Claude Code) was used to trace the failure, draft the fix and tests, and verify them; the diagnosis and the final diff were reviewed by a human before submitting.

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->
