### PR TITLE
feat: accept `file:` URL strings where a path is expected

### DIFF
--- a/.changeset/010-file-url-strings.md
+++ b/.changeset/010-file-url-strings.md
@@ -1,0 +1,5 @@
+---
+"enhanced-resolve": minor
+---
+
+Accept `file:` URL strings wherever an option or the context path takes a path.

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -14,6 +14,7 @@ const {
 	createCachedDirname,
 	createCachedJoin,
 	getType,
+	isFileURL,
 	normalize,
 	toPath,
 } = require("./util/path");
@@ -26,8 +27,8 @@ const _withResolvers =
 		? /**
 			 * @param {Resolver} self resolver
 			 * @param {Context} context context information object
-			 * @param {string | URL} path context path or a `file:` URL instance
-			 * @param {string | URL} request request string or a `file:` URL instance
+			 * @param {string | URL} path context path or a `file:` URL
+			 * @param {string | URL} request request string or a `file:` URL
 			 * @param {ResolveContext} resolveContext resolve context
 			 * @returns {Promise<string | false>} result
 			 */
@@ -43,8 +44,8 @@ const _withResolvers =
 		: /**
 			 * @param {Resolver} self resolver
 			 * @param {Context} context context information object
-			 * @param {string | URL} path context path or a `file:` URL instance
-			 * @param {string | URL} request request string or a `file:` URL instance
+			 * @param {string | URL} path context path or a `file:` URL
+			 * @param {string | URL} request request string or a `file:` URL
 			 * @param {ResolveContext} resolveContext resolve context
 			 * @returns {Promise<string | false>} result
 			 */
