### PR TITLE
fix: route UNC paths through win32 instead of posix

### DIFF
--- a/.changeset/unc-paths-win32.md
+++ b/.changeset/unc-paths-win32.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Treat a UNC path (`\\server\share\…`) as a Windows path, so it normalizes, joins and walks up with `path.win32` semantics instead of being taken for a bare module request.

--- a/lib/util/path.js
+++ b/lib/util/path.js
@@ -17,7 +17,6 @@ const CHAR_LOWER_A = "a".charCodeAt(0);
 const CHAR_LOWER_Z = "z".charCodeAt(0);
 const CHAR_DOT = ".".charCodeAt(0);
 const CHAR_COLON = ":".charCodeAt(0);
-const CHAR_QUESTION = "?".charCodeAt(0);
 
 const posixNormalize = path.posix.normalize;
 const winNormalize = path.win32.normalize;
@@ -39,20 +38,6 @@ const deprecatedInvalidSegmentRegEx =
 
 const invalidSegmentRegEx =
 	/(^|\\|\/)((\.|%2e)(\.|%2e)?|(n|%6e|%4e)(o|%6f|%4f)(d|%64|%44)(e|%65|%45)(_|%5f)(m|%6d|%4d)(o|%6f|%4f)(d|%64|%44)(u|%75|%55)(l|%6c|%4c)(e|%65|%45)(s|%73|%53))?(\\|\/|$)/i;
