### PR TITLE
fix: soft-skip broken tsconfig in auto mode and keep relative extends relative

### DIFF
--- a/.changeset/010-tsconfig-broken-extends-soft-fail.md
+++ b/.changeset/010-tsconfig-broken-extends-soft-fail.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": patch
+---
+
+Soft-fail when auto tsconfig discovery loads a broken config, and keep relative `extends` paths relative.

--- a/lib/TsconfigPathsPlugin.js
+++ b/lib/TsconfigPathsPlugin.js
@@ -423,6 +423,7 @@ module.exports = class TsconfigPathsPlugin {
 
 		/**
 		 * @param {string} dir current directory
+		 * @returns {void}
 		 */
 		const check = (dir) => {
 			const candidate = resolver.join(dir, configFileName);
@@ -430,7 +431,10 @@ module.exports = class TsconfigPathsPlugin {
 				if (!statErr) {
 					// Found — load it
 					this._loadTsconfigPathsMap(resolver, candidate, (loadErr, result) => {
-						if (loadErr) return callback(loadErr);
+						if (loadErr) {
+							// Auto mode: soft-fail silently.
+							return callback(null, null);
+						}
 						callback(null, result);
 					});
 					return;
@@ -672,7 +676,11 @@ module.exports = class TsconfigPathsPlugin {
 				// node_modules/@scope/name/tsconfig.json (not @scope/name.json).
 				// See: test/fixtures/tsconfig-paths/extends-pkg-entry/
 				nodeModulesSubPath = `${originalExtendedConfigValue}/${DEFAULT_CONFIG_FILE}`;
-			} else if (extendedConfigValue.includes("/")) {
+			} else if (
+				extendedConfigValue.includes("/") &&
+				!originalExtendedConfigValue.startsWith(".") &&
+				!originalExtendedConfigValue.startsWith("/")
+			) {
 				// Package sub-path ("react/tsconfig", "@scope/name/tsconfig") →
 				// node_modules/react/tsconfig.json.
 				// See: test/fixtures/tsconfig-paths/extends-npm/

--- a/test/fixtures/tsconfig-paths/broken-pkg-extends/node_modules/@scope/pkg/dist/index.js
+++ b/test/fixtures/tsconfig-paths/broken-pkg-extends/node_modules/@scope/pkg/dist/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./sibling");

--- a/test/fixtures/tsconfig-paths/broken-pkg-extends/node_modules/@scope/pkg/dist/sibling.js
+++ b/test/fixtures/tsconfig-paths/broken-pkg-extends/node_modules/@scope/pkg/dist/sibling.js
@@ -1,0 +1,1 @@
+module.exports = "sibling";

--- a/test/fixtures/tsconfig-paths/broken-pkg-extends/node_modules/@scope/pkg/package.json
+++ b/test/fixtures/tsconfig-paths/broken-pkg-extends/node_modules/@scope/pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scope/pkg",
+  "version": "1.0.0",
+  "main": "dist/index.js"
+}

--- a/test/fixtures/tsconfig-paths/broken-pkg-extends/node_modules/@scope/pkg/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/broken-pkg-extends/node_modules/@scope/pkg/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/test/fixtures/tsconfig-paths/broken-pkg-extends/src/hello.js
+++ b/test/fixtures/tsconfig-paths/broken-pkg-extends/src/hello.js
@@ -1,0 +1,1 @@
+module.exports = "app-hello";

--- a/test/fixtures/tsconfig-paths/broken-pkg-extends/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/broken-pkg-extends/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["./src/*"]
+    }
+  }
+}

--- a/test/fixtures/tsconfig-paths/extends-missing-relative-slash/src/y.ts
+++ b/test/fixtures/tsconfig-paths/extends-missing-relative-slash/src/y.ts
@@ -1,0 +1,1 @@
+export const y = "y";

--- a/test/fixtures/tsconfig-paths/extends-missing-relative-slash/tsconfig.json
+++ b/test/fixtures/tsconfig-paths/extends-missing-relative-slash/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "paths": {
+      "@x/*": ["./src/*"]
+    }
+  }
+}

--- a/test/tsconfig-paths.test.js
+++ b/test/tsconfig-paths.test.js
@@ -1703,4 +1703,139 @@ describe("TsconfigPathsPlugin", () => {
 			});
 		});
 	});
+
+	// Regression for webpack/webpack#21551: published packages often ship a
+	// monorepo tsconfig.json whose `extends` points at a repo-root file that
+	// is not published (e.g. `../../tsconfig-base.json`). With `tsconfig: true`,
+	// discovering that file must not abort ordinary resolution inside the package.
+	// Like TypeScript's findConfigFile, the first existing config wins — load
+	// failure soft-fails (no paths) and must not fall through to a parent
+	// tsconfig's path mappings.
+	describe("bug: published package tsconfig with missing relative extends (#21551)", () => {
+		const brokenPkgExtendsDir = path.resolve(
+			__dirname,
+			"fixtures",
+			"tsconfig-paths",
+			"broken-pkg-extends",
+		);
+		const pkgDir = path.join(
+			brokenPkgExtendsDir,
+			"node_modules",
+			"@scope",
+			"pkg",
+		);
+
+		it("should resolve a relative request inside the package when tsconfig: true finds its broken tsconfig.json", (t, done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".js"],
+				mainFields: ["main"],
+				mainFiles: ["index"],
+				tsconfig: true,
+			});
+
+			resolver.resolve(
+				{},
+				path.join(pkgDir, "dist"),
+				"./sibling",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					if (!result) return done(new Error("No result"));
+					assert.deepStrictEqual(
+						result,
+						path.join(pkgDir, "dist", "sibling.js"),
+					);
+					done();
+				},
+			);
+		});
+
+		it("must not apply a parent tsconfig's paths after the nearer config fails to load", (t, done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".js"],
+				mainFields: ["main"],
+				mainFiles: ["index"],
+				tsconfig: true,
+			});
+
+			resolver.resolve(
+				{},
+				path.join(pkgDir, "dist"),
+				"@app/hello",
+				{},
+				(err, result) => {
+					// Parent broken-pkg-extends/tsconfig.json maps @app/* → ./src/*,
+					// but TypeScript stops at the package's own (broken) config and
+					// does not adopt the parent's paths.
+					if (
+						!err &&
+						result === path.join(brokenPkgExtendsDir, "src", "hello.js")
+					) {
+						return done(
+							new Error(
+								"incorrectly applied parent tsconfig paths after load failure",
+							),
+						);
+					}
+					assert.ok(err, "expected @app/hello not to resolve via parent paths");
+					done();
+				},
+			);
+		});
+	});
+
+	describe("extends a missing relative path containing slashes", () => {
+		const missingRelativeSlashDir = path.resolve(
+			__dirname,
+			"fixtures",
+			"tsconfig-paths",
+			"extends-missing-relative-slash",
+		);
+
+		it("surfaces ENOENT for the joined relative path, not a mangled node_modules path", () => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: path.join(missingRelativeSlashDir, "tsconfig.json"),
+				useSyncFileSystemCalls: true,
+			});
+
+			const expectedMissing = path.resolve(
+				missingRelativeSlashDir,
+				"..",
+				"..",
+				"tsconfig-base.json",
+			);
+
+			let err;
+			try {
+				resolver.resolveSync({}, missingRelativeSlashDir, "@x/y");
+			} catch (err_) {
+				err = err_;
+			}
+			assert.ok(err);
+			assert.strictEqual(
+				/** @type {NodeJS.ErrnoException} */ (err).code,
+				"ENOENT",
+			);
+			assert.ok(
+				/** @type {Error} */ (err).message.includes(expectedMissing),
+				`expected error to mention ${expectedMissing}, got: ${
+					/** @type {Error} */ (err).message
+				}`,
+			);
+			assert.ok(
+				!(
+					/** @type {Error} */ (err).message.includes(
+						`${path.sep}tsconfig-paths${path.sep}tsconfig-base.json`,
+					)
+				),
+				"must not rewrite ../../tsconfig-base.json via node_modules fallback",
+			);
+		});
+	});
 });


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Fixes webpack/webpack#21551.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing

**Use of AI**
Part