### PR TITLE
ci: fix the flaky "database is locked" failure in the Deno job

### DIFF
--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -61,8 +61,25 @@ jobs:
         with:
           deno-version: v2.x
 
+      # jest clears mocks by walking the sandbox globals and testing
+      # `"_isMockFunction" in value`. On `localStorage` that opens Deno's
+      # SQLite-backed web storage, and the jest workers - separate Deno
+      # processes - race to create that database on a cold cache, failing a
+      # random suite with "database is locked". The preload swaps in an
+      # in-memory `Storage`; the workers inherit `NODE_OPTIONS`, so it reaches
+      # all of them.
       - name: Run tests (jest via Deno node compatibility)
-        run: deno run -A --node-modules-dir=auto node_modules/jest/bin/jest.js
+        env:
+          DENO_DIR: ${{ runner.temp }}/deno
+          NODE_OPTIONS: --require ./test/deno-web-storage-shim.js
+        run: |
+          deno run -A --node-modules-dir=auto node_modules/jest/bin/jest.js
+          # A preload that stops being applied fails silently, so assert that
+          # the web storage database really was never opened.
+          if [ -d "$DENO_DIR/location_data" ]; then
+            echo "::error::Deno opened its SQLite web storage - test/deno-web-storage-shim.js was not applied"
+            exit 1
+          fi
 
   browser:
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -31,7 +31,7 @@ jobs:
           HUSKY: "0"
 
       - name: Run tests
-        run: bun test --max-concurrency 1 test/
+        run: bun test test/
 
   deno:
     runs-on: ubuntu-latest

--- a/test/deno-web-storage-shim.js
+++ b/test/deno-web-storage-shim.js
@@ -71,7 +71,9 @@ class MemoryStorage {
 	}
 }
 
