### PR TITLE
chore: use codeload which will trigger caching of webpack/tooling and disable cache properly on legacy node versions 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           architecture: ${{ steps.calculate_architecture.outputs.result }}
           # Legacy Node (10-16) reinstalls deps after dropping the lockfile,
-          # so there's nothing for setup-node's npm cache to key on.
-          cache: ${{ (matrix.node-version == '10.x' || matrix.node-version == '12.x' || matrix.node-version == '14.x' || matrix.node-version == '16.x') && '' || 'npm' }}
+          # so there's nothing for setup-node's npm cache to key on. The
+          # condition is written positively because `cond && '' || 'npm'`
+          # always yields 'npm' - an empty string is falsy in expressions.
+          cache: ${{ (matrix.node-version != '10.x' && matrix.node-version != '12.x' && matrix.node-version != '14.x' && matrix.node-version != '16.x') && 'npm' || '' }}
 
       # TODO: drop the legacy install + jest steps below once `engines.node`
       # is bumped to >= 18. That also makes `jest.config.js`, the jest branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "memfs": "^4.56.11",
         "prettier": "^3.7.4",
         "tinybench": "^6.0.0",
-        "tooling": "git+https://github.com/webpack/tooling.git#v1.26.4",
+        "tooling": "git+https://github.com/webpack/tooling.git#978dc1c9680ef7d79f5f5c02c3439385d7937c39",
         "typescript": "^6.0.2",
         "webpack": "^5.107.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "memfs": "^4.56.11",
         "prettier": "^3.7.4",
         "tinybench": "^6.0.0",
-        "tooling": "git+https://github.com/webpack/tooling.git#978dc1c9680ef7d79f5f5c02c3439385d7937c39",
+        "tooling": "https://codeload.github.com/webpack/tooling/tar.gz/refs/tags/v1.26.4",
         "typescript": "^6.0.2",
         "webpack": "^5.107.2"
       },
@@ -10030,8 +10030,8 @@
     },
     "node_modules/tooling": {
       "version": "1.26.4",
-      "resolved": "git+ssh://git@github.com/webpack/tooling.git#978dc1c9680ef7d79f5f5c02c3439385d7937c39",
-      "integrity": "sha512-ay+Gy5P4J6Kw5Bowy6j6Ssg0TI8QdiDPs2mrzDrgXrl8VFMphxZ/xcac3RWYC781g50s99Yoa/1ELmDkNdG8RQ==",
+      "resolved": "https://codeload.github.com/webpack/tooling/tar.gz/refs/tags/v1.26.4",
+      "integrity": "sha512-SpwV8A0E7t6nfWSy4tPYfmbVLjJtZu7d39tTyZ5ZUmqJ19C0dLFZHVgnUewQR6uJVkPSDyFj9PSkBiHJw7tuzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "memfs": "^4.56.11",
         "prettier": "^3.7.4",
         "tinybench": "^6.0.0",
-        "tooling": "webpack/tooling#v1.26.4",
+        "tooling": "git+https://github.com/webpack/tooling.git#v1.26.4",
         "typescript": "^6.0.2",
         "webpack": "^5.107.2"
       },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "memfs": "^4.56.11",
     "prettier": "^3.7.4",
     "tinybench": "^6.0.0",
-    "tooling": "git+https://github.com/webpack/tooling.git#978dc1c9680ef7d79f5f5c02c3439385d7937c39",
+    "tooling": "https://codeload.github.com/webpack/tooling/tar.gz/refs/tags/v1.26.4",
     "typescript": "^6.0.2",
     "webpack": "^5.107.2"
   },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "memfs": "^4.56.11",
     "prettier": "^3.7.4",
     "tinybench": "^6.0.0",
-    "tooling": "git+https://github.com/webpack/tooling.git#v1.26.4",
+    "tooling": "git+https://github.com/webpack/tooling.git#978dc1c9680ef7d79f5f5c02c3439385d7937c39",
     "typescript": "^6.0.2",
     "webpack": "^5.107.2"
   },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "memfs": "^4.56.11",
     "prettier": "^3.7.4",
     "tinybench": "^6.0.0",
-    "tooling": "webpack/tooling#v1.26.4",
+    "tooling": "git+https://github.com/webpack/tooling.git#v1.26.4",
     "typescript": "^6.0.2",
     "webpack": "^5.107.2"
   },


### PR DESCRIPTION
> If you ran across "codeload" in a network log or an API call, codeload.github.com is GitHub's internal, specialized domain designed to optimize and cache source code file archives (like .zip and .tar.gz). 