### PR TITLE
fix: correct string `restrictions` path boundary checks

### DIFF
--- a/.changeset/restrictions-path-boundaries.md
+++ b/.changeset/restrictions-path-boundaries.md
@@ -2,4 +2,4 @@
 "enhanced-resolve": patch
 ---
 
-Fix string `restrictions` boundary checks: a restriction ending with a separator no longer rejects everything inside it, restrictions are normalized before they are compared, and a Windows restriction now matches the way `path.win32` does, treating `/` and `\` as interchangeable and comparing case-insensitively, while `\` stays a filename character in a posix path.
+Fix string `restrictions` boundary checks: a restriction ending with a separator no longer rejects everything inside it, restrictions are normalized before they are compared, and a Windows path now matches the way `path.win32` does, treating `/` and `\` as interchangeable and comparing case-insensitively, while `\` stays a filename character in a posix path. The same comparison backs `tsconfig` path matching.

--- a/.changeset/restrictions-path-boundaries.md
+++ b/.changeset/restrictions-path-boundaries.md
@@ -2,4 +2,4 @@
 "enhanced-resolve": patch
 ---
 
-Fix string `restrictions` boundary checks: a restriction ending with a separator no longer rejects everything inside it, `\` is only a separator in Windows paths, and restrictions are normalized before they are compared.
+Fix string `restrictions` boundary checks: a restriction ending with a separator no longer rejects everything inside it, `\` is only a separator in Windows paths, where `/` and `\` are interchangeable, and restrictions are normalized before they are compared.

--- a/.changeset/restrictions-path-boundaries.md
+++ b/.changeset/restrictions-path-boundaries.md
@@ -2,4 +2,4 @@
 "enhanced-resolve": patch
 ---
 
-Fix string `restrictions` boundary checks: a restriction ending with a separator no longer rejects everything inside it, `\` is only a separator in Windows paths, where `/` and `\` are interchangeable, and restrictions are normalized before they are compared.
+Fix string `restrictions` boundary checks: a restriction ending with a separator no longer rejects everything inside it, restrictions are normalized before they are compared, and a Windows restriction now matches the way `path.win32` does, treating `/` and `\` as interchangeable and comparing case-insensitively, while `\` stays a filename character in a posix path.

--- a/.changeset/restrictions-path-boundaries.md
+++ b/.changeset/restrictions-path-boundaries.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Fix string `restrictions` boundary checks: a restriction ending with a separator no longer rejects everything inside it, `\` is only a separator in Windows paths, and restrictions are normalized before they are compared.

--- a/lib/RestrictionsPlugin.js
+++ b/lib/RestrictionsPlugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { PathType, getType, normalize } = require("./util/path");
+const { posix, win32 } = require("path");
 
 /** @typedef {import("./Resolver")} Resolver */
 /** @typedef {import("./Resolver").ResolveStepHook} ResolveStepHook */
@@ -13,8 +13,10 @@ const { PathType, getType, normalize } = require("./util/path");
 /**
  * @typedef {object} PathRestriction
  * @property {"path"} type type of the restriction
- * @property {string} rule normalized path the request has to be inside of
- * @property {boolean} windowsStyle whether `\` separates segments in `rule`
+ * @property {string} rule normalized restriction, used for logging
+ * @property {string} parent `rule` without a trailing separator
+ * @property {string} parentLower lowercased `parent`
+ * @property {boolean} windowsStyle whether `parent` is a Windows path
  */
 
 /**
@@ -27,18 +29,34 @@ const { PathType, getType, normalize } = require("./util/path");
 
 const slashCode = "/".charCodeAt(0);
 const backslashCode = "\\".charCodeAt(0);
+const colonCode = ":".charCodeAt(0);
+const upperACode = "A".charCodeAt(0);
+const upperZCode = "Z".charCodeAt(0);
+const lowerACode = "a".charCodeAt(0);
+const lowerZCode = "z".charCodeAt(0);
 
 /**
- * Whether `\` separates segments in this path, which is true for Windows paths
- * (`C:\a`, `\\server\share`) and false elsewhere, where `\` is an ordinary
- * filename character. The flavor comes from the path itself and never from the
- * host: this package normalizes and joins Windows paths on posix (and runs in
- * browsers), so `path.sep` would be the wrong signal here.
+ * Whether this is a Windows path, in which `/` and `\` are interchangeable and
+ * comparison is case-insensitive, as opposed to a posix path, in which `\` is
+ * an ordinary filename character. Decided by the root — a drive letter or a
+ * leading `\` — which is where `path.win32` and `path.posix` disagree about
+ * `parse(path).root`, and never by the host platform, since this package
+ * resolves Windows paths on posix hosts and runs in browsers. A path starting
+ * with `//` stays posix: `path.win32` reads it as a UNC root, but here it is
+ * indistinguishable from a posix path, where `\` has to keep being a filename
+ * character.
  * @param {string} path path
- * @returns {boolean} true, when `\` separates segments
+ * @returns {boolean} true, when the path is a Windows path
  */
-const isWindowsStyle = (path) =>
-	path.includes("\\") || getType(path) === PathType.AbsoluteWin;
+const isWindowsPath = (path) => {
+	const charCode = path.charCodeAt(0);
+	if (charCode === backslashCode) return true;
+	if (path.charCodeAt(1) !== colonCode) return false;
+	return (
+		(charCode >= upperACode && charCode <= upperZCode) ||
+		(charCode >= lowerACode && charCode <= lowerZCode)
+	);
+};
 
 /**
  * @param {number} charCode char code
@@ -49,9 +67,17 @@ const isSeparator = (charCode, windowsStyle) =>
 	charCode === slashCode || (windowsStyle && charCode === backslashCode);
 
 /**
- * Windows accepts `/` and `\` interchangeably and mixed within one path, so
- * `C:\a\b`, `C:/a/b` and `C:\a/b` all name the same directory and must all
- * match each other. Elsewhere only an exact prefix is a prefix.
+ * @param {string} path path
+ * @param {boolean} windowsStyle whether `\` separates segments in `path`
+ * @returns {string} path without its trailing separators
+ */
+const trimTrailingSeparators = (path, windowsStyle) => {
+	let end = path.length;
+	while (end > 0 && isSeparator(path.charCodeAt(end - 1), windowsStyle)) end--;
+	return end === path.length ? path : path.slice(0, end);
+};
+
+/**
  * @param {string} path path
  * @param {string} parent parent path
  * @param {boolean} windowsStyle whether `\` separates segments in `parent`
@@ -59,6 +85,8 @@ const isSeparator = (charCode, windowsStyle) =>
  */
 const startsWithPath = (path, parent, windowsStyle) => {
 	if (path.startsWith(parent)) return true;
+	// Windows mixes both separators freely, so `C:\a\b`, `C:/a/b` and `C:\a/b`
+	// all name the same directory
 	if (!windowsStyle || path.length < parent.length) return false;
 	for (let i = 0; i < parent.length; i++) {
 		const charCode = path.charCodeAt(i);
@@ -73,21 +101,31 @@ const startsWithPath = (path, parent, windowsStyle) => {
 
 /**
  * @param {string} path path
- * @param {string} parent parent path
+ * @param {string} parent parent path without a trailing separator
  * @param {boolean} windowsStyle whether `\` separates segments in `parent`
  * @returns {boolean} true, if path is inside of parent
  */
 const isInside = (path, parent, windowsStyle) => {
 	if (!startsWithPath(path, parent, windowsStyle)) return false;
-	if (path.length === parent.length) return true;
-	// A parent ending with a separator (`/`, `/a/b/`, `C:\`) already ends at a
-	// segment boundary, otherwise the next character has to be that boundary so
-	// that `/a/b` does not contain the sibling `/a/b-other`.
-	if (isSeparator(parent.charCodeAt(parent.length - 1), windowsStyle)) {
-		return true;
-	}
-	return isSeparator(path.charCodeAt(parent.length), windowsStyle);
+	// the restricted directory itself, or a segment boundary right after it, so
+	// that `/a/b` does not contain the sibling `/a/b-other`
+	return (
+		path.length === parent.length ||
+		isSeparator(path.charCodeAt(parent.length), windowsStyle)
+	);
 };
+
+/**
+ * @param {string} path path
+ * @param {PathRestriction} restriction restriction
+ * @returns {boolean} true, if path is inside of the restriction
+ */
+const isInsideRestriction = (path, restriction) =>
+	isInside(path, restriction.parent, restriction.windowsStyle) ||
+	// Windows compares paths case-insensitively, like `path.win32` does. Only
+	// reached when the exact comparison already failed.
+	(restriction.windowsStyle &&
+		isInside(path.toLowerCase(), restriction.parentLower, true));
 
 module.exports = class RestrictionsPlugin {
 	/**
@@ -97,17 +135,22 @@ module.exports = class RestrictionsPlugin {
 	constructor(source, restrictions) {
 		this.source = source;
 		this.restrictions = restrictions;
-		// Restrictions never change, so normalizing them into the shape requests
+		// Restrictions never change, so bringing them into the shape requests
 		// arrive in is done once here instead of on every request.
 		/** @type {Restriction[]} */
 		this._restrictions = [];
 		for (const rule of restrictions) {
 			if (typeof rule === "string") {
-				const path = normalize(rule);
+				const windowsStyle = isWindowsPath(rule);
+				const normalized =
+					rule === "" ? rule : (windowsStyle ? win32 : posix).normalize(rule);
+				const parent = trimTrailingSeparators(normalized, windowsStyle);
 				this._restrictions.push({
 					type: "path",
-					rule: path,
-					windowsStyle: isWindowsStyle(path),
+					rule: normalized,
+					parent,
+					parentLower: parent.toLowerCase(),
+					windowsStyle,
 				});
 			} else {
 				this._restrictions.push({ type: "regexp", rule });
@@ -127,9 +170,7 @@ module.exports = class RestrictionsPlugin {
 					const { path } = request;
 					for (const restriction of this._restrictions) {
 						if (restriction.type === "path") {
-							if (isInside(path, restriction.rule, restriction.windowsStyle)) {
-								continue;
-							}
+							if (isInsideRestriction(path, restriction)) continue;
 							if (resolveContext.log) {
 								resolveContext.log(
 									`${path} is not inside of the restriction ${restriction.rule}`,

--- a/lib/RestrictionsPlugin.js
+++ b/lib/RestrictionsPlugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { posix, win32 } = require("path");
+const { isInside, normalize } = require("./util/path");
 
 /** @typedef {import("./Resolver")} Resolver */
 /** @typedef {import("./Resolver").ResolveStepHook} ResolveStepHook */
@@ -13,10 +13,7 @@ const { posix, win32 } = require("path");
 /**
  * @typedef {object} PathRestriction
  * @property {"path"} type type of the restriction
- * @property {string} rule normalized restriction, used for logging
- * @property {string} parent `rule` without a trailing separator
- * @property {string} parentLower lowercased `parent`
- * @property {boolean} windowsStyle whether `parent` is a Windows path
+ * @property {string} rule normalized path the request has to be inside of
  */
 
 /**
@@ -26,106 +23,6 @@ const { posix, win32 } = require("path");
  */
 
 /** @typedef {PathRestriction | RegExpRestriction} Restriction */
-
-const slashCode = "/".charCodeAt(0);
-const backslashCode = "\\".charCodeAt(0);
-const colonCode = ":".charCodeAt(0);
-const upperACode = "A".charCodeAt(0);
-const upperZCode = "Z".charCodeAt(0);
-const lowerACode = "a".charCodeAt(0);
-const lowerZCode = "z".charCodeAt(0);
-
-/**
- * Whether this is a Windows path, in which `/` and `\` are interchangeable and
- * comparison is case-insensitive, as opposed to a posix path, in which `\` is
- * an ordinary filename character. Decided by the root — a drive letter or a
- * leading `\` — which is where `path.win32` and `path.posix` disagree about
- * `parse(path).root`, and never by the host platform, since this package
- * resolves Windows paths on posix hosts and runs in browsers. A path starting
- * with `//` stays posix: `path.win32` reads it as a UNC root, but here it is
- * indistinguishable from a posix path, where `\` has to keep being a filename
- * character.
- * @param {string} path path
- * @returns {boolean} true, when the path is a Windows path
- */
-const isWindowsPath = (path) => {
-	const charCode = path.charCodeAt(0);
-	if (charCode === backslashCode) return true;
-	if (path.charCodeAt(1) !== colonCode) return false;
-	return (
-		(charCode >= upperACode && charCode <= upperZCode) ||
-		(charCode >= lowerACode && charCode <= lowerZCode)
-	);
-};
-
-/**
- * @param {number} charCode char code
- * @param {boolean} windowsStyle whether `\` separates segments
- * @returns {boolean} true, when the char code separates path segments
- */
-const isSeparator = (charCode, windowsStyle) =>
-	charCode === slashCode || (windowsStyle && charCode === backslashCode);
-
-/**
- * @param {string} path path
- * @param {boolean} windowsStyle whether `\` separates segments in `path`
- * @returns {string} path without its trailing separators
- */
-const trimTrailingSeparators = (path, windowsStyle) => {
-	let end = path.length;
-	while (end > 0 && isSeparator(path.charCodeAt(end - 1), windowsStyle)) end--;
-	return end === path.length ? path : path.slice(0, end);
-};
-
-/**
- * @param {string} path path
- * @param {string} parent parent path
- * @param {boolean} windowsStyle whether `\` separates segments in `parent`
- * @returns {boolean} true, if path starts with parent
- */
-const startsWithPath = (path, parent, windowsStyle) => {
-	if (path.startsWith(parent)) return true;
-	// Windows mixes both separators freely, so `C:\a\b`, `C:/a/b` and `C:\a/b`
-	// all name the same directory
-	if (!windowsStyle || path.length < parent.length) return false;
-	for (let i = 0; i < parent.length; i++) {
-		const charCode = path.charCodeAt(i);
-		const parentCharCode = parent.charCodeAt(i);
-		if (charCode === parentCharCode) continue;
-		if (!isSeparator(charCode, true) || !isSeparator(parentCharCode, true)) {
-			return false;
-		}
-	}
-	return true;
-};
-
-/**
- * @param {string} path path
- * @param {string} parent parent path without a trailing separator
- * @param {boolean} windowsStyle whether `\` separates segments in `parent`
- * @returns {boolean} true, if path is inside of parent
- */
-const isInside = (path, parent, windowsStyle) => {
-	if (!startsWithPath(path, parent, windowsStyle)) return false;
-	// the restricted directory itself, or a segment boundary right after it, so
-	// that `/a/b` does not contain the sibling `/a/b-other`
-	return (
-		path.length === parent.length ||
-		isSeparator(path.charCodeAt(parent.length), windowsStyle)
-	);
-};
-
-/**
- * @param {string} path path
- * @param {PathRestriction} restriction restriction
- * @returns {boolean} true, if path is inside of the restriction
- */
-const isInsideRestriction = (path, restriction) =>
-	isInside(path, restriction.parent, restriction.windowsStyle) ||
-	// Windows compares paths case-insensitively, like `path.win32` does. Only
-	// reached when the exact comparison already failed.
-	(restriction.windowsStyle &&
-		isInside(path.toLowerCase(), restriction.parentLower, true));
 
 module.exports = class RestrictionsPlugin {
 	/**
@@ -140,21 +37,11 @@ module.exports = class RestrictionsPlugin {
 		/** @type {Restriction[]} */
 		this._restrictions = [];
 		for (const rule of restrictions) {
-			if (typeof rule === "string") {
-				const windowsStyle = isWindowsPath(rule);
-				const normalized =
-					rule === "" ? rule : (windowsStyle ? win32 : posix).normalize(rule);
-				const parent = trimTrailingSeparators(normalized, windowsStyle);
-				this._restrictions.push({
-					type: "path",
-					rule: normalized,
-					parent,
-					parentLower: parent.toLowerCase(),
-					windowsStyle,
-				});
-			} else {
-				this._restrictions.push({ type: "regexp", rule });
-			}
+			this._restrictions.push(
+				typeof rule === "string"
+					? { type: "path", rule: normalize(rule) }
+					: { type: "regexp", rule },
+			);
 		}
 	}
 
@@ -170,7 +57,7 @@ module.exports = class RestrictionsPlugin {
 					const { path } = request;
 					for (const restriction of this._restrictions) {
 						if (restriction.type === "path") {
-							if (isInsideRestriction(path, restriction)) continue;
+							if (isInside(restriction.rule, path)) continue;
 							if (resolveContext.log) {
 								resolveContext.log(
 									`${path} is not inside of the restriction ${restriction.rule}`,

--- a/lib/RestrictionsPlugin.js
+++ b/lib/RestrictionsPlugin.js
@@ -49,13 +49,36 @@ const isSeparator = (charCode, windowsStyle) =>
 	charCode === slashCode || (windowsStyle && charCode === backslashCode);
 
 /**
+ * Windows accepts `/` and `\` interchangeably and mixed within one path, so
+ * `C:\a\b`, `C:/a/b` and `C:\a/b` all name the same directory and must all
+ * match each other. Elsewhere only an exact prefix is a prefix.
+ * @param {string} path path
+ * @param {string} parent parent path
+ * @param {boolean} windowsStyle whether `\` separates segments in `parent`
+ * @returns {boolean} true, if path starts with parent
+ */
+const startsWithPath = (path, parent, windowsStyle) => {
+	if (path.startsWith(parent)) return true;
+	if (!windowsStyle || path.length < parent.length) return false;
+	for (let i = 0; i < parent.length; i++) {
+		const charCode = path.charCodeAt(i);
+		const parentCharCode = parent.charCodeAt(i);
+		if (charCode === parentCharCode) continue;
+		if (!isSeparator(charCode, true) || !isSeparator(parentCharCode, true)) {
+			return false;
+		}
+	}
+	return true;
+};
+
+/**
  * @param {string} path path
  * @param {string} parent parent path
  * @param {boolean} windowsStyle whether `\` separates segments in `parent`
  * @returns {boolean} true, if path is inside of parent
  */
 const isInside = (path, parent, windowsStyle) => {
-	if (!path.startsWith(parent)) return false;
+	if (!startsWithPath(path, parent, windowsStyle)) return false;
 	if (path.length === parent.length) return true;
 	// A parent ending with a separator (`/`, `/a/b/`, `C:\`) already ends at a
 	// segment boundary, otherwise the next character has to be that boundary so

--- a/lib/RestrictionsPlugin.js
+++ b/lib/RestrictionsPlugin.js
@@ -5,22 +5,65 @@
 
 "use strict";
 
+const { PathType, getType, normalize } = require("./util/path");
+
 /** @typedef {import("./Resolver")} Resolver */
 /** @typedef {import("./Resolver").ResolveStepHook} ResolveStepHook */
+
+/**
+ * @typedef {object} PathRestriction
+ * @property {"path"} type type of the restriction
+ * @property {string} rule normalized path the request has to be inside of
+ * @property {boolean} windowsStyle whether `\` separates segments in `rule`
+ */
+
+/**
+ * @typedef {object} RegExpRestriction
+ * @property {"regexp"} type type of the restriction
+ * @property {RegExp} rule pattern the request has to match
+ */
+
+/** @typedef {PathRestriction | RegExpRestriction} Restriction */
 
 const slashCode = "/".charCodeAt(0);
 const backslashCode = "\\".charCodeAt(0);
 
 /**
+ * Whether `\` separates segments in this path, which is true for Windows paths
+ * (`C:\a`, `\\server\share`) and false elsewhere, where `\` is an ordinary
+ * filename character. The flavor comes from the path itself and never from the
+ * host: this package normalizes and joins Windows paths on posix (and runs in
+ * browsers), so `path.sep` would be the wrong signal here.
+ * @param {string} path path
+ * @returns {boolean} true, when `\` separates segments
+ */
+const isWindowsStyle = (path) =>
+	path.includes("\\") || getType(path) === PathType.AbsoluteWin;
+
+/**
+ * @param {number} charCode char code
+ * @param {boolean} windowsStyle whether `\` separates segments
+ * @returns {boolean} true, when the char code separates path segments
+ */
+const isSeparator = (charCode, windowsStyle) =>
+	charCode === slashCode || (windowsStyle && charCode === backslashCode);
+
+/**
  * @param {string} path path
  * @param {string} parent parent path
+ * @param {boolean} windowsStyle whether `\` separates segments in `parent`
  * @returns {boolean} true, if path is inside of parent
  */
-const isInside = (path, parent) => {
+const isInside = (path, parent, windowsStyle) => {
 	if (!path.startsWith(parent)) return false;
 	if (path.length === parent.length) return true;
-	const charCode = path.charCodeAt(parent.length);
-	return charCode === slashCode || charCode === backslashCode;
+	// A parent ending with a separator (`/`, `/a/b/`, `C:\`) already ends at a
+	// segment boundary, otherwise the next character has to be that boundary so
+	// that `/a/b` does not contain the sibling `/a/b-other`.
+	if (isSeparator(parent.charCodeAt(parent.length - 1), windowsStyle)) {
+		return true;
+	}
+	return isSeparator(path.charCodeAt(parent.length), windowsStyle);
 };
 
 module.exports = class RestrictionsPlugin {
@@ -31,6 +74,22 @@ module.exports = class RestrictionsPlugin {
 	constructor(source, restrictions) {
 		this.source = source;
 		this.restrictions = restrictions;
+		// Restrictions never change, so normalizing them into the shape requests
+		// arrive in is done once here instead of on every request.
+		/** @type {Restriction[]} */
+		this._restrictions = [];
+		for (const rule of restrictions) {
+			if (typeof rule === "string") {
+				const path = normalize(rule);
+				this._restrictions.push({
+					type: "path",
+					rule: path,
+					windowsStyle: isWindowsStyle(path),
+				});
+			} else {
+				this._restrictions.push({ type: "regexp", rule });
+			}
+		}
 	}
 
 	/**
@@ -43,32 +102,30 @@ module.exports = class RestrictionsPlugin {
 			.tapAsync("RestrictionsPlugin", (request, resolveContext, callback) => {
 				if (typeof request.path === "string") {
 					const { path } = request;
-					for (const rule of this.restrictions) {
-						if (typeof rule === "string") {
-							if (!isInside(path, rule)) {
-								if (resolveContext.log) {
-									resolveContext.log(
-										`${path} is not inside of the restriction ${rule}`,
-									);
-								}
-								// Target existed (FileExistsPlugin already passed) but is
-								// outside the jail; signal ExportsFieldPlugin to fall back.
-								if (request.__restrictionsMarker) {
-									request.__restrictionsMarker.blocked = true;
-								}
-								return callback(null, null);
+					for (const restriction of this._restrictions) {
+						if (restriction.type === "path") {
+							if (isInside(path, restriction.rule, restriction.windowsStyle)) {
+								continue;
 							}
-						} else if (!rule.test(path)) {
 							if (resolveContext.log) {
 								resolveContext.log(
-									`${path} doesn't match the restriction ${rule}`,
+									`${path} is not inside of the restriction ${restriction.rule}`,
 								);
 							}
-							if (request.__restrictionsMarker) {
-								request.__restrictionsMarker.blocked = true;
+						} else {
+							if (restriction.rule.test(path)) continue;
+							if (resolveContext.log) {
+								resolveContext.log(
+									`${path} doesn't match the restriction ${restriction.rule}`,
+								);
 							}
-							return callback(null, null);
 						}
+						// Target existed (FileExistsPlugin already passed) but is
+						// outside the jail; signal ExportsFieldPlugin to fall back.
+						if (request.__restrictionsMarker) {
+							request.__restrictionsMarker.blocked = true;
+						}
+						return callback(null, null);
 					}
 				}
 

--- a/lib/util/path.js
+++ b/lib/util/path.js
@@ -298,37 +298,140 @@ const isRelativeRequest = (request) => {
 };
 
 /**
- * Check if childPath is a subdirectory of parentPath.
+ * Whether this is a Windows path, in which `/` and `\` are interchangeable and
+ * paths compare case-insensitively, as opposed to a posix path, in which `\` is
+ * an ordinary filename character. Decided by the root — a drive letter or a
+ * leading `\` — which is where `path.win32` and `path.posix` disagree about
+ * `parse(maybePath).root`, and never by the host platform, since Windows paths
+ * are resolved on posix hosts and in browsers too. A path starting with `//`
+ * stays posix: `path.win32` reads it as a UNC root, but here it cannot be told
+ * apart from a posix path, where `\` has to keep being a filename character.
+ * @param {string} maybePath a path
+ * @returns {boolean} true, when the path is a Windows path
+ */
+const isWindowsPath = (maybePath) => {
+	const c0 = maybePath.charCodeAt(0);
+	if (c0 === CHAR_BACKSLASH) return true;
+	if (maybePath.charCodeAt(1) !== CHAR_COLON) return false;
+	return (
+		(c0 >= CHAR_A && c0 <= CHAR_Z) || (c0 >= CHAR_LOWER_A && c0 <= CHAR_LOWER_Z)
+	);
+};
+
+/**
+ * @param {number} charCode a char code
+ * @param {boolean} windowsPath whether `\` separates segments
+ * @returns {boolean} true, when the char code separates path segments
+ */
+const isSeparator = (charCode, windowsPath) =>
+	charCode === CHAR_SLASH || (windowsPath && charCode === CHAR_BACKSLASH);
+
+/**
+ * @param {string} parentPath parent directory path
+ * @param {boolean} windowsPath whether `parentPath` is a Windows path
+ * @returns {number} length of `parentPath` without its trailing separators
+ */
+const parentPathLength = (parentPath, windowsPath) => {
+	let end = parentPath.length;
+	while (end > 0 && isSeparator(parentPath.charCodeAt(end - 1), windowsPath)) {
+		end--;
+	}
+	return end;
+};
+
+/**
+ * Cold path of `startsWithPath`: Node lowercases whole paths rather than single
+ * characters, which only makes a difference outside of ASCII.
+ * @param {string} parentPath parent directory path
+ * @param {number} length number of characters to compare
+ * @param {string} childPath child path to check
+ * @returns {boolean} true, when both prefixes name the same Windows path
+ */
+const equalsWindowsPrefix = (parentPath, length, childPath) =>
+	childPath.slice(0, length).replace(/\//g, "\\").toLowerCase() ===
+	parentPath.slice(0, length).replace(/\//g, "\\").toLowerCase();
+
+/**
+ * @param {string} parentPath parent directory path
+ * @param {number} length number of characters of `parentPath` to compare
+ * @param {string} childPath child path to check
+ * @param {boolean} windowsPath whether `parentPath` is a Windows path
+ * @returns {boolean} true, when `childPath` starts with that prefix
+ */
+const startsWithPath = (parentPath, length, childPath, windowsPath) => {
+	if (childPath.length < length) return false;
+	// The common case is an exact prefix of a parent without trailing
+	// separators, which `startsWith` answers natively and without a slice. For
+	// a posix parent that is the whole answer, only a Windows one has more
+	// spellings of the same path to try.
+	if (length === parentPath.length) {
+		if (childPath.startsWith(parentPath)) return true;
+		if (!windowsPath) return false;
+	}
+	for (let i = 0; i < length; i++) {
+		const childCharCode = childPath.charCodeAt(i);
+		const parentCharCode = parentPath.charCodeAt(i);
+		if (childCharCode === parentCharCode) continue;
+		if (!windowsPath) return false;
+		// Windows mixes `/` and `\` freely and compares case-insensitively.
+		if (isSeparator(childCharCode, true) && isSeparator(parentCharCode, true)) {
+			continue;
+		}
+		if (childCharCode > 127 || parentCharCode > 127) {
+			return equalsWindowsPrefix(parentPath, length, childPath);
+		}
+		const childLower =
+			childCharCode >= CHAR_A && childCharCode <= CHAR_Z
+				? childCharCode + 32
+				: childCharCode;
+		const parentLower =
+			parentCharCode >= CHAR_A && parentCharCode <= CHAR_Z
+				? parentCharCode + 32
+				: parentCharCode;
+		if (childLower !== parentLower) return false;
+	}
+	return true;
+};
+
+/**
+ * Whether childPath is parentPath itself or a path under it, the answer node's
+ * `relative(parentPath, childPath)` gives: not escaping upward and not
+ * absolute. A trailing separator on the parent is not part of the boundary, so
+ * `/a/b/` contains exactly what `/a/b` contains.
+ * @param {string} parentPath parent directory path
+ * @param {string} childPath child path to check
+ * @returns {boolean} true if childPath is parentPath or is under it
+ */
+const isInside = (parentPath, childPath) => {
+	const windowsPath = isWindowsPath(parentPath);
+	const length = parentPathLength(parentPath, windowsPath);
+	if (!startsWithPath(parentPath, length, childPath, windowsPath)) return false;
+	// The parent itself, or a segment boundary right after it so that `/a/b`
+	// does not contain the sibling `/a/b-other`.
+	return (
+		childPath.length === length ||
+		isSeparator(childPath.charCodeAt(length), windowsPath)
+	);
+};
+
+/**
+ * Check if childPath is a subdirectory of parentPath. Compares like `isInside`,
+ * except that a path is not a subpath of itself.
  *
  * Called from `TsconfigPathsPlugin._selectPathsDataForContext` inside a loop
  * over every tsconfig-paths context on every resolve, so it's worth keeping
- * cheap. Compared to the previous `startsWith(normalize(parent + "/"))`
- * version, this: checks the last char with `charCodeAt` instead of two
- * `endsWith` calls; and skips `normalize()` entirely in the common case
- * (parent has no trailing separator), since all we really need is the same
- * anchoring effect — a cheap `startsWith` plus a separator char check on the
- * byte immediately after `parentPath.length`.
+ * cheap: a native `startsWith` plus a separator char check answers it, and the
+ * character loop only runs for a Windows path that the prefix test missed.
  * @param {string} parentPath parent directory path
  * @param {string} childPath child path to check
  * @returns {boolean} true if childPath is under parentPath
  */
 const isSubPath = (parentPath, childPath) => {
-	const parentLen = parentPath.length;
-	if (parentLen === 0) {
-		// Match the old `normalize("" + "/") === "/"` fallback: an empty
-		// parent only "contains" a child that starts with a forward slash.
-		return childPath.length > 0 && childPath.charCodeAt(0) === CHAR_SLASH;
-	}
-	const lastChar = parentPath.charCodeAt(parentLen - 1);
-	if (lastChar === CHAR_SLASH || lastChar === CHAR_BACKSLASH) {
-		// Parent already ends with a separator — a plain prefix test is enough.
-		return childPath.startsWith(parentPath);
-	}
-	if (childPath.length <= parentLen) return false;
-	if (!childPath.startsWith(parentPath)) return false;
-	// Must be followed by a separator so "/app" doesn't match "/app-other".
-	const nextChar = childPath.charCodeAt(parentLen);
-	return nextChar === CHAR_SLASH || nextChar === CHAR_BACKSLASH;
+	const windowsPath = isWindowsPath(parentPath);
+	const length = parentPathLength(parentPath, windowsPath);
+	if (childPath.length <= length) return false;
+	if (!startsWithPath(parentPath, length, childPath, windowsPath)) return false;
+	return isSeparator(childPath.charCodeAt(length), windowsPath);
 };
 
 /**
@@ -351,8 +454,10 @@ module.exports.deprecatedInvalidSegmentRegEx = deprecatedInvalidSegmentRegEx;
 module.exports.dirname = dirname;
 module.exports.getType = getType;
 module.exports.invalidSegmentRegEx = invalidSegmentRegEx;
+module.exports.isInside = isInside;
 module.exports.isRelativeRequest = isRelativeRequest;
 module.exports.isSubPath = isSubPath;
+module.exports.isWindowsPath = isWindowsPath;
 module.exports.join = join;
 module.exports.normalize = normalize;
 module.exports.toPath = toPath;

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -10,8 +10,10 @@ const {
 	dirname,
 	getType,
 	invalidSegmentRegEx,
+	isInside,
 	isRelativeRequest,
 	isSubPath,
+	isWindowsPath,
 	join,
 	normalize,
 } = require("../lib/util/path");
@@ -321,6 +323,88 @@ describe("util/path isSubPath", () => {
 		assert.strictEqual(isSubPath("", "C:\\a"), false);
 		assert.strictEqual(isSubPath("", "foo"), false);
 		assert.strictEqual(isSubPath("", ""), false);
+	});
+
+	it("compares a Windows parent the way windows does", () => {
+		assert.strictEqual(isSubPath("C:\\a\\b", "C:/a/b/c"), true);
+		assert.strictEqual(isSubPath("C:/a/b", "C:\\a\\b/c"), true);
+		assert.strictEqual(isSubPath("C:\\a\\b", "c:\\A\\B\\c"), true);
+		assert.strictEqual(isSubPath("C:\\a\\b", "C:\\a\\b-other"), false);
+	});
+
+	it("keeps a backslash a filename character in a posix parent", () => {
+		assert.strictEqual(isSubPath("/a/b", "/a/b\\c"), false);
+		assert.strictEqual(isSubPath("/a/b\\c", "/a/b\\c\\d"), false);
+		assert.strictEqual(isSubPath("/a/b", "/A/b/c"), false);
+	});
+});
+
+describe("util/path isWindowsPath", () => {
+	it("detects a path rooted at a drive letter", () => {
+		assert.strictEqual(isWindowsPath("C:\\a"), true);
+		assert.strictEqual(isWindowsPath("C:/a"), true);
+		assert.strictEqual(isWindowsPath("c:a"), true);
+		assert.strictEqual(isWindowsPath("C:"), true);
+	});
+
+	it("detects a path rooted at a backslash", () => {
+		assert.strictEqual(isWindowsPath("\\a\\b"), true);
+		assert.strictEqual(isWindowsPath("\\\\server\\share"), true);
+		assert.strictEqual(isWindowsPath("\\\\?\\C:\\a"), true);
+	});
+
+	it("treats everything else as posix", () => {
+		assert.strictEqual(isWindowsPath("/a/b"), false);
+		assert.strictEqual(isWindowsPath("/a/b\\c"), false);
+		assert.strictEqual(isWindowsPath("a\\b"), false);
+		assert.strictEqual(isWindowsPath("1:\\a"), false);
+		assert.strictEqual(isWindowsPath(""), false);
+	});
+
+	it("treats a path starting with // as posix", () => {
+		// `path.win32` reads it as a UNC root, but here it cannot be told apart
+		// from a posix path, where `\` has to stay a filename character.
+		assert.strictEqual(isWindowsPath("//server/share"), false);
+	});
+});
+
+describe("util/path isInside", () => {
+	it("returns true for the parent itself", () => {
+		assert.strictEqual(isInside("/a/b", "/a/b"), true);
+		assert.strictEqual(isInside("/a/b/", "/a/b"), true);
+		assert.strictEqual(isInside("C:\\a\\", "C:\\a"), true);
+	});
+
+	it("ignores trailing separators on the parent", () => {
+		assert.strictEqual(isInside("/a/b/", "/a/b/c"), true);
+		assert.strictEqual(isInside("/", "/a"), true);
+		assert.strictEqual(isInside("C:\\a\\b\\", "C:\\a\\b\\c"), true);
+	});
+
+	it("requires a segment boundary", () => {
+		assert.strictEqual(isInside("/a/b", "/a/b-other"), false);
+		assert.strictEqual(isInside("/a/b", "/a"), false);
+		assert.strictEqual(isInside("C:\\a\\b", "C:\\a\\b-other"), false);
+	});
+
+	it("compares a Windows parent the way windows does", () => {
+		assert.strictEqual(isInside("C:\\a\\b", "C:/a/b/c"), true);
+		assert.strictEqual(isInside("C:/a/b", "C:\\a\\b/c"), true);
+		assert.strictEqual(isInside("C:\\a\\b", "c:\\A\\B\\c"), true);
+		assert.strictEqual(
+			isInside("\\\\server\\share\\a", "\\\\SERVER\\share\\a\\b"),
+			true,
+		);
+		assert.strictEqual(
+			isInside("\\\\server\\share\\a", "\\\\server\\other\\a\\b"),
+			false,
+		);
+	});
+
+	it("keeps a backslash a filename character in a posix parent", () => {
+		assert.strictEqual(isInside("/a/b", "/a/b\\c"), false);
+		assert.strictEqual(isInside("/a/b\\c", "/a/b\\c\\d"), false);
+		assert.strictEqual(isInside("/a/b", "/A/B/c"), false);
 	});
 });
 

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -326,6 +326,22 @@ describe("restrictions", () => {
 				file: "C:\\a\\b\\c\\index.js",
 				allowed: true,
 			},
+			{
+				title: "a file inside a windows restriction differing in case",
+				restriction: "C:\\A\\B\\C",
+				context: "c:\\a\\b\\c",
+				request: "./index.js",
+				file: "c:\\a\\b\\c\\index.js",
+				allowed: true,
+			},
+			{
+				title: "a file inside a posix restriction differing in case",
+				restriction: "/A/B/C",
+				context: "/a/b/c",
+				request: "./index.js",
+				file: "/a/b/c/index.js",
+				allowed: false,
+			},
 		];
 
 		for (const {
@@ -359,10 +375,11 @@ describe("restrictions", () => {
 		}
 	});
 
-	describe("mixed separators", () => {
-		// Windows accepts `/` and `\` interchangeably and mixed within one path.
-		// The plugin is driven directly because the resolver normalizes a path
-		// before it reaches the plugin, so a mixed one cannot arrive through it.
+	describe("windows and posix semantics", () => {
+		// Windows accepts `/` and `\` interchangeably and mixed within one path,
+		// and compares case-insensitively; posix does neither. The plugin is
+		// driven directly because the resolver normalizes a path before it
+		// reaches the plugin, so those forms cannot arrive through it.
 		const testCases = [
 			{
 				title: "a windows path using slashes under a backslash restriction",
@@ -383,6 +400,36 @@ describe("restrictions", () => {
 				inside: true,
 			},
 			{
+				title: "a windows path differing in case from its restriction",
+				restriction: "C:\\a\\b\\c",
+				path: "c:\\A\\B\\C\\index.js",
+				inside: true,
+			},
+			{
+				title: "the restricted directory itself",
+				restriction: "/a/b/c/",
+				path: "/a/b/c",
+				inside: true,
+			},
+			{
+				title: "a path inside a UNC restriction",
+				restriction: "\\\\server\\share\\a",
+				path: "\\\\SERVER\\share\\a\\index.js",
+				inside: true,
+			},
+			{
+				title: "a path inside a DOS device restriction",
+				restriction: "\\\\?\\C:\\a",
+				path: "\\\\?\\C:\\a\\index.js",
+				inside: true,
+			},
+			{
+				title: "a path on another share than the UNC restriction",
+				restriction: "\\\\server\\share\\a",
+				path: "\\\\server\\other\\a\\index.js",
+				inside: false,
+			},
+			{
 				title: "a sibling of a windows restriction written with slashes",
 				restriction: "C:\\a\\b\\c",
 				path: "C:/a/b/c-other.js",
@@ -393,6 +440,20 @@ describe("restrictions", () => {
 				title: "a posix sibling separated by a backslash",
 				restriction: "/a/b/c",
 				path: "/a/b/c\\sibling.js",
+				inside: false,
+			},
+			{
+				// the restriction contains a backslash but is still a posix path,
+				// so the backslash names a directory instead of separating one
+				title: "a posix sibling of a restriction containing a backslash",
+				restriction: "/a/b\\c",
+				path: "/a/b\\c\\sibling.js",
+				inside: false,
+			},
+			{
+				title: "a posix path differing in case from its restriction",
+				restriction: "/a/b/c",
+				path: "/A/B/C/index.js",
 				inside: false,
 			},
 		];
@@ -414,6 +475,121 @@ describe("restrictions", () => {
 				});
 			});
 		}
+	});
+
+	describe("compared with node's path api", () => {
+		// Containment is Node's answer, not ours: a target is inside a parent
+		// when `relative(parent, target)` neither escapes upward nor is absolute.
+		// Which flavor answers is where `win32` and `posix` disagree about the
+		// root of the restriction.
+		const isWindowsPath = (maybePath) =>
+			path.win32.parse(maybePath).root !== path.posix.parse(maybePath).root;
+
+		const nodeSaysInside = (parent, target) => {
+			const flavor = isWindowsPath(parent) ? path.win32 : path.posix;
+			const relative = flavor.relative(parent, target);
+			return (
+				relative === "" ||
+				(!relative.startsWith("..") && !flavor.isAbsolute(relative))
+			);
+		};
+
+		const restrictions = [
+			"/a/b/c",
+			"/a/b/c/",
+			"/a/b\\c",
+			"/",
+			"C:\\a\\b\\c",
+			"C:\\a\\b\\c\\",
+			"C:/a/b/c",
+			"C:\\",
+			"\\\\server\\share\\a",
+			"\\\\?\\C:\\a",
+		];
+
+		const swapSeparators = (maybePath) =>
+			maybePath.replace(/[\\/]/g, (char) => (char === "/" ? "\\" : "/"));
+
+		const targetsFor = (restriction) => {
+			const separator = isWindowsPath(restriction) ? "\\" : "/";
+			const other = separator === "\\" ? "/" : "\\";
+			const trimmed = restriction.replace(/[\\/]+$/, "") || separator;
+			const targets = new Set();
+			for (const base of [
+				trimmed,
+				swapSeparators(trimmed),
+				trimmed.toUpperCase(),
+				trimmed.toLowerCase(),
+			]) {
+				for (const suffix of [
+					"",
+					`${separator}index.js`,
+					`${other}index.js`,
+					`${separator}sub${other}index.js`,
+					"-other.js",
+					"\\sibling.js",
+				]) {
+					targets.add(base + suffix);
+				}
+			}
+			for (const unrelated of [
+				"/unrelated/index.js",
+				"D:\\unrelated\\index.js",
+				"\\\\server\\other\\index.js",
+			]) {
+				targets.add(unrelated);
+			}
+			return [...targets];
+		};
+
+		let insideCount = 0;
+		let outsideCount = 0;
+
+		for (const restriction of restrictions) {
+			for (const target of targetsFor(restriction)) {
+				const flavor = isWindowsPath(restriction) ? path.win32 : path.posix;
+				// `relative` resolves a non-absolute input against `process.cwd()`,
+				// which says nothing about containment
+				if (!flavor.isAbsolute(restriction) || !flavor.isAbsolute(target)) {
+					continue;
+				}
+				// a `.`/`..` segment or a doubled separator never reaches the plugin,
+				// the resolver normalizes those away first - a mixed separator does
+				// survive on windows, so only the separators are canonicalized here
+				const canonical = isWindowsPath(restriction)
+					? target.replace(/\//g, "\\")
+					: target;
+				if (flavor.normalize(canonical) !== canonical) continue;
+
+				const inside = nodeSaysInside(restriction, target);
+				if (inside) {
+					insideCount++;
+				} else {
+					outsideCount++;
+				}
+
+				it(`should ${inside ? "allow" : "reject"} ${JSON.stringify(target)} under ${JSON.stringify(restriction)}`, (t, done) => {
+					const hook = new AsyncSeriesBailHook(["request", "resolveContext"]);
+
+					new RestrictionsPlugin(hook, new Set([restriction])).apply(
+						// @ts-expect-error a minimal resolver is enough for this plugin
+						{ getHook: () => hook },
+					);
+
+					hook.callAsync({ path: target }, {}, (err, result) => {
+						if (err) return done(err);
+						assert.strictEqual(result !== null, inside);
+						done();
+					});
+				});
+			}
+		}
+
+		it("should have compared both verdicts", () => {
+			// guards against a generator change quietly emptying the matrix above
+			assert.ok(insideCount > 50, `only ${insideCount} inside cases`);
+			assert.ok(outsideCount > 50, `only ${outsideCount} outside cases`);
+		});
 	});
 
 	describe("with symlinks", () => {

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -205,6 +205,150 @@ describe("restrictions", () => {
 		);
 	});
 
+	describe("path boundaries", () => {
+		// The resolver handles both path flavors on every host, so a fake
+		// filesystem is used to run the posix and the Windows cases everywhere.
+		const createFileSystem = (file) => {
+			const enoent = (requested) => {
+				const err = /** @type {NodeJS.ErrnoException} */ (
+					new Error(`ENOENT: no such file or directory, '${requested}'`)
+				);
+				err.code = "ENOENT";
+				throw err;
+			};
+			const fileSystem = {
+				statSync: (requested) =>
+					requested === file
+						? {
+								isFile: () => true,
+								isDirectory: () => false,
+								isSymbolicLink: () => false,
+							}
+						: enoent(requested),
+				lstatSync: (requested) => fileSystem.statSync(requested),
+				readFileSync: enoent,
+				readdirSync: enoent,
+				readlinkSync: enoent,
+			};
+			return fileSystem;
+		};
+
+		const testCases = [
+			{
+				title: "a file inside a posix restriction",
+				restriction: "/a/b/c",
+				context: "/a/b/c",
+				request: "./index.js",
+				file: "/a/b/c/index.js",
+				allowed: true,
+			},
+			{
+				title: "a sibling of a posix restriction",
+				restriction: "/a/b/c",
+				context: "/a/b",
+				request: "./c-other.js",
+				file: "/a/b/c-other.js",
+				allowed: false,
+			},
+			{
+				// `\` is a regular filename character on posix, so this file is a
+				// sibling of the restriction and not inside of it
+				title: "a sibling of a posix restriction separated by a backslash",
+				restriction: "/a/b/c",
+				context: "/a/b",
+				request: "./c\\sibling.js",
+				file: "/a/b/c\\sibling.js",
+				allowed: false,
+			},
+			{
+				title: "a file inside a posix restriction ending with a separator",
+				restriction: "/a/b/c/",
+				context: "/a/b/c",
+				request: "./index.js",
+				file: "/a/b/c/index.js",
+				allowed: true,
+			},
+			{
+				title: "a file inside the posix root restriction",
+				restriction: "/",
+				context: "/a",
+				request: "./index.js",
+				file: "/a/index.js",
+				allowed: true,
+			},
+			{
+				title: "a file inside a non-normalized posix restriction",
+				restriction: "/a/x/../b/c",
+				context: "/a/b/c",
+				request: "./index.js",
+				file: "/a/b/c/index.js",
+				allowed: true,
+			},
+			{
+				title: "a file inside a windows restriction",
+				restriction: "C:\\a\\b\\c",
+				context: "C:\\a\\b\\c",
+				request: "./index.js",
+				file: "C:\\a\\b\\c\\index.js",
+				allowed: true,
+			},
+			{
+				title: "a sibling of a windows restriction",
+				restriction: "C:\\a\\b\\c",
+				context: "C:\\a\\b",
+				request: "./c-other.js",
+				file: "C:\\a\\b\\c-other.js",
+				allowed: false,
+			},
+			{
+				title: "a file inside a windows restriction ending with a separator",
+				restriction: "C:\\a\\b\\c\\",
+				context: "C:\\a\\b\\c",
+				request: "./index.js",
+				file: "C:\\a\\b\\c\\index.js",
+				allowed: true,
+			},
+			{
+				title: "a file inside a windows restriction written with slashes",
+				restriction: "C:/a/b/c",
+				context: "C:\\a\\b\\c",
+				request: "./index.js",
+				file: "C:\\a\\b\\c\\index.js",
+				allowed: true,
+			},
+		];
+
+		for (const {
+			title,
+			restriction,
+			context,
+			request,
+			file,
+			allowed,
+		} of testCases) {
+			it(`should ${allowed ? "resolve" : "not resolve"} ${title}`, (t, done) => {
+				const resolver = ResolverFactory.createResolver({
+					extensions: [".js"],
+					useSyncFileSystemCalls: true,
+					// @ts-expect-error a minimal filesystem is enough for these cases
+					fileSystem: createFileSystem(file),
+					restrictions: [restriction],
+				});
+
+				resolver.resolve({}, context, request, {}, (err, result) => {
+					if (allowed) {
+						if (err) return done(err);
+						assert.deepStrictEqual(result, file);
+					} else {
+						if (!err) return done(new Error(`expect error, got ${result}`));
+						assert.ok(err instanceof Error);
+					}
+					done();
+				});
+			});
+		}
+	});
+
 	describe("with symlinks", () => {
 		const symlinkRoot = path.resolve(__dirname, "temp-restrictions-symlink");
 		const allowed = path.join(symlinkRoot, "allowed");

--- a/test/restrictions.test.js
+++ b/test/restrictions.test.js
@@ -4,8 +4,10 @@ const assert = require("assert");
 const fs = require("fs");
 
 const path = require("path");
+const { AsyncSeriesBailHook } = require("tapable");
 const CachedInputFileSystem = require("../lib/CachedInputFileSystem");
 const ResolverFactory = require("../lib/ResolverFactory");
+const RestrictionsPlugin = require("../lib/RestrictionsPlugin");
 const { after, describe, it } = require("./_runner");
 
 const fixture = path.resolve(__dirname, "fixtures", "restrictions");
@@ -316,6 +318,14 @@ describe("restrictions", () => {
 				file: "C:\\a\\b\\c\\index.js",
 				allowed: true,
 			},
+			{
+				title: "a file inside a windows restriction from a mixed context",
+				restriction: "C:\\a\\b\\c",
+				context: "C:/a\\b",
+				request: "./c/index.js",
+				file: "C:\\a\\b\\c\\index.js",
+				allowed: true,
+			},
 		];
 
 		for (const {
@@ -343,6 +353,63 @@ describe("restrictions", () => {
 						if (!err) return done(new Error(`expect error, got ${result}`));
 						assert.ok(err instanceof Error);
 					}
+					done();
+				});
+			});
+		}
+	});
+
+	describe("mixed separators", () => {
+		// Windows accepts `/` and `\` interchangeably and mixed within one path.
+		// The plugin is driven directly because the resolver normalizes a path
+		// before it reaches the plugin, so a mixed one cannot arrive through it.
+		const testCases = [
+			{
+				title: "a windows path using slashes under a backslash restriction",
+				restriction: "C:\\a\\b\\c",
+				path: "C:/a/b/c/index.js",
+				inside: true,
+			},
+			{
+				title: "a windows path mixing separators under a slash restriction",
+				restriction: "C:/a/b/c",
+				path: "C:\\a\\b/c/index.js",
+				inside: true,
+			},
+			{
+				title: "a windows path under a restriction ending with a slash",
+				restriction: "C:\\a\\b\\c/",
+				path: "C:\\a\\b\\c\\index.js",
+				inside: true,
+			},
+			{
+				title: "a sibling of a windows restriction written with slashes",
+				restriction: "C:\\a\\b\\c",
+				path: "C:/a/b/c-other.js",
+				inside: false,
+			},
+			{
+				// separators are never interchangeable outside of windows paths
+				title: "a posix sibling separated by a backslash",
+				restriction: "/a/b/c",
+				path: "/a/b/c\\sibling.js",
+				inside: false,
+			},
+		];
+
+		for (const { title, restriction, path: requestPath, inside } of testCases) {
+			it(`should ${inside ? "allow" : "reject"} ${title}`, (t, done) => {
+				const hook = new AsyncSeriesBailHook(["request", "resolveContext"]);
+
+				new RestrictionsPlugin(hook, new Set([restriction])).apply(
+					// @ts-expect-error a minimal resolver is enough for this plugin
+					{ getHook: () => hook },
+				);
+
+				hook.callAsync({ path: requestPath }, {}, (err, result) => {
+					if (err) return done(err);
+					// the plugin bails with `null` when it filters a request out
+					assert.strictEqual(result !== null, inside);
 					done();
 				});
 			});


### PR DESCRIPTION
**Summary**

`isInside` in `RestrictionsPlugin` decided containment with its own prefix rule, which disagrees with how `path.win32` and `path.posix` — and therefore Windows and posix — actually compare paths. `isSubPath` in `lib/util/path.js` had the same misalignments, so the comparison now lives there once, aligned with Node, and both call sites share it. Supersedes #639 and #640 (bugs reported by @stormslowly), which fix two of these cases but key the boundary off `path.sep` — the host platform is the wrong signal here, see below.

| restriction | path | before | after |
| --- | --- | --- | --- |
| `/a/b/c` | `/a/b/c\sibling.js` (posix sibling, `\` in the filename) | **allowed** | rejected |
| `/a/b/c/` | `/a/b/c/index.js` | **rejected** | allowed |
| `/a/b/c/` | `/a/b/c` (the restricted directory itself) | **rejected** | allowed |
| `/` | `/a/index.js` | **rejected** | allowed |
| `C:/a/b/c` | `C:\a\b\c\index.js` | **rejected** | allowed |
| `C:\a\b\c` | `C:\a\b/c/index.js` | **rejected** | allowed |
| `C:\a\b\c` | `c:\a\b\c\index.js` (differing drive-letter case) | **rejected** | allowed |
| `\\server\share\a` | `\\server\share\a\index.js` | **rejected** | allowed |

Windows treats `/` and `\` as interchangeable and mixed within one path, and compares case-insensitively — `path.win32.normalize`, `isAbsolute`, `dirname`, `resolve` and `relative` all agree — so `C:\a\b`, `C:/a/b` and `c:\A\B` name the same directory and now all match each other. Posix does neither, so `\` stays an ordinary filename character there, which is what keeps the escape closed.

**In `lib/util/path.js`:** `isWindowsPath` decides the flavor from the root — a drive letter or a leading `\`, which is exactly where `win32.parse` and `posix.parse` disagree about `root` — never from `process.platform`. This package resolves Windows paths on posix hosts and vice versa, and runs in browsers, Deno and Bun; deriving the separator from `path.sep` makes every path inside a `C:\…` restriction unresolvable on Linux, and every path inside a `/…` restriction unresolvable on Windows. Deciding by root rather than by "contains a backslash" also keeps a posix directory whose name contains `\` comparing correctly. `isInside` answers containment the way `relative(parent, child)` does — including the parent itself, and ignoring a trailing separator on it — and `isSubPath` keeps its stricter "not a subpath of itself" rule on top of the same comparison, so `TsconfigPathsPlugin` gets the alignment too. One deliberate divergence from `path.win32`: a path starting with `//` stays posix, since it is indistinguishable from a posix path here and `\` has to keep being a filename character in one.

`RestrictionsPlugin` imports from `./util/path` only — no direct `path` use, so the browser shim keeps covering it — and normalizes each restriction once in the constructor. The posix hot path costs what it did before (a native `startsWith` is the whole answer); the character loop only runs for a Windows path whose spelling differs in separators or case, and the whole-string lowercase only for non-ASCII, matching how Node folds case. Measured on the `isSubPath` shape `TsconfigPathsPlugin` calls in its per-resolve loop: posix unchanged, Windows about 17 ns/call slower on a miss. The duplicated log/marker/callback tail in `apply` is now shared by both restriction kinds.

Out of scope, worth a separate look: `getType` classifies plain UNC (`\\server\share`) as `Normal`, which is already flagged in its tests. That makes `normalize`, `join` and `dirname` treat UNC paths as posix — `join("\\\\server\\share\\a", "./index.js")` yields a mixed `\\server\share\a/index.js`, `..` segments are not collapsed, and `dirname("\\\\server\\share\\a\\b")` returns `"."`. The comparison here handles UNC correctly regardless, so fixing that is not needed for this change.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. `test/path.test.js` covers `isWindowsPath`, `isInside` and the newly aligned `isSubPath` behavior, alongside its existing cases, which all still hold. `test/restrictions.test.js` adds thirteen cases that run through the resolver on every host against a fake filesystem, precisely because the resolver is platform-agnostic, and twelve that drive the plugin directly for the forms the resolver normalizes away before they reach it. On top of those, a generated matrix asserts the plugin against Node's `relative()` verdict for every restriction/path pair, so the two cannot drift; pairs `relative()` cannot answer (a non-absolute input, which it resolves against `process.cwd()`) are skipped, and a guard fails if the matrix stops producing both verdicts.

**Does this PR introduce a breaking change?**

No. Paths that resolved before still resolve; a filename whose leading characters happen to match a restriction followed by `\` no longer escapes it on posix.

**If relevant, what needs to be documented once your changes are merged?**

n/a

**Use of AI**

Written with Claude Code. It reproduced each case against `main` first, wrote the failing tests before the fix, and checked the helpers against Node's `path` API over ~1000 restriction/path pairs, including mutation-testing that harness to confirm it catches each regression; I reviewed the result. `npm run lint`, `npm run test:only` and `npm run test:browser` all pass locally.