-
-/**
- * @param {string} maybePath a path known to start with `\\`
- * @returns {PathType} AbsoluteWin for `\\?\…` / `\\.\…`, otherwise Normal
- */
-const getDosDeviceType = (maybePath) => {
-	if (maybePath.length >= 4 && maybePath.charCodeAt(3) === CHAR_BACKSLASH) {
-		const c2 = maybePath.charCodeAt(2);
-		if (c2 === CHAR_QUESTION || c2 === CHAR_DOT) {
-			return PathType.AbsoluteWin;
-		}
-	}
-	return PathType.Normal;
-};
 
 /**
  * @param {string} maybePath a path
@@ -99,6 +84,9 @@ const getType = (maybePath) => {
 			) {
 				return PathType.AbsoluteWin;
 			}
+			if (c0 === CHAR_BACKSLASH && c1 === CHAR_BACKSLASH) {
+				return PathType.AbsoluteWin;
+			}
 			return PathType.Normal;
 		}
 	}
@@ -133,12 +121,11 @@ const getType = (maybePath) => {
 			return PathType.AbsoluteWin;
 		}
 	}
-	// DOS device paths (`\\?\…`, `\\.\…`) are handled in a cold helper so
-	// this function stays small — inlining the full check here regressed
-	// `description-files-multi` under `--no-opt` interpretation. Here we
-	// only pay the two-byte gate for non-DOS inputs.
+	// Two leading backslashes root a UNC share (`\\server\share`) or a DOS
+	// device path (`\\?\…`, `\\.\…`); `path.win32` reads either as absolute,
+	// so both belong on `path.win32` and not on posix.
 	if (c0 === CHAR_BACKSLASH && c1 === CHAR_BACKSLASH) {
-		return getDosDeviceType(maybePath);
+		return PathType.AbsoluteWin;
 	}
 	return PathType.Normal;
 };

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const assert = require("assert");
+const nodePath = require("path");
 const {
 	PathType,
 	createCachedBasename,
@@ -398,5 +399,243 @@ describe("util/path join fallbacks for special rootPath types", () => {
 		// rootPath "#x" (Internal) and request "./foo" (Relative): returns
 		// posixNormalize(rootPath) ("#x"), not relative, so prefixed with "./".
 		assert.strictEqual(join("#x", "./foo"), "./#x");
+	});
+});
+
+// Node's own `path` is the reference for how a path behaves. These tests keep
+// `lib/util/path.js` answering the way `path.win32` and `path.posix` do, and
+// spell out every shape where it deliberately answers differently.
+describe("util/path alignment with node's path module", () => {
+	// Which flavor node reads a path as: the two parsers disagree about the
+	// root exactly when the path is Windows-specific.
+	const nodeReadsAsWindows = (maybePath) =>
+		nodePath.win32.parse(maybePath).root !==
+		nodePath.posix.parse(maybePath).root;
+
+	const nodeFlavor = (maybePath) =>
+		nodeReadsAsWindows(maybePath) ? nodePath.win32 : nodePath.posix;
+
+	// The shapes we answer differently on purpose, each asserted on its own in
+	// "documented divergences" below.
+	const isDocumentedDivergence = (maybePath) => {
+		// a leading forward slash is a posix root however the next separator is
+		// spelled, while `path.win32` reads two separators as a UNC root
+		if (maybePath.startsWith("//") || maybePath.startsWith("/\\")) return true;
+		// a single leading backslash roots a path only on windows
+		if (maybePath.startsWith("\\") && !maybePath.startsWith("\\\\")) {
+			return true;
+		}
+		// drive-relative (`C:foo`), which node roots but does not call absolute
+		if (/^[a-zA-Z]:[^\\/]/.test(maybePath)) return true;
+		// requests the resolver handles with its own semantics
+		const type = getType(maybePath);
+		return (
+			type === PathType.Relative ||
+			type === PathType.Empty ||
+			type === PathType.Internal
+		);
+	};
+
+	const requests = ["b", "./b", "../b", "b/c"];
+
+	const assertMatchesNode = (maybePath) => {
+		const flavor = nodeFlavor(maybePath);
+		const subject = JSON.stringify(maybePath);
+		assert.strictEqual(
+			getType(maybePath) === PathType.AbsoluteWin,
+			nodeReadsAsWindows(maybePath),
+			`flavor of ${subject}`,
+		);
+		assert.strictEqual(
+			normalize(maybePath),
+			flavor.normalize(maybePath),
+			`normalize(${subject})`,
+		);
+		assert.strictEqual(
+			dirname(maybePath),
+			flavor.dirname(maybePath),
+			`dirname(${subject})`,
+		);
+		for (const request of requests) {
+			assert.strictEqual(
+				join(maybePath, request),
+				flavor.join(maybePath, request),
+				`join(${subject}, ${JSON.stringify(request)})`,
+			);
+		}
+	};
+
+	const paths = [
+		// posix
+		"/",
+		"/a",
+		"/a/b/c",
+		"/a/b/c/",
+		"/a//b",
+		"/a/./b",
+		"/a/../b",
+		"/a/b\\c",
+		"/a/b c/d",
+		// windows drive
+		"C:",
+		"c:",
+		"C:\\",
+		"C:\\a",
+		"C:\\a\\b",
+		"C:/a/b",
+		"C:\\a/b",
+		"C:\\a\\..\\b",
+		"C:\\a\\.\\b",
+		"C:\\a\\\\b",
+		"C:\\a\\b\\",
+		"c:\\a",
+		// UNC
+		"\\\\server\\share",
+		"\\\\server\\share\\",
+		"\\\\server\\share\\a",
+		"\\\\server\\share\\a\\b",
+		"\\\\server\\share\\a\\..\\b",
+		"\\\\server\\share\\a\\.\\b",
+		"\\\\server\\share\\\\a",
+		"\\\\server\\share\\a/b",
+		"\\\\SERVER\\Share\\a",
+		// DOS device
+		"\\\\?\\C:\\a",
+		"\\\\?\\C:\\a\\..\\b",
+		"\\\\?\\UNC\\server\\share\\a",
+		"\\\\.\\C:\\a",
+		"\\\\.\\PhysicalDrive0",
+		"\\\\?\\Volume{abc}\\f",
+		"\\\\?\\",
+		"\\\\",
+		"\\\\?",
+		"\\\\.",
+		"\\\\a",
+		// module requests
+		"lodash",
+		"@scope/pkg",
+		"a",
+	];
+
+	for (const maybePath of paths) {
+		it(`answers like node for ${JSON.stringify(maybePath)}`, () => {
+			// a path listed here must not be one we diverge on
+			assert.strictEqual(
+				isDocumentedDivergence(maybePath),
+				false,
+				`${JSON.stringify(maybePath)} is a documented divergence`,
+			);
+			assertMatchesNode(maybePath);
+		});
+	}
+
+	it("answers like node for generated path shapes", () => {
+		// Seeded so a failure reproduces, and wide enough to reach shapes
+		// nobody enumerated by hand.
+		let seed = 42;
+		const random = (max) => {
+			seed = (seed + 0x6d2b79f5) | 0;
+			let t = seed;
+			t = Math.imul(t ^ (t >>> 15), t | 1);
+			t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+			return ((((t ^ (t >>> 14)) >>> 0) / 4294967296) * max) | 0;
+		};
+		const prefixes = [
+			"",
+			"/",
+			"//",
+			"\\",
+			"\\\\",
+			"C:\\",
+			"C:/",
+			"c:",
+			"\\\\server\\share\\",
+			"\\\\server\\share",
+			"\\\\?\\C:\\",
+			"\\\\.\\C:\\",
+			"\\\\?\\UNC\\server\\share\\",
+			"./",
+			"../",
+			"#",
+		];
+		const segments = [
+			"a",
+			"b",
+			"..",
+			".",
+			"sub dir",
+			"x.js",
+			"",
+			"node_modules",
+		];
+		const separators = ["/", "\\"];
+		const makePath = () => {
+			let result = prefixes[random(prefixes.length)];
+			const count = random(5);
+			for (let i = 0; i < count; i++) {
+				if (i > 0) result += separators[random(separators.length)];
+				result += segments[random(segments.length)];
+			}
+			if (random(4) === 0) result += separators[random(separators.length)];
+			return result;
+		};
+
+		let compared = 0;
+		for (let i = 0; i < 5000; i++) {
+			const maybePath = makePath();
+			if (isDocumentedDivergence(maybePath)) continue;
+			assertMatchesNode(maybePath);
+			compared++;
+		}
+		// guards against a generator change quietly emptying this
+		assert.ok(compared > 1000, `only ${compared} shapes compared`);
+	});
+
+	describe("documented divergences", () => {
+		it("reads a leading forward slash as a posix root", () => {
+			for (const maybePath of [
+				"//server/share",
+				"/\\server\\share",
+				"//?/C:/foo",
+			]) {
+				assert.strictEqual(getType(maybePath), PathType.AbsolutePosix);
+				// node takes any two leading separators for a UNC root
+				assert.strictEqual(nodeReadsAsWindows(maybePath), true);
+			}
+		});
+
+		it("keeps a single leading backslash a filename character", () => {
+			// rooted on windows, an ordinary character everywhere else, and
+			// nothing in the string tells the two apart
+			for (const maybePath of ["\\a\\b", "\\", "\\?\\C:\\foo"]) {
+				assert.notStrictEqual(getType(maybePath), PathType.AbsoluteWin);
+				assert.strictEqual(nodeReadsAsWindows(maybePath), true);
+			}
+		});
+
+		it("keeps a drive-relative path normal", () => {
+			// node roots `C:foo` at `C:` but does not call it absolute, and
+			// `PathType` has no windows-relative member — classifying it as
+			// `AbsoluteWin` would make `join` drop the root it is relative to
+			assert.strictEqual(getType("C:foo"), PathType.Normal);
+			assert.strictEqual(nodePath.win32.parse("C:foo").root, "C:");
+			assert.strictEqual(nodePath.win32.isAbsolute("C:foo"), false);
+		});
+
+		it("keeps the ./ prefix of a relative request", () => {
+			assert.strictEqual(normalize("./a/b"), "./a/b");
+			assert.strictEqual(nodePath.posix.normalize("./a/b"), "a/b");
+		});
+
+		it("keeps an empty path empty", () => {
+			assert.strictEqual(normalize(""), "");
+			assert.strictEqual(nodePath.posix.normalize(""), ".");
+		});
+
+		it("keeps an internal request out of path handling", () => {
+			assert.strictEqual(getType("#a/b"), PathType.Internal);
+			assert.strictEqual(join("#x", "foo"), "#x");
+			assert.strictEqual(nodePath.posix.join("#x", "foo"), "#x/foo");
+		});
 	});
 });

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -75,18 +75,26 @@ describe("util/path getType", () => {
 		assert.strictEqual(getType("\\\\.\\"), PathType.AbsoluteWin);
 	});
 
-	it("does not classify non-DOS backslash paths as Windows-absolute", () => {
-		// Plain UNC (\\server\share) is not a DOS device path — don't
-		// misclassify it (its handling is out of scope of this change).
-		assert.strictEqual(getType("\\\\server\\share"), PathType.Normal);
-		// Too short to match a DOS device prefix.
-		assert.strictEqual(getType("\\\\?"), PathType.Normal);
-		assert.strictEqual(getType("\\\\."), PathType.Normal);
-		// Second char must also be a backslash.
+	it("classifies UNC paths as Windows-absolute", () => {
+		// `path.win32` roots every path starting with two backslashes, so a
+		// share belongs on win32 just like a DOS device path does.
+		assert.strictEqual(getType("\\\\server\\share"), PathType.AbsoluteWin);
+		assert.strictEqual(getType("\\\\server\\share\\a"), PathType.AbsoluteWin);
+		// Too short to name a share, still rooted.
+		assert.strictEqual(getType("\\\\"), PathType.AbsoluteWin);
+		assert.strictEqual(getType("\\\\?"), PathType.AbsoluteWin);
+		assert.strictEqual(getType("\\\\."), PathType.AbsoluteWin);
+	});
+
+	it("does not classify other backslash paths as Windows-absolute", () => {
+		// A single leading backslash is a rooted path only on Windows, and a
+		// filename character everywhere else — too ambiguous to reroute.
 		assert.strictEqual(getType("\\?\\C:\\foo"), PathType.Normal);
+		assert.strictEqual(getType("\\a\\b"), PathType.Normal);
 		// Forward-slash variants aren't equivalent — Windows won't normalize
-		// a DOS device path expressed with `/`.
+		// a DOS device path expressed with `/`, and `//a/b` is a posix path.
 		assert.strictEqual(getType("//?/C:/foo"), PathType.AbsolutePosix);
+		assert.strictEqual(getType("//server/share"), PathType.AbsolutePosix);
 	});
 });
 
@@ -110,6 +118,17 @@ describe("util/path normalize", () => {
 
 	it("normalizes normal paths through posix normalize", () => {
 		assert.strictEqual(normalize("a/b/../c"), "a/c");
+	});
+
+	it("normalizes UNC paths via win32", () => {
+		assert.strictEqual(
+			normalize("\\\\server\\share\\a\\..\\b"),
+			"\\\\server\\share\\b",
+		);
+		assert.strictEqual(
+			normalize("\\\\server\\share\\\\a"),
+			"\\\\server\\share\\a",
+		);
 	});
 
 	it("normalizes DOS device paths via win32", () => {
@@ -146,6 +165,18 @@ describe("util/path join", () => {
 		assert.strictEqual(join("C:\\a", "b"), "C:\\a\\b");
 	});
 
+	it("joins UNC paths with win32 semantics", () => {
+		assert.strictEqual(
+			join("\\\\server\\share\\a", "b"),
+			"\\\\server\\share\\a\\b",
+		);
+		// Absolute UNC request wins over any root.
+		assert.strictEqual(
+			join("/posix/root", "\\\\server\\share\\a"),
+			"\\\\server\\share\\a",
+		);
+	});
+
 	it("joins DOS device paths with win32 semantics", () => {
 		assert.strictEqual(join("\\\\?\\C:\\a", "b"), "\\\\?\\C:\\a\\b");
 		assert.strictEqual(join("\\\\.\\C:\\a", "b"), "\\\\.\\C:\\a\\b");
@@ -162,6 +193,15 @@ describe("util/path dirname", () => {
 
 	it("computes windows dirname for windows absolute paths", () => {
 		assert.strictEqual(dirname("C:\\foo\\bar"), "C:\\foo");
+	});
+
+	it("computes windows dirname for UNC paths", () => {
+		assert.strictEqual(
+			dirname("\\\\server\\share\\a\\b"),
+			"\\\\server\\share\\a",
+		);
+		// The share itself is the root, so walking up stops there.
+		assert.strictEqual(dirname("\\\\server\\share\\a"), "\\\\server\\share\\");
 	});
 
 	it("computes windows dirname for DOS device paths", () => {

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -91,10 +91,11 @@ describe("util/path getType", () => {
 		// filename character everywhere else — too ambiguous to reroute.
 		assert.strictEqual(getType("\\?\\C:\\foo"), PathType.Normal);
 		assert.strictEqual(getType("\\a\\b"), PathType.Normal);
-		// Forward-slash variants aren't equivalent — Windows won't normalize
-		// a DOS device path expressed with `/`, and `//a/b` is a posix path.
+		// A leading forward slash is a posix root, however the separator after
+		// it is spelled — `path.win32` would read both as a UNC root.
 		assert.strictEqual(getType("//?/C:/foo"), PathType.AbsolutePosix);
 		assert.strictEqual(getType("//server/share"), PathType.AbsolutePosix);
+		assert.strictEqual(getType("/\\server\\share"), PathType.AbsolutePosix);
 	});
 });
 

--- a/test/unc-paths.test.js
+++ b/test/unc-paths.test.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const assert = require("assert");
+const { ResolverFactory } = require("../");
+const { describe, it } = require("./_runner");
+
+// UNC paths (`\\server\share\…`) are Windows-only constructs addressing a
+// network share, so a real one cannot be mounted in CI. The resolver picks the
+// path flavor from the path itself rather than from the host, so a fake
+// filesystem exercises the same code paths on every platform.
+const share = "\\\\server\\share\\a";
+
+const files = new Map([
+	[`${share}\\package.json`, '{"main":"./main.js"}'],
+	[`${share}\\main.js`, "module.exports = 1;"],
+	[`${share}\\sub\\index.js`, "module.exports = 2;"],
+]);
+
+const directories = new Set([
+	"\\\\server\\share",
+	share,
+	`${share}\\sub`,
+	`${share}\\node_modules`,
+]);
+
+const createFileSystem = () => {
+	const enoent = (requested) => {
+		const err = /** @type {NodeJS.ErrnoException} */ (
+			new Error(`ENOENT: no such file or directory, '${requested}'`)
+		);
+		err.code = "ENOENT";
+		throw err;
+	};
+	const fileSystem = {
+		statSync: (requested) => {
+			const isFile = files.has(requested);
+			if (!isFile && !directories.has(requested)) return enoent(requested);
+			return {
+				isFile: () => isFile,
+				isDirectory: () => !isFile,
+				isSymbolicLink: () => false,
+			};
+		},
+		lstatSync: (requested) => fileSystem.statSync(requested),
+		readFileSync: (requested) => {
+			const content = files.get(requested);
+			return content === undefined ? enoent(requested) : content;
+		},
+		readdirSync: enoent,
+		readlinkSync: enoent,
+	};
+	return fileSystem;
+};
+
+const createResolver = () =>
+	ResolverFactory.createResolver({
+		extensions: [".js"],
+		useSyncFileSystemCalls: true,
+		// @ts-expect-error a minimal filesystem is enough for these cases
+		fileSystem: createFileSystem(),
+	});
+
+describe("UNC path resolution", () => {
+	it("should resolve a relative request against a UNC context", (t, done) => {
+		createResolver().resolve(
+			{},
+			`${share}\\sub`,
+			"./index.js",
+			{},
+			(err, result) => {
+				if (err) return done(err);
+				assert.strictEqual(result, `${share}\\sub\\index.js`);
+				done();
+			},
+		);
+	});
+
+	it("should resolve a directory request against a UNC context", (t, done) => {
+		createResolver().resolve({}, share, "./sub/index.js", {}, (err, result) => {
+			if (err) return done(err);
+			assert.strictEqual(result, `${share}\\sub\\index.js`);
+			done();
+		});
+	});
+
+	it("should treat an absolute UNC request as a path, not a module", (t, done) => {
+		createResolver().resolve(
+			{},
+			"/somewhere/else",
+			`${share}\\sub\\index.js`,
+			{},
+			(err, result) => {
+				if (err) return done(err);
+				assert.strictEqual(result, `${share}\\sub\\index.js`);
+				done();
+			},
+		);
+	});
+
+	it("should use the description file of a UNC directory", (t, done) => {
+		createResolver().resolve({}, share, ".", {}, (err, result) => {
+			if (err) return done(err);
+			assert.strictEqual(result, `${share}\\main.js`);
+			done();
+		});
+	});
+});


### PR DESCRIPTION
**Summary**

`getType` accepted only the DOS device forms (`\\?\`, `\\.\`) as windows-absolute, so a plain UNC share fell through to `Normal` and every helper answered it with posix semantics. `path.win32` roots any path starting with two backslashes, so both forms are windows-absolute and both now take that branch.

| call | before | after / `path.win32` |
| --- | --- | --- |
| `dirname("\\\\server\\share\\a\\b")` | **`"."`** | `\\server\share\a` |
| `join("\\\\server\\share\\a", "./index.js")` | **`\\server\share\a/index.js`** | `\\server\share\a\index.js` |
| `normalize("\\\\server\\share\\a\\..\\b")` | **unchanged** | `\\server\share\b` |
| `Resolver.isModule("\\\\server\\share\\a")` | **`true`** | `false` |

The `dirname` and `isModule` rows are the ones that bite: walking up from a share to find a `package.json` gave up immediately at `"."`, and an absolute share path was reported as a bare module request, so it was looked for in `node_modules` instead of being resolved as a path. Resolving anything on a network share was broken as a result.

`getDosDeviceType` is gone since the two forms no longer need telling apart, which also drops a call from `getType`; it measures marginally faster (89 ms vs 94 ms per 11M calls on a realistic mix of requests).

The helpers pick a flavor by path shape and then have to answer the way that flavor does, so `test/path.test.js` now asserts that directly against `path.win32`/`path.posix` — a curated list of shapes plus 5000 seeded generated ones, comparing the flavor, `normalize`, `dirname` and `join` (~270 ms). Reverting this fix fails 22 of them.

Every shape we answer differently on purpose is listed in one place and asserted on its own, next to what node does with it, so a divergence can only be added deliberately:

- **A leading forward slash is a posix root**, however the separator after it is spelled — `path.win32` reads `//server/share` *and* `/\server\share` as UNC roots.
- **A single leading backslash** is a rooted path on Windows and an ordinary filename character everywhere else; nothing in the string tells the two apart.
- **Drive-relative paths** (`C:foo`, no separator after the colon) stay `Normal`, as they already did on `main`. `path.win32` gives them the root `C:` but reports them as *not* absolute, and `PathType` has no windows-relative member — classifying them as `AbsoluteWin` would make `join` treat them as absolute and drop the root, trading one misalignment for another. Worth its own change.
- **Relative, empty and internal (`#…`) requests**, where the resolver deliberately keeps its own semantics (a `./` prefix is preserved, an empty path stays empty).

Found while reviewing #643, which fixes the restriction boundary check. That PR is independent of this one — its comparison already handles UNC — and they touch different parts of `lib/util/path.js`.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. `test/unc-paths.test.js` resolves against a UNC context through the public API — a relative request, a nested directory, an absolute share request from an unrelated context, and a description-file `main` — all four fail on `main` and pass here. They run on every host against a fake filesystem, since a real share cannot be mounted in CI and the resolver picks the path flavor from the path rather than from the host. `test/path.test.js` covers `getType`, `normalize`, `join` and `dirname` directly, and adds the alignment suite described above.

**Does this PR introduce a breaking change?**

No, unless a posix path literally starting with `\\` was being resolved, which would previously have been treated as a relative filename.

**If relevant, what needs to be documented once your changes are merged?**

n/a

**Use of AI**

Written with Claude Code. It compared every helper against `path.win32`/`path.posix` before and after — a curated matrix plus 70k generated shapes — wrote the failing tests first, mutation-tested the new alignment suite to confirm it catches the regression, and benchmarked `getType` to confirm the hot path did not regress; I reviewed the result. `npm run lint`, `npm run test:only` and `npm run test:browser` all pass locally.