-if (typeof Deno !== "undefined") {
+// `"Deno" in global` rather than a bare `Deno` reference: the suite is
+// type-checked with the Node.js types only, which do not declare that global.
+if ("Deno" in global) {
 	for (const name of ["localStorage", "sessionStorage"]) {
 		Object.defineProperty(global, name, {
 			configurable: true,

--- a/test/deno-web-storage-shim.js
+++ b/test/deno-web-storage-shim.js
@@ -1,0 +1,83 @@
+"use strict";
+
+// Preloaded through `NODE_OPTIONS=--require` in the Deno leg of the
+// cross-runtime CI job, which puts it in the main process and in every jest
+// worker (they inherit `NODE_OPTIONS`).
+//
+// jest clears mocks by walking the globals of the test sandbox and testing
+// `"_isMockFunction" in value` on each one (`ModuleMocker.clearMocksOnScope`).
+// Its node environment exposes `localStorage` there, and in Deno that global is
+// backed by a SQLite database under `DENO_DIR` which is opened on first access.
+// Jest workers are separate Deno processes, so on a cold cache they all race to
+// create that database and the losers throw "database is locked", failing a
+// random test suite.
+//
+// An in-memory `Storage` keeps the globals (and jest's `in` check) working
+// without ever opening the database. Neither the library nor the suite uses web
+// storage, so nothing needs to persist.
+
+/** In-memory stand-in for the web `Storage` interface. */
+class MemoryStorage {
+	constructor() {
+		/** @type {Map<string, string>} */
+		this._items = new Map();
+	}
+
+	/** @returns {number} number of stored items */
+	get length() {
+		return this._items.size;
+	}
+
+	/**
+	 * @param {number} index position of the key
+	 * @returns {string | null} the key at `index`, or `null` when out of range
+	 */
+	key(index) {
+		const keys = [...this._items.keys()];
+
+		return index < keys.length ? keys[index] : null;
+	}
+
+	/**
+	 * @param {string} key item key
+	 * @returns {string | null} the stored value, or `null` when not set
+	 */
+	getItem(key) {
+		const item = this._items.get(String(key));
+
+		return item === undefined ? null : item;
+	}
+
+	/**
+	 * @param {string} key item key
+	 * @param {string} value item value
+	 * @returns {void}
+	 */
+	setItem(key, value) {
+		this._items.set(String(key), String(value));
+	}
+
+	/**
+	 * @param {string} key item key
+	 * @returns {void}
+	 */
+	removeItem(key) {
+		this._items.delete(String(key));
+	}
+
+	/** @returns {void} */
+	clear() {
+		this._items.clear();
+	}
+}
+
+if (typeof Deno !== "undefined") {
+	for (const name of ["localStorage", "sessionStorage"]) {
+		Object.defineProperty(global, name, {
+			configurable: true,
+			enumerable: true,
+			writable: true,
+			value: new MemoryStorage(),
+		});
+	}
+}


### PR DESCRIPTION
Fixes #660

## The failure

The `deno` leg of **Cross-runtime** fails intermittently with a random test suite dying before it runs:

```
FAIL test/exportsField.test.js
  ● Test suite failed to run
    database is locked
      at Object.has (ext:deno_webstorage/01_webstorage.js:1:898)
```

## Root cause

jest clears mocks by walking the globals of the test sandbox and testing `"_isMockFunction" in value` on each one. Instrumenting the global catches the exact caller:

```
[STORAGE] localStorage has _isMockFunction
    at ModuleMocker.clearMocksOnScope (node_modules/jest-mock/build/index.js:868)
    at Runtime.resetModules  (jest-runtime)
    at Runtime.teardown      (jest-runtime)
    at tearDownEnv           (jest-runner)
    at processTicksAndRejections (ext:core/01_core.js:405:7)
```

`jest-environment-node` exposes `localStorage` in the sandbox, and in Deno that global is backed by a SQLite database under `DENO_DIR` which is opened on first access. That `in` check is the first access. Jest workers are separate Deno processes, so on a cold cache (CI never caches `DENO_DIR`) they all race to *create* that database and the losers throw `database is locked`, taking down whichever suite they were holding.

Reproduced standalone — 6 Deno processes opening `localStorage` at a synchronized instant:

| database | failed rounds |
| --- | --- |
| cold (created during the run) | 2 / 10 |
| warm (created beforehand) | 0 / 10 |

## Fix

Preload an in-memory `Storage` over `localStorage`/`sessionStorage` before jest starts. Jest workers inherit `NODE_OPTIONS`, so the shim reaches every process — which keeps the suite parallel instead of serialising it with `--runInBand`. Neither the library nor the suite uses web storage, so nothing needs to persist.

Measured on Deno 2.9.6 from a cold cache:

| | wall | databases created | tests |
| --- | --- | --- | --- |
| before | 9.5s | 1 (raced) | 1522 pass |
| `--runInBand` | 13.7s | 1 | 1522 pass |
| **this PR** | **9.0s** | **0** | **1522 pass** |

All four processes (parent + 3 workers) report the preload installed and `DENO_DIR/location_data` never appears, so the race is structurally impossible rather than merely unlikely.

A `--require` preload fails *silently* if it ever stops being applied, which would quietly restore the flake, so the job now also asserts that no web storage database was created. Tested both ways: passes with the shim, errors with `NODE_OPTIONS` unset.

## Also: the bun job's `--max-concurrency 1`

Dropped as dead config. `--max-concurrency` caps how many `test.concurrent()` tests run at once; the suite declares none and the job doesn't pass `--concurrent`, so it never gated anything — on bun 1.4.2 (what `latest` resolves to today) the suite runs in 9.27s / 9.25s / 9.11s without it versus 9.44s with it. Bun also doesn't implement web storage at all (`typeof localStorage === "undefined"`) and uses its own runner, so it never had the Deno problem.

It arrived in 6f87171, whose message ("ci: run bun concurrently") describes the opposite of what the diff did, and the bun job was green without it in the run immediately before. Happy to drop this commit if it was deliberate for something not visible in the logs.

## Verification

`lint:code`, `lint:types`, `fmt:check`, `lint:spellcheck` and the Node suite (1522 pass) are all green. I could not run `lint:special` — it needs the `tooling` dependency, which this sandbox's proxy blocks from `codeload.github.com`; it only regenerates types from `lib/`, which this PR does not touch.

No changeset: CI-only change, matching how previous `ci:` commits were handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aGHrb1YaEvaGwNELGEHjF

---
_Generated by [Claude Code](https://claude.ai/code/session_016aGHrb1YaEvaGwNELGEHjF)_