@@ -693,23 +694,23 @@ class Resolver {
 
 	/**
 	 * @overload
-	 * @param {string | URL} parent context path or a `file:` URL instance
-	 * @param {string | URL} specifier request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL
+	 * @param {string | URL} specifier request string or a `file:` URL
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {string | false} result
 	 */
 	/**
 	 * @overload
 	 * @param {Context} context context information object
-	 * @param {string | URL} parent context path or a `file:` URL instance
-	 * @param {string | URL} specifier request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL
+	 * @param {string | URL} specifier request string or a `file:` URL
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {string | false} result
 	 */
 	/**
-	 * @param {Context | string | URL} context context information object, or the context path (string or `file:` URL instance) when no context is provided
-	 * @param {string | URL | ResolveContext=} parent context path (string or `file:` URL instance) or resolve context when no context is provided
-	 * @param {string | URL | ResolveContext=} specifier request string (or `file:` URL instance) or resolve context when no context is provided
+	 * @param {Context | string | URL} context context information object, or the context path (a path or a `file:` URL) when no context is provided
+	 * @param {string | URL | ResolveContext=} parent context path (a path or a `file:` URL) or resolve context when no context is provided
+	 * @param {string | URL | ResolveContext=} specifier request string (or a `file:` URL) or resolve context when no context is provided
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {string | false} result
 	 */
@@ -745,23 +746,23 @@ class Resolver {
 
 	/**
 	 * @overload
-	 * @param {string | URL} parent context path or a `file:` URL instance
-	 * @param {string | URL} specifier request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL
+	 * @param {string | URL} specifier request string or a `file:` URL
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {Promise<string | false>} result
 	 */
 	/**
 	 * @overload
 	 * @param {Context} context context information object
-	 * @param {string | URL} parent context path or a `file:` URL instance
-	 * @param {string | URL} specifier request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL
+	 * @param {string | URL} specifier request string or a `file:` URL
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {Promise<string | false>} result
 	 */
 	/**
-	 * @param {Context | string | URL} context context information object, or the context path (string or `file:` URL instance) when no context is provided
-	 * @param {string | URL | ResolveContext=} parent context path (string or `file:` URL instance) or resolve context when no context is provided
-	 * @param {string | URL | ResolveContext=} specifier request string (or `file:` URL instance) or resolve context when no context is provided
+	 * @param {Context | string | URL} context context information object, or the context path (a path or a `file:` URL) when no context is provided
+	 * @param {string | URL | ResolveContext=} parent context path (a path or a `file:` URL) or resolve context when no context is provided
+	 * @param {string | URL | ResolveContext=} specifier request string (or a `file:` URL) or resolve context when no context is provided
 	 * @param {ResolveContext=} resolveContext resolve context
 	 * @returns {Promise<string | false>} result
 	 */
@@ -779,15 +780,15 @@ class Resolver {
 
 	/**
 	 * @overload
-	 * @param {string | URL} parent context path or a `file:` URL instance
-	 * @param {string | URL} specifier request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL
+	 * @param {string | URL} specifier request string or a `file:` URL
 	 * @param {ResolveCallback} callback callback function
 	 * @returns {void}
 	 */
 	/**
 	 * @overload
-	 * @param {string | URL} parent context path or a `file:` URL instance
-	 * @param {string | URL} specifier request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL
+	 * @param {string | URL} specifier request string or a `file:` URL
 	 * @param {ResolveContext} resolveContext resolve context
 	 * @param {ResolveCallback} callback callback function
 	 * @returns {void}
@@ -795,24 +796,24 @@ class Resolver {
 	/**
 	 * @overload
 	 * @param {Context} context context information object
-	 * @param {string | URL} parent context path or a `file:` URL instance
-	 * @param {string | URL} specifier request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL
+	 * @param {string | URL} specifier request string or a `file:` URL
 	 * @param {ResolveCallback} callback callback function
 	 * @returns {void}
 	 */
 	/**
 	 * @overload
 	 * @param {Context} context context information object
-	 * @param {string | URL} parent context path or a `file:` URL instance
-	 * @param {string | URL} specifier request string or a `file:` URL instance
+	 * @param {string | URL} parent context path or a `file:` URL
+	 * @param {string | URL} specifier request string or a `file:` URL
 	 * @param {ResolveContext} resolveContext resolve context
 	 * @param {ResolveCallback} callback callback function
 	 * @returns {void}
 	 */
 	/**
-	 * @param {Context | string | URL} context context information object, or the context path (string or `file:` URL instance) when no context is provided
-	 * @param {string | URL | ResolveContext | ResolveCallback=} parent context path (string or `file:` URL instance) or (when no context) resolve context or callback
-	 * @param {string | URL | ResolveContext | ResolveCallback=} specifier request string (or `file:` URL instance) or (when no context) resolve context or callback
+	 * @param {Context | string | URL} context context information object, or the context path (a path or a `file:` URL) when no context is provided
+	 * @param {string | URL | ResolveContext | ResolveCallback=} parent context path (a path or a `file:` URL) or (when no context) resolve context or callback
+	 * @param {string | URL | ResolveContext | ResolveCallback=} specifier request string (or a `file:` URL) or (when no context) resolve context or callback
 	 * @param {ResolveContext | ResolveCallback=} resolveContext resolve context or callback when no resolve context is provided
 	 * @param {ResolveCallback=} callback callback function
 	 * @returns {void}
@@ -837,7 +838,7 @@ class Resolver {
 		} else {
 			// Slow path: shift positional args based on what was supplied.
 			// Shift when context is omitted (first positional arg is the parent,
-			// either a string or a `file:` URL instance).
+			// either a path or a `file:` URL).
 			if (typeof context === "string" || context instanceof URL) {
 				// Keep an already-supplied callback (resolveSync / resolvePromise
 				// always pass one in the 5th position).
@@ -868,13 +869,17 @@ class Resolver {
 				context = {};
 			}
 		}
-		// Accept `file:` URL instances for parent/specifier, converting to a
-		// filesystem path (mirrors the URL support in resolve options). The
-		// `instanceof` check sits on the error branch, so the common string
-		// case keeps its single `typeof` check on this hot path.
+		// Accept `file:` URLs for parent/specifier, converting to a filesystem
+		// path (mirrors the URL support in resolve options). The `instanceof`
+		// check sits on the error branch and `isFileURL` reads one character of
+		// a path, so the common string case stays cheap on this hot path.
+		// A `file:` specifier string needs nothing here — `parseIdentifier`
+		// converts it once the request is parsed.
 		if (typeof parent !== "string") {
 			if (parent instanceof URL) parent = toPath(parent);
 			else return callback(new Error("path argument is not a string"));
+		} else if (isFileURL(parent)) {
+			parent = toPath(parent);
 		}
 		if (typeof specifier !== "string") {
 			if (specifier instanceof URL) specifier = toPath(specifier);

--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -27,8 +27,8 @@ const _withResolvers =
 		? /**
 			 * @param {Resolver} self resolver
 			 * @param {Context} context context information object
-			 * @param {string | URL} path context path or a `file:` URL
-			 * @param {string | URL} request request string or a `file:` URL
+			 * @param {string | URL} path context path or a `file:` URL instance
+			 * @param {string | URL} request request string or a `file:` URL instance
 			 * @param {ResolveContext} resolveContext resolve context
 			 * @returns {Promise<string | false>} result
 			 */
@@ -44,8 +44,8 @@ const _withResolvers =
 		: /**
 			 * @param {Resolver} self resolver
 			 * @param {Context} context context information object
-			 * @param {string | URL} path context path or a `file:` URL
-			 * @param {string | URL} request request string or a `file:` URL
+			 * @param {string | URL} path context path or a `file:` URL instance
+			 * @param {string | URL} request request string or a `file:` URL instance
 			 * @param {ResolveContext} resolveContext resolve context
 			 * @returns {Promise<string | false>} result
 			 */

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -67,9 +67,9 @@ const { PathType, getType, toPath } = require("./util/path");
 
 /**
  * @typedef {object} UserTsconfigOptions
- * @property {(string | URL)=} configFile A path, or `file:` `URL` instance, pointing at the tsconfig file
- * @property {((string | URL)[] | "auto")=} references References to other tsconfig files. 'auto' inherits from TypeScript config, or an array of relative/absolute paths or `file:` `URL` instances
- * @property {(string | URL)=} baseUrl Override baseUrl from tsconfig.json with a path or `file:` `URL` instance
+ * @property {(string | URL)=} configFile A path, or `file:` URL, pointing at the tsconfig file
+ * @property {((string | URL)[] | "auto")=} references References to other tsconfig files. 'auto' inherits from TypeScript config, or an array of relative/absolute paths or `file:` URLs
+ * @property {(string | URL)=} baseUrl Override baseUrl from tsconfig.json with a path or `file:` URL
  */
 
 /**
@@ -91,19 +91,19 @@ const { PathType, getType, toPath } = require("./util/path");
  * @property {(Cache | boolean)=} unsafeCache Use this cache object to unsafely cache the successful requests
  * @property {boolean=} symlinks Resolve symlinks to their symlinked location
  * @property {Resolver=} resolver A prepared Resolver to which the plugins are attached
- * @property {(string | URL)[] | string | URL=} modules A list of directories to resolve modules from, can be absolute path, folder name, or a `file:` `URL` instance
+ * @property {(string | URL)[] | string | URL=} modules A list of directories to resolve modules from, can be absolute path, folder name, or a `file:` URL
  * @property {(string | string[] | { name: string | string[], forceRelative: boolean })[]=} mainFields A list of main fields in description files
  * @property {string[]=} mainFiles A list of main files in directories
  * @property {Plugin[]=} plugins A list of additional resolve plugins which should be applied
  * @property {PnpApi | null=} pnpApi A PnP API that should be used - null is "never", undefined is "auto"
- * @property {(string | URL)[]=} roots A list of root paths, each an absolute path or a `file:` `URL` instance
+ * @property {(string | URL)[]=} roots A list of root paths, each an absolute path or a `file:` URL
  * @property {boolean=} fullySpecified The request is already fully specified and no extensions or directories are resolved for it
  * @property {boolean=} resolveToContext Resolve to a context instead of a file
- * @property {(string | URL | RegExp)[]=} restrictions A list of resolve restrictions, each an absolute path, a `file:` `URL` instance, or a RegExp
+ * @property {(string | URL | RegExp)[]=} restrictions A list of resolve restrictions, each an absolute path, a `file:` URL, or a RegExp
  * @property {boolean=} useSyncFileSystemCalls Use only the sync constraints of the file system calls
  * @property {boolean=} preferRelative Prefer to resolve module requests as relative requests before falling back to modules
  * @property {boolean=} preferAbsolute Prefer to resolve server-relative urls as absolute paths before falling back to resolve in roots
- * @property {string | URL | boolean | UserTsconfigOptions=} tsconfig TypeScript config file path (or `file:` `URL` instance) or config object with configFile and references
+ * @property {string | URL | boolean | UserTsconfigOptions=} tsconfig TypeScript config file path (or `file:` URL) or config object with configFile and references
  */
 
 /**
@@ -176,7 +176,7 @@ function processPnpApiOption(option) {
 
 /**
  * @param {UserAliasOptionNewRequest} alias alias target(s)
- * @returns {AliasOptionNewRequest} target(s) with file `URL` instances converted to paths
+ * @returns {AliasOptionNewRequest} target(s) with `file:` URLs converted to paths
  */
 function toPathAlias(alias) {
 	if (alias === false) return false;
@@ -213,7 +213,7 @@ function normalizeAlias(alias) {
 
 /**
  * @param {string | URL | boolean | UserTsconfigOptions | undefined} tsconfig tsconfig option
- * @returns {string | boolean | TsconfigOptions} normalized tsconfig with file `URL` instances converted to paths
+ * @returns {string | boolean | TsconfigOptions} normalized tsconfig with `file:` URLs converted to paths
  */
 function normalizeTsconfig(tsconfig) {
 	if (tsconfig === undefined) return false;

--- a/lib/util/path.js
+++ b/lib/util/path.js
@@ -17,6 +17,10 @@ const CHAR_LOWER_A = "a".charCodeAt(0);
 const CHAR_LOWER_Z = "z".charCodeAt(0);
 const CHAR_DOT = ".".charCodeAt(0);
 const CHAR_COLON = ":".charCodeAt(0);
+const CHAR_F = "F".charCodeAt(0);
+const CHAR_LOWER_F = "f".charCodeAt(0);
+
+const FILE_URL_REGEXP = /^file:\/\//i;
 
 const posixNormalize = path.posix.normalize;
 const winNormalize = path.win32.normalize;
@@ -422,16 +426,30 @@ const isSubPath = (parentPath, childPath) => {
 };
 
 /**
- * Convert a `file:` `URL` instance to a filesystem path; any other input
- * (including plain strings) is returned unchanged. Mirrors Node's `fs`, which
- * treats strings as literal paths and only `URL` objects as URLs (see
- * nodejs/node#17658) — so a directory literally named `file:` is never
- * mistaken for a URL.
- * @param {string | URL} maybeURL a path string or a `file:` `URL` instance
+ * Whether a string names a `file:` URL rather than a path. Only the `file://`
+ * prefix counts, so a path segment spelled `file:` stays a path.
+ * @param {string} maybePath a path or a `file:` URL string
+ * @returns {boolean} true when the string is a `file:` URL
+ */
+const isFileURL = (maybePath) => {
+	// The first character keeps every path not starting with `f` off the regexp
+	const c0 = maybePath.charCodeAt(0);
+	return (
+		(c0 === CHAR_LOWER_F || c0 === CHAR_F) && FILE_URL_REGEXP.test(maybePath)
+	);
+};
+
+/**
+ * Convert a `file:` URL — a `URL` instance or a `file://` string, the form
+ * `import.meta.resolve` returns — to the path it names. Anything else is
+ * returned unchanged, so a path passes through.
+ * @param {string | URL} maybeURL a path, a `file://` URL string or a `file:` `URL` instance
  * @returns {string} a filesystem path
  */
-const toPath = (maybeURL) =>
-	maybeURL instanceof URL ? fileURLToPath(maybeURL) : maybeURL;
+const toPath = (maybeURL) => {
+	if (maybeURL instanceof URL) return fileURLToPath(maybeURL);
+	return isFileURL(maybeURL) ? fileURLToPath(maybeURL) : maybeURL;
+};
 
 module.exports.PathType = PathType;
 module.exports.createCachedBasename = createCachedBasename;
@@ -441,6 +459,7 @@ module.exports.deprecatedInvalidSegmentRegEx = deprecatedInvalidSegmentRegEx;
 module.exports.dirname = dirname;
 module.exports.getType = getType;
 module.exports.invalidSegmentRegEx = invalidSegmentRegEx;
+module.exports.isFileURL = isFileURL;
 module.exports.isInside = isInside;
 module.exports.isRelativeRequest = isRelativeRequest;
 module.exports.isSubPath = isSubPath;

--- a/test/file-url-options.test.js
+++ b/test/file-url-options.test.js
@@ -32,6 +32,17 @@ describe("file: URL path options", () => {
 				done();
 			});
 		});
+
+		it("should accept a file: URL string", (t, done) => {
+			const resolver = makeResolver({
+				roots: [String(pathToFileURL(fixtures))],
+			});
+			resolver.resolve({}, fixtures, "/b.js", {}, (err, result) => {
+				if (err) return done(err);
+				assert.deepStrictEqual(result, path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
 	});
 
 	describe("modules", () => {
@@ -46,6 +57,28 @@ describe("file: URL path options", () => {
 
 		it("should accept a single URL instance", (t, done) => {
 			const resolver = makeResolver({ modules: pathToFileURL(modulesDir) });
+			resolver.resolve({}, fixtures, "m1/a", {}, (err, result) => {
+				if (err) return done(err);
+				assert.deepStrictEqual(result, path.resolve(modulesDir, "m1/a.js"));
+				done();
+			});
+		});
+
+		it("should accept a file: URL string", (t, done) => {
+			const resolver = makeResolver({
+				modules: [String(pathToFileURL(modulesDir))],
+			});
+			resolver.resolve({}, fixtures, "m1/a", {}, (err, result) => {
+				if (err) return done(err);
+				assert.deepStrictEqual(result, path.resolve(modulesDir, "m1/a.js"));
+				done();
+			});
+		});
+
+		it("should accept a single file: URL string", (t, done) => {
+			const resolver = makeResolver({
+				modules: String(pathToFileURL(modulesDir)),
+			});
 			resolver.resolve({}, fixtures, "m1/a", {}, (err, result) => {
 				if (err) return done(err);
 				assert.deepStrictEqual(result, path.resolve(modulesDir, "m1/a.js"));
@@ -97,12 +130,25 @@ describe("file: URL path options", () => {
 			});
 		});
 
-		// A `file:` string target is not converted here (strings stay literal),
-		// but the rewritten request still resolves because the request side
-		// (`parseIdentifier`) converts `file:` request strings.
-		it("should still resolve a file: string target via request parsing", (t, done) => {
+		it("should accept a file: URL string as the target", (t, done) => {
 			const resolver = makeResolver({
 				alias: { "@": String(pathToFileURL(fixtures)) },
+			});
+			resolver.resolve({}, fixtures, "@/b.js", {}, (err, result) => {
+				if (err) return done(err);
+				assert.deepStrictEqual(result, path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
+
+		it("should accept a file: URL string in an array target", (t, done) => {
+			const resolver = makeResolver({
+				alias: {
+					"@": [
+						String(pathToFileURL(modulesDir)),
+						String(pathToFileURL(fixtures)),
+					],
+				},
 			});
 			resolver.resolve({}, fixtures, "@/b.js", {}, (err, result) => {
 				if (err) return done(err);
@@ -133,11 +179,20 @@ describe("file: URL path options", () => {
 			});
 		});
 
-		// A `file:` string restriction stays literal, so no real path is ever
-		// "inside" it and resolution is blocked — use a URL instance or a path.
-		it("should treat a file: string restriction as a literal path", (t, done) => {
+		it("should accept a file: URL string", (t, done) => {
 			const resolver = makeResolver({
 				restrictions: [String(pathToFileURL(fixtures))],
+			});
+			resolver.resolve({}, fixtures, "./b.js", {}, (err, result) => {
+				if (err) return done(err);
+				assert.deepStrictEqual(result, path.resolve(fixtures, "b.js"));
+				done();
+			});
+		});
+
+		it("should still block a request outside a file: URL string", (t, done) => {
+			const resolver = makeResolver({
+				restrictions: [String(pathToFileURL(modulesDir))],
 			});
 			resolver.resolve({}, fixtures, "./b.js", {}, (err) => {
 				assert.ok(err instanceof Error);
@@ -157,6 +212,30 @@ describe("file: URL path options", () => {
 				mainFields: ["browser", "main"],
 				mainFiles: ["index"],
 				tsconfig: pathToFileURL(tsconfigFile),
+			});
+			resolver.resolve(
+				{},
+				tsconfigDir,
+				"@components/button",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					assert.deepStrictEqual(
+						result,
+						path.join(tsconfigDir, "src", "components", "button.ts"),
+					);
+					done();
+				},
+			);
+		});
+
+		it("should accept a file: URL string as the config file", (t, done) => {
+			const resolver = ResolverFactory.createResolver({
+				fileSystem,
+				extensions: [".ts", ".tsx"],
+				mainFields: ["browser", "main"],
+				mainFiles: ["index"],
+				tsconfig: String(pathToFileURL(tsconfigFile)),
 			});
 			resolver.resolve(
 				{},
@@ -204,11 +283,29 @@ describe("file: URL path options", () => {
 			assert.strictEqual(toPath(pathToFileURL(modulesDir)), modulesDir);
 		});
 
-		// A string is always a literal path (matches Node fs, nodejs/node#17658),
-		// so a directory literally named `file:` is never mistaken for a URL.
-		it("should leave strings untouched, including `file:`-prefixed ones", () => {
+		it("should convert a file: URL string to a path", () => {
+			assert.strictEqual(toPath(String(pathToFileURL(modulesDir))), modulesDir);
+		});
+
+		it("should decode a percent-encoded file: URL string", () => {
+			const encoded = path.resolve(fixtures, "a directory");
+			assert.strictEqual(toPath(String(pathToFileURL(encoded))), encoded);
+		});
+
+		it("should accept an upper-case scheme", () => {
+			const url = String(pathToFileURL(modulesDir));
+			assert.strictEqual(
+				toPath(`FILE://${url.slice("file://".length)}`),
+				modulesDir,
+			);
+		});
+
+		// Only the `file://` prefix names a URL, so a path spelled `file:`
+		// stays a path — as it does for Node `fs` (nodejs/node#17658).
+		it("should leave paths untouched, `file:`-prefixed ones included", () => {
 			assert.strictEqual(toPath("file:foo"), "file:foo");
-			assert.strictEqual(toPath("file:///abs"), "file:///abs");
+			assert.strictEqual(toPath("filesystem"), "filesystem");
+			assert.strictEqual(toPath(""), "");
 			assert.strictEqual(toPath(modulesDir), modulesDir);
 		});
 	});
@@ -247,6 +344,33 @@ describe("file: URL resolve context and request", () => {
 			});
 		});
 
+		it("should accept a file: URL string as the context path", (t, done) => {
+			resolver.resolve(
+				{},
+				String(pathToFileURL(fixtures)),
+				"./b.js",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					assert.deepStrictEqual(result, bFile);
+					done();
+				},
+			);
+		});
+
+		it("should accept a file: URL string when the context object is omitted", (t, done) => {
+			resolver.resolve(
+				String(pathToFileURL(fixtures)),
+				"./b.js",
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					assert.deepStrictEqual(result, bFile);
+					done();
+				},
+			);
+		});
+
 		it("should still reject a non-string, non-URL context path", (t, done) => {
 			// @ts-expect-error for tests
 			resolver.resolve({}, 42, "./b.js", {}, (err) => {
@@ -266,6 +390,20 @@ describe("file: URL resolve context and request", () => {
 				{},
 				fixtures,
 				pathToFileURL(bFile),
+				{},
+				(err, result) => {
+					if (err) return done(err);
+					assert.deepStrictEqual(result, bFile);
+					done();
+				},
+			);
+		});
+
+		it("should accept a file: URL string as the request", (t, done) => {
+			resolver.resolve(
+				{},
+				fixtures,
+				String(pathToFileURL(bFile)),
 				{},
 				(err, result) => {
 					if (err) return done(err);
@@ -314,6 +452,35 @@ describe("file: URL resolve context and request", () => {
 				assert.deepStrictEqual(result, bFile);
 				done();
 			});
+		});
+
+		it("resolve should accept a file: URL string context with the context object omitted", (t, done) => {
+			enhancedResolve(
+				String(pathToFileURL(fixtures)),
+				"./b.js",
+				(err, result) => {
+					if (err) return done(err);
+					assert.deepStrictEqual(result, bFile);
+					done();
+				},
+			);
+		});
+
+		it("resolveSync should accept a file: URL string context", () => {
+			assert.deepStrictEqual(
+				enhancedResolve.sync(String(pathToFileURL(fixtures)), "./b.js"),
+				bFile,
+			);
+		});
+
+		it("resolvePromise should accept a file: URL string context", async () => {
+			assert.deepStrictEqual(
+				await enhancedResolve.promise(
+					String(pathToFileURL(fixtures)),
+					"./b.js",
+				),
+				bFile,
+			);
 		});
 
 		it("resolveSync should accept a URL context", () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1508,7 +1508,7 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	resolver?: Resolver;
 
 	/**
-	 * A list of directories to resolve modules from, can be absolute path, folder name, or a `file:` `URL` instance
+	 * A list of directories to resolve modules from, can be absolute path, folder name, or a `file:` URL
 	 */
 	modules?: string | URL_url | (string | URL_url)[];
 
@@ -1535,7 +1535,7 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	pnpApi?: null | PnpApi;
 
 	/**
-	 * A list of root paths, each an absolute path or a `file:` `URL` instance
+	 * A list of root paths, each an absolute path or a `file:` URL
 	 */
 	roots?: (string | URL_url)[];
 
@@ -1550,7 +1550,7 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	resolveToContext?: boolean;
 
 	/**
-	 * A list of resolve restrictions, each an absolute path, a `file:` `URL` instance, or a RegExp
+	 * A list of resolve restrictions, each an absolute path, a `file:` URL, or a RegExp
 	 */
 	restrictions?: (string | RegExp | URL_url)[];
 
@@ -1570,7 +1570,7 @@ declare interface ResolveOptionsResolverFactoryObject_2 {
 	preferAbsolute?: boolean;
 
 	/**
-	 * TypeScript config file path (or `file:` `URL` instance) or config object with configFile and references
+	 * TypeScript config file path (or `file:` URL) or config object with configFile and references
 	 */
 	tsconfig?: string | boolean | URL_url | UserTsconfigOptions;
 }
@@ -1939,17 +1939,17 @@ declare interface UserAliasOptions {
 }
 declare interface UserTsconfigOptions {
 	/**
-	 * A path, or `file:` `URL` instance, pointing at the tsconfig file
+	 * A path, or `file:` URL, pointing at the tsconfig file
 	 */
 	configFile?: string | URL_url;
 
 	/**
-	 * References to other tsconfig files. 'auto' inherits from TypeScript config, or an array of relative/absolute paths or `file:` `URL` instances
+	 * References to other tsconfig files. 'auto' inherits from TypeScript config, or an array of relative/absolute paths or `file:` URLs
 	 */
 	references?: (string | URL_url)[] | "auto";
 
 	/**
-	 * Override baseUrl from tsconfig.json with a path or `file:` `URL` instance
+	 * Override baseUrl from tsconfig.json with a path or `file:` URL
 	 */
 	baseUrl?: string | URL_url;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`import.meta.resolve()` returns a file URL as a **string**, so a config built with it hands the resolver `file:///abs/path` where an absolute path is expected — `toPath` converted only `URL` instances, so a string stayed literal and the option silently pointed at nothing (`modules` even fell into the hierarchical folder-name branch). `toPath` now converts `file://` strings too, which covers `modules`, `roots`, `restrictions`, `alias` and `tsconfig` in one place, and `resolve()` converts a `file:` URL string passed as the context path. Only the `file://` prefix counts, so a path segment spelled `file:` stays a path. This is the resolver half of webpack/webpack#22012, which did the same at webpack's config boundary.

**What kind of change does this PR introduce?**

feat.

**Did you add tests for your changes?**

Yes — `test/file-url-options.test.js` gains a string-form case next to every existing `URL`-instance one (roots, modules, alias, restrictions, tsconfig, context path, the high-level `resolve`/`sync`/`promise` API) plus `toPath` unit cases for percent-encoding, an upper-case scheme, and the paths that must stay literal. 13 of them fail without the change.

**Does this PR introduce a breaking change?**

No — a string that is not a `file://` URL is returned unchanged. The hot path grows one `charCodeAt` plus two comparisons per resolve (the regexp runs only for a path starting with `f`); CodSpeed measures it on this PR.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — the option JSDoc (and the generated `types.d.ts`) now say "a `file:` URL" rather than "a `file:` `URL` instance".

**Use of AI**

Written with Claude Code. It located the gap by reading the existing `URL`-instance support, made the change and the tests, and ran the full `lint` and test suites locally (1537/1537 green); every claim above was verified by running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmnzpSwSysywhmNw9p3uT5

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmnzpSwSysywhmNw9p3uT5)_